### PR TITLE
Fix crash in FindGBPDMetricBased filter

### DIFF
--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindGBCDMetricBased.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindGBCDMetricBased.cpp
@@ -77,6 +77,9 @@ const float FindGBCDMetricBased::k_ResolutionChoices[FindGBCDMetricBased::k_Numb
 
 const double FindGBCDMetricBased::k_BallVolumesM3M[FindGBCDMetricBased::k_NumberResolutionChoices] = {0.0000641361, 0.000139158, 0.000287439, 0.00038019, 0.000484151, 0.000747069, 0.00145491};
 
+namespace GBCDMetricBased
+{
+
 /**
  * @brief The TriAreaAndNormals class defines a container that stores the area of a given triangle
  * and the two normals for grains on either side of the triangle
@@ -401,6 +404,8 @@ public:
   }
 #endif
 };
+
+}
 
 // -----------------------------------------------------------------------------
 //
@@ -944,9 +949,9 @@ void FindGBCDMetricBased::execute()
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
   tbb::task_scheduler_init init;
   bool doParallel = true;
-  tbb::concurrent_vector<TriAreaAndNormals> selectedTris(0);
+  tbb::concurrent_vector<GBCDMetricBased::TriAreaAndNormals> selectedTris(0);
 #else
-  QVector<TriAreaAndNormals> selectedTris(0);
+  QVector<GBCDMetricBased::TriAreaAndNormals> selectedTris(0);
 #endif
 
   QVector<int8_t> triIncluded(numMeshTris, 0);
@@ -973,14 +978,14 @@ void FindGBCDMetricBased::execute()
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
     if(doParallel == true)
     {
-      tbb::parallel_for(tbb::blocked_range<size_t>(i, i + trisChunkSize), TrisSelector(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, &triIncluded, m_misorResol, m_PhaseOfInterest,
+      tbb::parallel_for(tbb::blocked_range<size_t>(i, i + trisChunkSize), GBCDMetricBased::TrisSelector(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, &triIncluded, m_misorResol, m_PhaseOfInterest,
                                                                                        gFixedT, m_CrystalStructures, m_Eulers, m_Phases, m_FaceLabels, m_FaceNormals, m_FaceAreas),
                         tbb::auto_partitioner());
     }
     else
 #endif
     {
-      TrisSelector serial(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, &triIncluded, m_misorResol, m_PhaseOfInterest, gFixedT, m_CrystalStructures, m_Eulers, m_Phases, m_FaceLabels,
+      GBCDMetricBased::TrisSelector serial(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, &triIncluded, m_misorResol, m_PhaseOfInterest, gFixedT, m_CrystalStructures, m_Eulers, m_Phases, m_FaceLabels,
                           m_FaceNormals, m_FaceAreas);
       serial.select(i, i + trisChunkSize);
     }
@@ -1044,13 +1049,13 @@ void FindGBCDMetricBased::execute()
     if(doParallel == true)
     {
       tbb::parallel_for(tbb::blocked_range<size_t>(i, i + pointsChunkSize),
-                        ProbeDistrib(&distribValues, &errorValues, samplPtsX, samplPtsY, samplPtsZ, selectedTris, m_PlaneResolSq, totalFaceArea, numDistinctGBs, ballVolume, gFixedT),
+                        GBCDMetricBased::ProbeDistrib(&distribValues, &errorValues, samplPtsX, samplPtsY, samplPtsZ, selectedTris, m_PlaneResolSq, totalFaceArea, numDistinctGBs, ballVolume, gFixedT),
                         tbb::auto_partitioner());
     }
     else
 #endif
     {
-      ProbeDistrib serial(&distribValues, &errorValues, samplPtsX, samplPtsY, samplPtsZ, selectedTris, m_PlaneResolSq, totalFaceArea, numDistinctGBs, ballVolume, gFixedT);
+      GBCDMetricBased::ProbeDistrib serial(&distribValues, &errorValues, samplPtsX, samplPtsY, samplPtsZ, selectedTris, m_PlaneResolSq, totalFaceArea, numDistinctGBs, ballVolume, gFixedT);
       serial.probe(i, i + pointsChunkSize);
     }
   }

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindGBPDMetricBased.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindGBPDMetricBased.cpp
@@ -72,6 +72,9 @@
 // Include the MOC generated file for this class
 #include "moc_FindGBPDMetricBased.cpp"
 
+namespace GBPDMetricBased
+{
+
 /**
  * @brief The TriAreaAndNormals class defines a container that stores the area of a given triangle
  * and the two normals for grains on either side of the triangle
@@ -359,6 +362,8 @@ public:
   }
 #endif
 };
+
+}
 
 // -----------------------------------------------------------------------------
 //
@@ -1024,9 +1029,9 @@ void FindGBPDMetricBased::execute()
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
   tbb::task_scheduler_init init;
   bool doParallel = true;
-  tbb::concurrent_vector<TriAreaAndNormals> selectedTris(0);
+  tbb::concurrent_vector<GBPDMetricBased::TriAreaAndNormals> selectedTris(0);
 #else
-  QVector<TriAreaAndNormals> selectedTris(0);
+  QVector<GBPDMetricBased::TriAreaAndNormals> selectedTris(0);
 #endif
 
   size_t trisChunkSize = 50000;
@@ -1051,14 +1056,14 @@ void FindGBPDMetricBased::execute()
 #ifdef SIMPLib_USE_PARALLEL_ALGORITHMS
     if(doParallel == true)
     {
-      tbb::parallel_for(tbb::blocked_range<size_t>(i, i + trisChunkSize), TrisSelector(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, m_PhaseOfInterest, m_CrystalStructures, m_Eulers,
+      tbb::parallel_for(tbb::blocked_range<size_t>(i, i + trisChunkSize), GBPDMetricBased::TrisSelector(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, m_PhaseOfInterest, m_CrystalStructures, m_Eulers,
                                                                                        m_Phases, m_FaceLabels, m_FaceNormals, m_FaceAreas),
                         tbb::auto_partitioner());
     }
     else
 #endif
     {
-      TrisSelector serial(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, m_PhaseOfInterest, m_CrystalStructures, m_Eulers, m_Phases, m_FaceLabels, m_FaceNormals, m_FaceAreas);
+      GBPDMetricBased::TrisSelector serial(m_ExcludeTripleLines, m_Triangles, m_NodeTypes, &selectedTris, m_PhaseOfInterest, m_CrystalStructures, m_Eulers, m_Phases, m_FaceLabels, m_FaceNormals, m_FaceAreas);
       serial.select(i, i + trisChunkSize);
     }
   }
@@ -1121,13 +1126,13 @@ void FindGBPDMetricBased::execute()
     if(doParallel == true)
     {
       tbb::parallel_for(tbb::blocked_range<size_t>(i, i + pointsChunkSize),
-                        ProbeDistrib(&distribValues, &errorValues, &samplPtsX, &samplPtsY, &samplPtsZ, selectedTris, m_LimitDist, totalFaceArea, numDistinctGBs, ballVolume, cryst),
+                        GBPDMetricBased::ProbeDistrib(&distribValues, &errorValues, &samplPtsX, &samplPtsY, &samplPtsZ, selectedTris, m_LimitDist, totalFaceArea, numDistinctGBs, ballVolume, cryst),
                         tbb::auto_partitioner());
     }
     else
 #endif
     {
-      ProbeDistrib serial(&distribValues, &errorValues, &samplPtsX, &samplPtsY, &samplPtsZ, selectedTris, m_LimitDist, totalFaceArea, numDistinctGBs, ballVolume, cryst);
+      GBPDMetricBased::ProbeDistrib serial(&distribValues, &errorValues, &samplPtsX, &samplPtsY, &samplPtsZ, selectedTris, m_LimitDist, totalFaceArea, numDistinctGBs, ballVolume, cryst);
       serial.probe(i, i + pointsChunkSize);
     }
   }


### PR DESCRIPTION
The crash was caused by a symbol conflict with the FindGBCDMetricBased filter.
This can be fixed by wrapping the helper classes in a namespace.

updates #600 
closes #600 