### PR TITLE
Improvements to StatsGenerator Documentation and Axis ODF Widget.

### DIFF
--- a/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/WriteStatsGenOdfAngleFile.md
+++ b/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/WriteStatsGenOdfAngleFile.md
@@ -1,5 +1,4 @@
-Export StatsGenerator ODF Angle File 
-=====
+# Export StatsGenerator ODF Angle File #   
 
 ## Group (Subgroup) ##
 

--- a/Source/Plugins/SyntheticBuilding/Documentation/SyntheticBuildingFilters/StatsGeneratorFilter.md
+++ b/Source/Plugins/SyntheticBuilding/Documentation/SyntheticBuildingFilters/StatsGeneratorFilter.md
@@ -176,8 +176,32 @@ The ODF tab controls the generation of the Orientation Distribution Function. Th
 
 ### Bulk Load of Angle Data ##
 
+The filter __Export StatsGenerator ODF Angle File__ can help the user create the proper kind of file that is needed for this section to work. An example input file is below:
+
 ![Bulk Load the ODF Angles from a File.](Images/BulkLoadAngles.png)
 
+
+	# All lines starting with '#' are comments and should come before the header.
+	# DREAM.3D StatsGenerator Angles Input File
+	# DREAM.3D Version 6.1.107.0d8bad9
+	# Angle Data is space delimited.
+	# Euler0 Euler1 Euler2 Weight Sigma
+	Angle Count:100
+	0 0 0 1 1
+	3.6 1.8 3.6 1 1
+	7.2 3.6 7.2 1 1
+	10.8 5.4 10.8 1 1
+	14.4 7.2 14.4 1 1
+	
+The **only** required header line is:
+
+	Angle Count:100
+
+There are 5 columns of data which are the 3 Euler Angles, the Weight Value and the Sigma Value.
+
+### Delimiter ###
+
+Choice of delimiter can be Comma (,), semicolon (;), space ( ), colon (:) or tab (\t)
 
 
 ### MDF Section ###

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
@@ -518,6 +518,13 @@ void StatsGenAxisODFWidget::calculateAxisODF()
   config.numColors = numColors;
   config.discrete = true;
   config.discreteHeatMap = false;
+    
+  // Check if the user wants a Discreet or Lambert PoleFigure
+  if(m_PFTypeCB->currentIndex() == 1)
+  {
+    config.discrete = false;
+  }
+  
   QVector<QString> labels(3);
   labels[0] = QString("C Axis"); // 001
   labels[1] = QString("A Axis"); // 100


### PR DESCRIPTION
+ Added additional information to the StatsGenerator documentation pertaining to the use of a bulk load Euler file for the ODF and Axis ODF.
+ Fixed issue where the Axis ODF pole figures could not be switched to Lambert style pole figures.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>