### PR TITLE
Allow for extra ITK modules not defined in IncludeITK.cmake

### DIFF
--- a/Support/ITKSupport/IncludeITK.cmake
+++ b/Support/ITKSupport/IncludeITK.cmake
@@ -87,7 +87,7 @@ endif()
 set(ITK_LIBRARY_DIR "" CACHE  STRING "" FORCE)
 
 # Set the list of ITK Modules that DREAM3D supports using
-set(DREAM3D_ITK_MODULES
+set(DREAM3D_CORE_ITK_MODULES
     #Group Core
     ITKCommon
 
@@ -123,6 +123,12 @@ set(DREAM3D_ITK_MODULES
 
     #Other
     ITKReview
+  )
+
+get_property(DREAM3D_ADDITIONAL_ITK_MODULES GLOBAL PROPERTY DREAM3D_ADDITIONAL_ITK_MODULES)
+list(APPEND DREAM3D_ITK_MODULES
+    ${DREAM3D_CORE_ITK_MODULES}
+    ${DREAM3D_ADDITIONAL_ITK_MODULES}
   )
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
As of now, the components for the ITK find_package must be defined in the
IncludeITK.cmake. This is uncovinient for plugins as they cannot depend on
ITK components that are NOT defined in this file.
With this change, plugins can add the following lines to be able to pull
and package other components from ITK before calling IncludeITK.cmake:

set(DREAM3D_ADDITIONAL_ITK_MODULES THE_ITK_COMPONENT_I_WANT)
set_property(GLOBAL APPEND PROPERTY DREAM3D_ADDITIONAL_ITK_MODULES ${DREAM3D_ADDITIONAL_ITK_MODULES})

@imikejackson: Would you mind taking a look ? Thanks !