### PR TITLE
fix compilation errors

### DIFF
--- a/Source/Plugins/Statistics/Test/ComputeMomentInvariants2DTest.cpp
+++ b/Source/Plugins/Statistics/Test/ComputeMomentInvariants2DTest.cpp
@@ -45,6 +45,8 @@
 #include "SIMPLib/SIMPLib.h"
 #include "UnitTestSupport.hpp"
 
+#include "SIMPLib/Math/SIMPLibMath.h"
+
 #include "StatisticsTestFileLocations.h"
 
 #include <Eigen/Dense>

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.cpp
@@ -47,6 +47,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QTableView>
 #include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QHeaderView>
 
 //-- Qwt Includes
 #include <qwt.h>


### PR DESCRIPTION
QheaderView definition missing arount line 473 in "StatsGenPlotWidget.cpp"
  m_TableView->horizontalHeader()->setCascadingSectionResizes(true);
  m_TableView->horizontalHeader()->setStretchLastSection(true);
--> add #include <QtWidgets/QHeaderView>

M_PI definition missing in ComputeMomentInvariants2DTest.cpp
--> add #include "SIMPLib/Math/SIMPLibMath.h"