### PR TITLE
Using mask array should be optional in WritePoleFigure

### DIFF
--- a/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/WritePoleFigure.md
+++ b/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/WritePoleFigure.md
@@ -28,9 +28,10 @@ The pole figure algorithm uses a _modified Lambert square_ to perform the interp
 | Image Prefix | String | Prefix the prepend each pole figure file with |
 | Output Path | File Path | Output directory path for images |
 | Image Size (Square Pixels) | int32_t | Size of the output image in square pixels |
- 
+| Use Mask Array | bool | Specifies whether to use a boolean array to exclude some **Cells**. Only those cells that have a _Mask Array_ value of 1 will be used. |
 ## Required Geometry ##
-Image
+
+NONE
 
 ## Required Objects ##
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.h
@@ -83,7 +83,6 @@ class WritePoleFigure : public AbstractFilter
       JpgImageType = 3
     };
 
-
     SIMPL_FILTER_PARAMETER(DataArrayPath, CellEulerAnglesArrayPath)
     Q_PROPERTY(DataArrayPath CellEulerAnglesArrayPath READ getCellEulerAnglesArrayPath WRITE setCellEulerAnglesArrayPath)
 
@@ -95,6 +94,9 @@ class WritePoleFigure : public AbstractFilter
 
     SIMPL_FILTER_PARAMETER(DataArrayPath, GoodVoxelsArrayPath)
     Q_PROPERTY(DataArrayPath GoodVoxelsArrayPath READ getGoodVoxelsArrayPath WRITE setGoodVoxelsArrayPath)
+
+    SIMPL_FILTER_PARAMETER(bool, UseGoodVoxels)
+    Q_PROPERTY(bool UseGoodVoxels READ getUseGoodVoxels WRITE setUseGoodVoxels)
 
     /**
      * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class


### PR DESCRIPTION
The user did not have a real choice but to use a mask array in the
WritePoleFigure filter. Implemented proper LinkedBoolean Filter Parameter
to allow the user to turn on/off the use of a mask array

updates #690. fixes #690