### PR TITLE
ENH: Deactivate automatic ITK IO factory registration

### DIFF
--- a/Support/ITKSupport/IncludeITK.cmake
+++ b/Support/ITKSupport/IncludeITK.cmake
@@ -91,13 +91,6 @@ set(DREAM3D_CORE_ITK_MODULES
     #Group Core
     ITKCommon
 
-    #Group IO  ---No ITK Modules---
-    ITKIOImageBase
-    ITKIOBMP
-    ITKIOJPEG
-    ITKIOPNG
-    ITKIOTIFF
-
     #Group Filtering
     ITKImageCompare
     ITKImageIntensity
@@ -134,6 +127,8 @@ list(APPEND DREAM3D_ITK_MODULES
 
 # --------------------------------------------------------------------
 # find ITK libararies
+# Does not register IO factories. It will be done by each plugin that needs it.
+set(ITK_NO_IO_FACTORY_REGISTER_MANAGER TRUE)
 find_package(ITK COMPONENTS ${DREAM3D_ITK_MODULES} REQUIRED)
 message(STATUS "${PROJECT_NAME}: ITK Location ${ITK_DIR} ITK Version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}")
 


### PR DESCRIPTION
By default, ITK IO factory modules are automatically registered
with targets depending on ITK. This is a convenient method but
it does not allow the developer to select the order in which
the different IO modules are registered, and therefore which IO
module is used if multiple modules can read and write a format.
The automatic IO factory registration has been disable to allow
control on the order in which the IO modules are loaded.
