### PR TITLE
Fix issue reading the PhaseName from the Json pipeline file.

### DIFF
--- a/Source/Plugins/StatsGenerator/FilterParameterWidgets/StatsGeneratorWidget.cpp
+++ b/Source/Plugins/StatsGenerator/FilterParameterWidgets/StatsGeneratorWidget.cpp
@@ -160,41 +160,41 @@ void StatsGeneratorWidget::setupGui()
       {
         progress.setLabelText("Opening Boundaray Phase...");
         BoundaryPhaseWidget* w = new BoundaryPhaseWidget(this);
-        phaseTabs->addTab(w, w->getTabTitle());
         w->extractStatsData(cellEnsembleAttrMat, static_cast<int>(phase));
+        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(dataChanged()), this, SIGNAL(parametersChanged()));
       }
       else if (phaseTypes->getValue(phase) == static_cast<PhaseType::EnumType>(PhaseType::Type::Matrix))
       {
         progress.setLabelText("Opening Matrix Phase...");
         MatrixPhaseWidget* w = new MatrixPhaseWidget(this);
-        phaseTabs->addTab(w, w->getTabTitle());
         w->extractStatsData(cellEnsembleAttrMat, static_cast<int>(phase));
+        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(dataChanged()), this, SIGNAL(parametersChanged()));
       }
       if (phaseTypes->getValue(phase) == static_cast<PhaseType::EnumType>(PhaseType::Type::Precipitate))
       {
         progress.setLabelText("Opening Precipitate Phase...");
         PrecipitatePhaseWidget* w = new PrecipitatePhaseWidget(this);
-        phaseTabs->addTab(w, w->getTabTitle());
         w->extractStatsData(cellEnsembleAttrMat, static_cast<int>(phase));
+        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(dataChanged()), this, SIGNAL(parametersChanged()));
       }
       if (phaseTypes->getValue(phase) == static_cast<PhaseType::EnumType>(PhaseType::Type::Primary))
       {
         progress.setLabelText("Opening Primary Phase...");
         PrimaryPhaseWidget* w = new PrimaryPhaseWidget(this);
-        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(progressText(const QString&)), &progress, SLOT(setLabelText(const QString&)));
         w->extractStatsData(cellEnsembleAttrMat, static_cast<int>(phase));
+        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(dataChanged()), this, SIGNAL(parametersChanged()));
       }
       if (phaseTypes->getValue(phase) == static_cast<PhaseType::EnumType>(PhaseType::Type::Transformation))
       {
         progress.setLabelText("Opening Transformation Phase...");
         TransformationPhaseWidget* w = new TransformationPhaseWidget(this);
-        phaseTabs->addTab(w, w->getTabTitle());
         w->extractStatsData(cellEnsembleAttrMat, static_cast<int>(phase));
+        phaseTabs->addTab(w, w->getTabTitle());
         connect(w, SIGNAL(dataChanged()), this, SIGNAL(parametersChanged()));
       }
       else

--- a/Source/Plugins/StatsGenerator/StatsGeneratorFilters/StatsGeneratorFilter.cpp
+++ b/Source/Plugins/StatsGenerator/StatsGeneratorFilters/StatsGeneratorFilter.cpp
@@ -226,7 +226,7 @@ void StatsGeneratorFilter::readArray(const QJsonObject& jsonRoot, size_t numTupl
     PhaseType::Type pt = m_StatsDataArray->getStatsData(index)->getPhaseType();
     m_PhaseTypes->setValue(index, static_cast<PhaseType::EnumType>(pt));
 
-    QString phaseName = phaseObject[SIMPL::EnsembleData::PhaseName].toString();
+    QString phaseName = phaseObject[SIMPL::StringConstants::Name].toString();
     m_PhaseNames->setValue(index, phaseName);
   }
 }

--- a/Source/Plugins/StatsGenerator/Widgets/BoundaryPhaseWidget.cpp
+++ b/Source/Plugins/StatsGenerator/Widgets/BoundaryPhaseWidget.cpp
@@ -162,6 +162,7 @@ void BoundaryPhaseWidget::extractStatsData(AttributeMatrix::Pointer attrMat, int
     phaseName = QString("Boundary Phase (%1)").arg(index);
   }
   setPhaseName(phaseName);
+  setTabTitle(phaseName);
   setPhaseFraction(boundaryStatsData->getPhaseFraction());
 }
 

--- a/Source/Plugins/StatsGenerator/Widgets/MatrixPhaseWidget.cpp
+++ b/Source/Plugins/StatsGenerator/Widgets/MatrixPhaseWidget.cpp
@@ -168,6 +168,7 @@ void MatrixPhaseWidget::extractStatsData(AttributeMatrix::Pointer attrMat, int i
     phaseName = QString("Matrix Phase (%1)").arg(index);
   }
   setPhaseName(phaseName);
+  setTabTitle(phaseName);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/StatsGenerator/Widgets/PrecipitatePhaseWidget.cpp
+++ b/Source/Plugins/StatsGenerator/Widgets/PrecipitatePhaseWidget.cpp
@@ -440,7 +440,9 @@ void PrecipitatePhaseWidget::extractStatsData(AttributeMatrix::Pointer attrMat, 
   {
     phaseName = QString("Precipitate Phase (%1)").arg(index);
   }
-  setPhaseName(phaseName);  setPhaseFraction(precipitateStatsData->getPhaseFraction());
+  setPhaseName(phaseName);
+  setTabTitle(phaseName);
+  setPhaseFraction(precipitateStatsData->getPhaseFraction());
   m_PptFraction = precipitateStatsData->getPrecipBoundaryFraction();
 
   getFeatureSizeWidget()->setCrystalStructure(getCrystalStructure());

--- a/Source/Plugins/StatsGenerator/Widgets/PrimaryPhaseWidget.cpp
+++ b/Source/Plugins/StatsGenerator/Widgets/PrimaryPhaseWidget.cpp
@@ -817,6 +817,7 @@ void PrimaryPhaseWidget::extractStatsData(AttributeMatrix::Pointer attrMat, int 
     phaseName = QString("Primary Phase (%1)").arg(index);
   }
   setPhaseName(phaseName);
+  setTabTitle(phaseName);
   m_FeatureSizeDistWidget->setCrystalStructure(getCrystalStructure());
   foreach(StatsGenPlotWidget* w, m_SGPlotWidgets)
   {

--- a/Source/Plugins/StatsGenerator/Widgets/TransformationPhaseWidget.cpp
+++ b/Source/Plugins/StatsGenerator/Widgets/TransformationPhaseWidget.cpp
@@ -838,6 +838,7 @@ void TransformationPhaseWidget::extractStatsData(AttributeMatrix::Pointer attrMa
     phaseName = QString("Transformation Phase (%1)").arg(index);
   }
   setPhaseName(phaseName);
+  setTabTitle(phaseName);
   m_PhaseFraction = transformationStatsData->getPhaseFraction();
 
   m_ParentPhase = transformationStatsData->getParentPhase();


### PR DESCRIPTION
Root cause was the use of an incorrect constant to look for the value
in the section of the Json file for the StatsData. Other issues were also
fixed such as the PhaseName not properly showing up on tabs in the
StatsGenerator Widget.

Fixes #693. Updates #693.