### PR TITLE
Allow STL files written by Magics Materialise to be read by DREAM.3D.

### DIFF
--- a/Source/Plugins/IO/IOFilters/ReadStlFile.h
+++ b/Source/Plugins/IO/IOFilters/ReadStlFile.h
@@ -164,12 +164,12 @@ class ReadStlFile : public AbstractFilter
   private:
     DEFINE_DATAARRAY_VARIABLE(double, FaceNormals)
 
-    double m_minXcoord;
-    double m_maxXcoord;
-    double m_minYcoord;
-    double m_maxYcoord;
-    double m_minZcoord;
-    double m_maxZcoord;
+    float m_minXcoord;
+    float m_maxXcoord;
+    float m_minYcoord;
+    float m_maxYcoord;
+    float m_minZcoord;
+    float m_maxZcoord;
 
     /**
      * @brief updateFaceInstancePointers Updates raw Face pointers

--- a/Source/Plugins/IO/IOFilters/WriteStlFile.cpp
+++ b/Source/Plugins/IO/IOFilters/WriteStlFile.cpp
@@ -267,11 +267,11 @@ void WriteStlFile::execute()
   }
 
   unsigned char data[50];
-  float* normal = (float*)data;
-  float* vert1 = (float*)(data + 12);
-  float* vert2 = (float*)(data + 24);
-  float* vert3 = (float*)(data + 36);
-  uint16_t* attrByteCount = (uint16_t*)(data + 48);
+  float* normal = reinterpret_cast<float*>(data);
+  float* vert1 = reinterpret_cast<float*>(data + 12);
+  float* vert2 = reinterpret_cast<float*>(data + 24);
+  float* vert3 = reinterpret_cast<float*>(data + 36);
+  uint16_t* attrByteCount = reinterpret_cast<uint16_t*>(data + 48);
   *attrByteCount = 0;
 
   size_t totalWritten = 0;
@@ -399,8 +399,10 @@ int32_t WriteStlFile::writeHeader(FILE* f, const QString& header, int32_t triCou
   {
     headlength = header.length();
   }
+
+  std::string c_str = header.toStdString();
   ::memset(h, 0, 80);
-  ::memcpy(h, header.data(), headlength);
+  ::memcpy(h, c_str.data(), headlength);
   // Return the number of bytes written - which should be 80
   fwrite(h, 1, 80, f);
   fwrite(&triCount, 1, 4, f);
@@ -417,7 +419,7 @@ int32_t WriteStlFile::writeNumTrianglesToFile(const QString& filename, int32_t t
 
   FILE* out = fopen(filename.toLatin1().data(), "r+b");
   fseek(out, 80L, SEEK_SET);
-  fwrite((char*)(&triCount), 1, 4, out);
+  fwrite(reinterpret_cast<char*>(&triCount), 1, 4, out);
   fclose(out);
 
   return err;


### PR DESCRIPTION
Write UTF8 based header in STL files instead of UTF16.

Fixes #732. Closes #732