### PR TITLE
Avizo Exporters do not write correctly formatted files.

### DIFF
--- a/Source/Plugins/IO/IOFilters/AvizoRectilinearCoordinateWriter.h
+++ b/Source/Plugins/IO/IOFilters/AvizoRectilinearCoordinateWriter.h
@@ -33,20 +33,19 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-
 #ifndef _avizorectilinearcoordinatewriter_h_
 #define _avizorectilinearcoordinatewriter_h_
 
-#include <QtCore/QString>
-#include <QtCore/QDataStream>
+#include <stdio.h>
 
-#include "SIMPLib/SIMPLib.h"
+#include <QtCore/QString>
+
 #include "SIMPLib/Common/AbstractFilter.h"
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/DataArrays/IDataArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
-
+#include "SIMPLib/SIMPLib.h"
 
 /**
  * @class AvizoRectilinearCoordinateWriter AvizoRectilinearCoordinateWriter.h DREAM3DLib/IOFilters/AvizoRectilinearCoordinateWriter.h
@@ -57,144 +56,145 @@
  */
 class AvizoRectilinearCoordinateWriter : public AbstractFilter
 {
-    Q_OBJECT
-  public:
+  Q_OBJECT
+public:
+  SIMPL_SHARED_POINTERS(AvizoRectilinearCoordinateWriter)
+  SIMPL_STATIC_NEW_MACRO(AvizoRectilinearCoordinateWriter)
+  SIMPL_TYPE_MACRO_SUPER(AvizoRectilinearCoordinateWriter, AbstractFilter)
 
-    SIMPL_SHARED_POINTERS(AvizoRectilinearCoordinateWriter)
-    SIMPL_STATIC_NEW_MACRO(AvizoRectilinearCoordinateWriter)
-    SIMPL_TYPE_MACRO_SUPER(AvizoRectilinearCoordinateWriter, AbstractFilter)
+  virtual ~AvizoRectilinearCoordinateWriter();
 
-    virtual ~AvizoRectilinearCoordinateWriter();
+  SIMPL_FILTER_PARAMETER(QString, OutputFile)
+  Q_PROPERTY(QString OutputFile READ getOutputFile WRITE setOutputFile)
 
-    SIMPL_FILTER_PARAMETER(QString, OutputFile)
-    Q_PROPERTY(QString OutputFile READ getOutputFile WRITE setOutputFile)
+  SIMPL_FILTER_PARAMETER(bool, WriteBinaryFile)
+  Q_PROPERTY(bool WriteBinaryFile READ getWriteBinaryFile WRITE setWriteBinaryFile)
 
-    SIMPL_FILTER_PARAMETER(bool, WriteBinaryFile)
-    Q_PROPERTY(bool WriteBinaryFile READ getWriteBinaryFile WRITE setWriteBinaryFile)
+  SIMPL_FILTER_PARAMETER(QString, Units)
+  Q_PROPERTY(QString Units READ getUnits WRITE setUnits)
 
-    SIMPL_INSTANCE_PROPERTY(bool, WriteFeatureIds)
+  SIMPL_INSTANCE_PROPERTY(bool, WriteFeatureIds)
 
-    /**
-    * @brief This returns the group that the filter belonds to. You can select
-    * a different group if you want. The string returned here will be displayed
-    * in the GUI for the filter
-    */
-    SIMPL_FILTER_PARAMETER(DataArrayPath, FeatureIdsArrayPath)
-    Q_PROPERTY(DataArrayPath FeatureIdsArrayPath READ getFeatureIdsArrayPath WRITE setFeatureIdsArrayPath)
+  /**
+  * @brief This returns the group that the filter belonds to. You can select
+  * a different group if you want. The string returned here will be displayed
+  * in the GUI for the filter
+  */
+  SIMPL_FILTER_PARAMETER(DataArrayPath, FeatureIdsArrayPath)
+  Q_PROPERTY(DataArrayPath FeatureIdsArrayPath READ getFeatureIdsArrayPath WRITE setFeatureIdsArrayPath)
 
-    /**
-     * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getCompiledLibraryName();
+  /**
+   * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getCompiledLibraryName();
 
-    /**
-     * @brief getBrandingString Returns the branding string for the filter, which is a tag
-     * used to denote the filter's association with specific plugins
-     * @return Branding string
-    */
-    virtual const QString getBrandingString();
+  /**
+   * @brief getBrandingString Returns the branding string for the filter, which is a tag
+   * used to denote the filter's association with specific plugins
+   * @return Branding string
+  */
+  virtual const QString getBrandingString();
 
-    /**
-     * @brief getFilterVersion Returns a version string for this filter. Default
-     * value is an empty string.
-     * @return
-     */
-    virtual const QString getFilterVersion();
+  /**
+   * @brief getFilterVersion Returns a version string for this filter. Default
+   * value is an empty string.
+   * @return
+   */
+  virtual const QString getFilterVersion();
 
-    /**
-     * @brief newFilterInstance Reimplemented from @see AbstractFilter class
-     */
-    virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters);
+  /**
+   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+   */
+  virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters);
 
-    /**
-     * @brief getGroupName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getGroupName();
+  /**
+   * @brief getGroupName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getGroupName();
 
-    /**
-     * @brief getSubGroupName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getSubGroupName();
+  /**
+   * @brief getSubGroupName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getSubGroupName();
 
-    /**
-     * @brief getHumanLabel Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getHumanLabel();
+  /**
+   * @brief getHumanLabel Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getHumanLabel();
 
-    /**
-     * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
-     */
-    virtual void setupFilterParameters();
+  /**
+   * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  virtual void setupFilterParameters();
 
-    /**
-     * @brief readFilterParameters Reimplemented from @see AbstractFilter class
-     */
-    virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index);
+  /**
+   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index);
 
-    /**
-     * @brief execute Reimplemented from @see AbstractFilter class
-     */
-    virtual void execute();
+  /**
+   * @brief execute Reimplemented from @see AbstractFilter class
+   */
+  virtual void execute();
 
-    /**
-    * @brief preflight Reimplemented from @see AbstractFilter class
-    */
-    virtual void preflight();
+  /**
+  * @brief preflight Reimplemented from @see AbstractFilter class
+  */
+  virtual void preflight();
 
-  signals:
-    /**
-     * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
-     * be pushed from a user-facing control (such as a widget)
-     * @param filter Filter instance pointer
-     */
-    void updateFilterParameters(AbstractFilter* filter);
+signals:
+  /**
+   * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
+   * be pushed from a user-facing control (such as a widget)
+   * @param filter Filter instance pointer
+   */
+  void updateFilterParameters(AbstractFilter* filter);
 
-    /**
-     * @brief parametersChanged Emitted when any Filter parameter is changed internally
-     */
-    void parametersChanged();
+  /**
+   * @brief parametersChanged Emitted when any Filter parameter is changed internally
+   */
+  void parametersChanged();
 
-    /**
-     * @brief preflightAboutToExecute Emitted just before calling dataCheck()
-     */
-    void preflightAboutToExecute();
+  /**
+   * @brief preflightAboutToExecute Emitted just before calling dataCheck()
+   */
+  void preflightAboutToExecute();
 
-    /**
-     * @brief preflightExecuted Emitted just after calling dataCheck()
-     */
-    void preflightExecuted();
+  /**
+   * @brief preflightExecuted Emitted just after calling dataCheck()
+   */
+  void preflightExecuted();
 
-  protected:
-    AvizoRectilinearCoordinateWriter();
-    /**
-     * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
-     */
-    void dataCheck();
+protected:
+  AvizoRectilinearCoordinateWriter();
+  /**
+   * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
+   */
+  void dataCheck();
 
-    /**
-     * @brief Initializes all the private instance variables.
-     */
-    void initialize();
+  /**
+   * @brief Initializes all the private instance variables.
+   */
+  void initialize();
 
+  /**
+   * @brief Generates the Avizo Header for this file
+   * @return The header as a string
+   */
+  void generateHeader(FILE* f);
 
-    /**
-     * @brief Generates the Avizo Header for this file
-     * @return The header as a string
-     */
-    void generateHeader(QDataStream& out);
+  /**
+   * @brief Writes the data to the Avizo file
+   * @param writer The MXAFileWriter object
+   * @return Error code
+   */
+  int writeData(FILE* f);
 
-    /**
-     * @brief Writes the data to the Avizo file
-     * @param writer The MXAFileWriter object
-     * @return Error code
-     */
-    int writeData(QDataStream& writer);
+private:
+  DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-  private:
-    DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
-
-    AvizoRectilinearCoordinateWriter(const AvizoRectilinearCoordinateWriter&); // Copy Constructor Not Implemented
-    void operator=(const AvizoRectilinearCoordinateWriter&); // Operator '=' Not Implemented
+  AvizoRectilinearCoordinateWriter(const AvizoRectilinearCoordinateWriter&); // Copy Constructor Not Implemented
+  void operator=(const AvizoRectilinearCoordinateWriter&);                   // Operator '=' Not Implemented
 };
 
 #endif /* AvizoRectilinearCoordinateWriter_H_ */

--- a/Source/Plugins/IO/IOFilters/AvizoUniformCoordinateWriter.cpp
+++ b/Source/Plugins/IO/IOFilters/AvizoUniformCoordinateWriter.cpp
@@ -48,6 +48,7 @@
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/OutputFileFilterParameter.h"
 #include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
+#include "SIMPLib/FilterParameters/StringFilterParameter.h"
 #include "SIMPLib/Geometry/ImageGeom.h"
 
 // Include the MOC generated file for this class
@@ -60,6 +61,7 @@ AvizoUniformCoordinateWriter::AvizoUniformCoordinateWriter()
 : AbstractFilter()
 , m_OutputFile("")
 , m_WriteBinaryFile(false)
+, m_Units("microns")
 , m_WriteFeatureIds(true)
 , m_FeatureIdsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::FeatureIds)
 , m_FeatureIds(nullptr)
@@ -87,6 +89,7 @@ void AvizoUniformCoordinateWriter::setupFilterParameters()
     DataArraySelectionFilterParameter::RequirementType req;
     parameters.push_back(SIMPL_NEW_DA_SELECTION_FP("FeatureIds", FeatureIdsArrayPath, FilterParameter::RequiredArray, AvizoUniformCoordinateWriter, req));
   }
+  parameters.push_back(SIMPL_NEW_STRING_FP("Units", Units, FilterParameter::Parameter, AvizoUniformCoordinateWriter, 0));
 
   setFilterParameters(parameters);
 }
@@ -184,19 +187,20 @@ void AvizoUniformCoordinateWriter::execute()
     return;
   }
 
-  QFile writer(getOutputFile());
-  if(!writer.open(QIODevice::WriteOnly | QIODevice::Text))
+  FILE* avizoFile = fopen(getOutputFile().toLatin1().data(), "wb");
+  if(nullptr == avizoFile)
   {
-    QString ss = QObject::tr("Avizo Output file could not be opened: %1").arg(getOutputFile());
-    setErrorCondition(-100);
+    setErrorCondition(-93001);
+    QString ss = QObject::tr("Error creating file '%1'").arg(getOutputFile());
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
     return;
   }
 
-  QDataStream out(&writer);
-  generateHeader(out);
+  generateHeader(avizoFile);
 
-  err = writeData(out);
+  err = writeData(avizoFile);
+
+  fclose(avizoFile);
 
   /* Let the GUI know we are done with this filter */
   notifyStatusMessage(getHumanLabel(), "Complete");
@@ -205,86 +209,89 @@ void AvizoUniformCoordinateWriter::execute()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void AvizoUniformCoordinateWriter::generateHeader(QDataStream& ss)
+void AvizoUniformCoordinateWriter::generateHeader(FILE* f)
 {
   if(m_WriteBinaryFile == true)
   {
 #ifdef CMP_WORDS_BIGENDIAN
-    ss << "# AmiraMesh BINARY 2.1\n";
+    fprintf(f, "# AmiraMesh BINARY 2.1\n");
 #else
-    ss << "# AmiraMesh BINARY-LITTLE-ENDIAN 2.1\n";
+    fprintf(f, "# AmiraMesh BINARY-LITTLE-ENDIAN 2.1\n");
 #endif
   }
   else
   {
-    ss << "# AmiraMesh 3D ASCII 2.0\n";
+    fprintf(f, "# AmiraMesh 3D ASCII 2.0\n");
   }
-  ss << "\n";
-  ss << "# Dimensions in x-, y-, and z-direction\n";
+  fprintf(f, "\n");
+  fprintf(f, "# Dimensions in x-, y-, and z-direction\n");
   size_t x = 0, y = 0, z = 0;
   getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName())->getGeometryAs<ImageGeom>()->getDimensions(x, y, z);
-  ss << "define Lattice " << (qint32)x << " " << (qint32)y << " " << (qint32)z << "\n\n";
 
-  ss << "Parameters {\n";
-  ss << "     DREAM3DParams {\n";
-  ss << "         Author \"DREAM3D\",\n";
-  ss << "         DateTime \"" << QDateTime::currentDateTime().toString() << "\"\n";
-  ss << "     }\n";
+  fprintf(f, "define Lattice %llu %llu %llu\n", static_cast<unsigned long long>(x), static_cast<unsigned long long>(y), static_cast<unsigned long long>(z));
 
-  ss << "     Units {\n";
-  ss << "         Coordinates \"microns\"\n";
-  ss << "     }\n";
-  ss << "     Content \"" << (qint32)x << "x" << (qint32)y << "x" << (qint32)z << " int, uniform coordinates\",\n";
+  fprintf(f, "Parameters {\n");
+  fprintf(f, "     DREAM3DParams {\n");
+  fprintf(f, "         Author \"DREAM.3D %s\",\n", IO::Version::PackageComplete().toLatin1().data());
+  fprintf(f, "         DateTime \"%s\"\n", QDateTime::currentDateTime().toString().toLatin1().data());
+  fprintf(f, "         FeatureIds Path \"%s\"\n", getFeatureIdsArrayPath().serialize("/").toLatin1().data());
+  fprintf(f, "     }\n");
+
+  fprintf(f, "     Units {\n");
+  fprintf(f, "         Coordinates \"%s\"\n", getUnits().toLatin1().data());
+  fprintf(f, "     }\n");
+
+  fprintf(f, "     Content \"%llux%llux%llu int, uniform coordinates\",\n", static_cast<unsigned long long int>(x), static_cast<unsigned long long int>(y), static_cast<unsigned long long int>(z));
+
   float origin[3];
   getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName())->getGeometryAs<ImageGeom>()->getOrigin(origin);
   float res[3];
   getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName())->getGeometryAs<ImageGeom>()->getResolution(res);
-  ss << "     # Bounding Box is xmin xmax ymin ymax zmin zmax\n";
-  ss << "     BoundingBox " << origin[0] << " " << origin[0] + (res[0] * x);
-  ss << " " << origin[1] << " " << origin[1] + (res[1] * y);
-  ss << " " << origin[2] << " " << origin[2] + (res[2] * z);
-  ss << ",\n";
-  ss << "     CoordType \"uniform\"\n";
-  ss << "}\n\n";
+  fprintf(f, "     # Bounding Box is xmin xmax ymin ymax zmin zmax\n");
+  fprintf(f, "     BoundingBox %f %f %f %f %f %f\n", origin[0], origin[0] + (res[0] * x), origin[1], origin[1] + (res[1] * y), origin[2], origin[2] + (res[2] * z));
 
-  ss << "Lattice { int FeatureIds } = @1\n\n";
+  fprintf(f, "     CoordType \"uniform\"\n");
+  fprintf(f, "}\n\n");
 
-  ss << "# Data section follows\n";
+  fprintf(f, "Lattice { int FeatureIds } = @1\n");
+
+  fprintf(f, "# Data section follows\n");
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int AvizoUniformCoordinateWriter::writeData(QDataStream& out)
+int AvizoUniformCoordinateWriter::writeData(FILE* f)
 {
   QString start("@1\n");
-  out << start;
+  fprintf(f, "%s", start.toLatin1().data());
+
+  size_t totalPoints = m_FeatureIdsPtr.lock()->getNumberOfTuples();
+
   if(true == m_WriteBinaryFile)
   {
-    out.writeRawData(reinterpret_cast<char*>(m_FeatureIds), m_FeatureIdsPtr.lock()->getNumberOfTuples() * sizeof(int32_t));
+    fwrite(m_FeatureIds, sizeof(int32_t), totalPoints, f);
   }
   else
   {
     // The "20 Items" is purely arbitrary and is put in to try and save some space in the ASCII file
-    int64_t totalPoints = m_FeatureIdsPtr.lock()->getNumberOfTuples();
     int count = 0;
-    for(int64_t i = 0; i < totalPoints; ++i)
+    for(size_t i = 0; i < totalPoints; ++i)
     {
-      out << m_FeatureIds[i];
+      fprintf(f, "%d", m_FeatureIds[i]);
       if(count < 20)
       {
-        out << " ";
+        fprintf(f, " ");
         count++;
       }
       else
       {
-        out << "\n";
+        fprintf(f, "\n");
         count = 0;
       }
     }
-    // Pick up any remaining data that was not written because we did not have 20 items on a line.
-    out << "\n";
   }
+  fprintf(f, "\n");
   return 1;
 }
 

--- a/Source/Plugins/IO/IOFilters/AvizoUniformCoordinateWriter.h
+++ b/Source/Plugins/IO/IOFilters/AvizoUniformCoordinateWriter.h
@@ -33,20 +33,19 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-
 #ifndef _avizouniformcoordinatewriter_h_
 #define _avizouniformcoordinatewriter_h_
 
+#include <stdio.h>
+
 #include <QtCore/QString>
 
-#include <QtCore/QFile>
-
-#include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/AbstractFilter.h"
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/DataArrays/IDataArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
+#include "SIMPLib/SIMPLib.h"
 
 /**
  * @class AvizoUniformCoordinateWriter AvizoUniformCoordinateWriter.h DREAM3DLib/IOFilters/AvizoUniformCoordinateWriter.h
@@ -57,143 +56,145 @@
  */
 class AvizoUniformCoordinateWriter : public AbstractFilter
 {
-    Q_OBJECT
-  public:
-    SIMPL_SHARED_POINTERS(AvizoUniformCoordinateWriter)
-    SIMPL_STATIC_NEW_MACRO(AvizoUniformCoordinateWriter)
-    SIMPL_TYPE_MACRO_SUPER(AvizoUniformCoordinateWriter, AbstractFilter)
+  Q_OBJECT
+public:
+  SIMPL_SHARED_POINTERS(AvizoUniformCoordinateWriter)
+  SIMPL_STATIC_NEW_MACRO(AvizoUniformCoordinateWriter)
+  SIMPL_TYPE_MACRO_SUPER(AvizoUniformCoordinateWriter, AbstractFilter)
 
-    virtual ~AvizoUniformCoordinateWriter();
+  virtual ~AvizoUniformCoordinateWriter();
 
-    SIMPL_FILTER_PARAMETER(QString, OutputFile)
-    Q_PROPERTY(QString OutputFile READ getOutputFile WRITE setOutputFile)
+  SIMPL_FILTER_PARAMETER(QString, OutputFile)
+  Q_PROPERTY(QString OutputFile READ getOutputFile WRITE setOutputFile)
 
-    SIMPL_FILTER_PARAMETER(bool, WriteBinaryFile)
-    Q_PROPERTY(bool WriteBinaryFile READ getWriteBinaryFile WRITE setWriteBinaryFile)
+  SIMPL_FILTER_PARAMETER(bool, WriteBinaryFile)
+  Q_PROPERTY(bool WriteBinaryFile READ getWriteBinaryFile WRITE setWriteBinaryFile)
 
-    SIMPL_INSTANCE_PROPERTY(bool, WriteFeatureIds)
+  SIMPL_FILTER_PARAMETER(QString, Units)
+  Q_PROPERTY(QString Units READ getUnits WRITE setUnits)
 
-    /**
-    * @brief This returns the group that the filter belonds to. You can select
-    * a different group if you want. The string returned here will be displayed
-    * in the GUI for the filter
-    */
-    SIMPL_FILTER_PARAMETER(DataArrayPath, FeatureIdsArrayPath)
-    Q_PROPERTY(DataArrayPath FeatureIdsArrayPath READ getFeatureIdsArrayPath WRITE setFeatureIdsArrayPath)
+  SIMPL_INSTANCE_PROPERTY(bool, WriteFeatureIds)
 
-    /**
-     * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getCompiledLibraryName();
+  /**
+  * @brief This returns the group that the filter belonds to. You can select
+  * a different group if you want. The string returned here will be displayed
+  * in the GUI for the filter
+  */
+  SIMPL_FILTER_PARAMETER(DataArrayPath, FeatureIdsArrayPath)
+  Q_PROPERTY(DataArrayPath FeatureIdsArrayPath READ getFeatureIdsArrayPath WRITE setFeatureIdsArrayPath)
 
-    /**
-     * @brief getBrandingString Returns the branding string for the filter, which is a tag
-     * used to denote the filter's association with specific plugins
-     * @return Branding string
-    */
-    virtual const QString getBrandingString();
+  /**
+   * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getCompiledLibraryName();
 
-    /**
-     * @brief getFilterVersion Returns a version string for this filter. Default
-     * value is an empty string.
-     * @return
-     */
-    virtual const QString getFilterVersion();
+  /**
+   * @brief getBrandingString Returns the branding string for the filter, which is a tag
+   * used to denote the filter's association with specific plugins
+   * @return Branding string
+  */
+  virtual const QString getBrandingString();
 
-    /**
-     * @brief newFilterInstance Reimplemented from @see AbstractFilter class
-     */
-    virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters);
+  /**
+   * @brief getFilterVersion Returns a version string for this filter. Default
+   * value is an empty string.
+   * @return
+   */
+  virtual const QString getFilterVersion();
 
-    /**
-     * @brief getGroupName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getGroupName();
+  /**
+   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+   */
+  virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters);
 
-    /**
-     * @brief getSubGroupName Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getSubGroupName();
+  /**
+   * @brief getGroupName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getGroupName();
 
-    /**
-     * @brief getHumanLabel Reimplemented from @see AbstractFilter class
-     */
-    virtual const QString getHumanLabel();
+  /**
+   * @brief getSubGroupName Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getSubGroupName();
 
-    /**
-     * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
-     */
-    virtual void setupFilterParameters();
+  /**
+   * @brief getHumanLabel Reimplemented from @see AbstractFilter class
+   */
+  virtual const QString getHumanLabel();
 
-    /**
-     * @brief readFilterParameters Reimplemented from @see AbstractFilter class
-     */
-    virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index);
+  /**
+   * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  virtual void setupFilterParameters();
 
-    /**
-     * @brief execute Reimplemented from @see AbstractFilter class
-     */
-    virtual void execute();
+  /**
+   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index);
 
-    /**
-    * @brief preflight Reimplemented from @see AbstractFilter class
-    */
-    virtual void preflight();
+  /**
+   * @brief execute Reimplemented from @see AbstractFilter class
+   */
+  virtual void execute();
 
-  signals:
-    /**
-     * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
-     * be pushed from a user-facing control (such as a widget)
-     * @param filter Filter instance pointer
-     */
-    void updateFilterParameters(AbstractFilter* filter);
+  /**
+  * @brief preflight Reimplemented from @see AbstractFilter class
+  */
+  virtual void preflight();
 
-    /**
-     * @brief parametersChanged Emitted when any Filter parameter is changed internally
-     */
-    void parametersChanged();
+signals:
+  /**
+   * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
+   * be pushed from a user-facing control (such as a widget)
+   * @param filter Filter instance pointer
+   */
+  void updateFilterParameters(AbstractFilter* filter);
 
-    /**
-     * @brief preflightAboutToExecute Emitted just before calling dataCheck()
-     */
-    void preflightAboutToExecute();
+  /**
+   * @brief parametersChanged Emitted when any Filter parameter is changed internally
+   */
+  void parametersChanged();
 
-    /**
-     * @brief preflightExecuted Emitted just after calling dataCheck()
-     */
-    void preflightExecuted();
+  /**
+   * @brief preflightAboutToExecute Emitted just before calling dataCheck()
+   */
+  void preflightAboutToExecute();
 
-  protected:
-    AvizoUniformCoordinateWriter();
-    /**
-     * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
-     */
-    void dataCheck();
+  /**
+   * @brief preflightExecuted Emitted just after calling dataCheck()
+   */
+  void preflightExecuted();
 
-    /**
-     * @brief Initializes all the private instance variables.
-     */
-    void initialize();
+protected:
+  AvizoUniformCoordinateWriter();
+  /**
+   * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
+   */
+  void dataCheck();
 
+  /**
+   * @brief Initializes all the private instance variables.
+   */
+  void initialize();
 
-    /**
-     * @brief Generates the Avizo Header for this file
-     * @return The header as a string
-     */
-    void generateHeader(QDataStream& ss);
+  /**
+   * @brief Generates the Avizo Header for this file
+   * @return The header as a string
+   */
+  void generateHeader(FILE* f);
 
-    /**
-     * @brief Writes the data to the Avizo file
-     * @param writer The MXAFileWriter object
-     * @return Error code
-     */
-    int writeData(QDataStream& out);
+  /**
+   * @brief Writes the data to the Avizo file
+   * @param writer The MXAFileWriter object
+   * @return Error code
+   */
+  int writeData(FILE* f);
 
-  private:
-    DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
+private:
+  DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-    AvizoUniformCoordinateWriter(const AvizoUniformCoordinateWriter&); // Copy Constructor Not Implemented
-    void operator=(const AvizoUniformCoordinateWriter&); // Operator '=' Not Implemented
+  AvizoUniformCoordinateWriter(const AvizoUniformCoordinateWriter&); // Copy Constructor Not Implemented
+  void operator=(const AvizoUniformCoordinateWriter&);               // Operator '=' Not Implemented
 };
 
 #endif /* AvizoUniformCoordinateWriter_H_ */


### PR DESCRIPTION
Do to the use of QDataStream both the export of binary and ASCII files
are not working correctly. Convert both classes to use FILE* pointers and
raw writing using fprintf and fwrite instead. Add additional parameters
to the header including DREAM.3D version and the Feature Ids Path.

updates #677
fixes #677