### PR TITLE
Fix incorrect labeling on pole figures for Hexagonal High Laue Class

### DIFF
--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
@@ -1365,7 +1365,7 @@ SIMPL::Rgb HexagonalLowOps::generateRodriguesColor(float r1, float r2, float r3)
 QVector<UInt8ArrayType::Pointer> HexagonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config)
 {
   QString label0 = QString("<0001>");
-  QString label1 = QString("<-1-120>");
+  QString label1 = QString("<11-20>");
   QString label2 = QString("<2-1-10>");
   if(config.labels.size() > 0) { label0 = config.labels.at(0); }
   if(config.labels.size() > 1) { label1 = config.labels.at(1); }

--- a/Source/OrientationLib/LaueOps/HexagonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.cpp
@@ -1451,8 +1451,8 @@ SIMPL::Rgb HexagonalOps::generateRodriguesColor(float r1, float r2, float r3)
 QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConfiguration_t& config)
 {
   QString label0 = QString("<0001>");
-  QString label1 = QString("<1010>");
-  QString label2 = QString("<1120>");
+  QString label1 = QString("<10-10>");
+  QString label2 = QString("<2-1-10>");
   if(config.labels.size() > 0) { label0 = config.labels.at(0); }
   if(config.labels.size() > 1) { label1 = config.labels.at(1); }
   if(config.labels.size() > 2) { label2 = config.labels.at(2); }

--- a/Source/OrientationLib/Utilities/PoleFigureUtilities.cpp
+++ b/Source/OrientationLib/Utilities/PoleFigureUtilities.cpp
@@ -206,9 +206,9 @@ void PoleFigureUtilities::GenerateHexPoleFigures(FloatArrayType* eulers, int lam
   // this is size for HEX ONLY, <0001> Family
   QVector<size_t> dims(1, 3);
   FloatArrayType::Pointer xyz0001 = FloatArrayType::CreateArray(numOrientations * 2, dims, "TEMP_<0001>_xyzCoords");
-  // this is size for HEX ONLY, <1010> Family
+  // this is size for HEX ONLY, <10-10> Family
   FloatArrayType::Pointer xyz1010 = FloatArrayType::CreateArray(numOrientations * 6, dims, "TEMP_<1010>_xyzCoords");
-  // this is size for HEX ONLY, <1120> Family
+  // this is size for HEX ONLY, <11-20> Family
   FloatArrayType::Pointer xyz1120 = FloatArrayType::CreateArray(numOrientations * 6, dims, "TEMP_<1120>_xyzCoords");
 
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/IPFLegendPainter.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/IPFLegendPainter.cpp
@@ -59,7 +59,7 @@ void IPFLegendPainter::paintSymmetryDirection(const QString& text, QFontMetrics 
 
   while(i < text.length())
   {
-    if(text.at(i) == '_')
+    if(text.at(i) == '-')
     {
       int offset = metrics->width(mod);
       i++;

--- a/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.cpp
@@ -283,6 +283,37 @@ QImage PoleFigureImageUtilities::GenerateScalarBar(int imageWidth, int imageHeig
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void PoleFigureImageUtilities::PaintSymmetryDirection(const QString& text, QFontMetrics *metrics, QPainter *painter, int x, int y)
+{
+
+  QVector<int> offsets;
+  int i = 0;
+  QString mod;
+  int fontHeight = metrics->height();
+
+  while(i < text.length())
+  {
+    if(text.at(i) == '-')
+    {
+      int offset = metrics->width(mod);
+      i++;
+      mod = mod + text.at(i);
+      int width = metrics->width(text.at(i)) * .80;
+      painter->drawRect(x + offset, y - 0.80 * fontHeight, width, 1);
+    }
+    else
+    {
+      mod = mod + text.at(i);
+    }
+    i++;
+  }
+  painter->drawText(x, y, mod);
+}
+
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 QImage PoleFigureImageUtilities::PaintPoleFigureOverlay(int imageWidth, int imageHeight, QString label, QImage image)
 {
   int pxHigh = 0;
@@ -346,8 +377,7 @@ QImage PoleFigureImageUtilities::PaintPoleFigureOverlay(int imageWidth, int imag
   }
   painter.setFont(font);
   pxHigh = metrics.height() + 2;
-  // pxWide = metrics.width(label);
-  painter.drawText(pxOffset, pxHigh, label);
+  PaintSymmetryDirection(label, &metrics, &painter, pxOffset, pxHigh);
 
   // Draw slightly transparent lines
   // penWidth = 1;

--- a/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.h
@@ -73,6 +73,16 @@ public:
 
   static QImage Create3ImagePoleFigure(UInt8ArrayType* i0, UInt8ArrayType* i1, UInt8ArrayType* i2, PoleFigureConfiguration_t& config, int32_t layout = SIMPL::Layout::Square);
 
+  /**
+   * @brief PaintSymmetryDirection
+   * @param text
+   * @param metrics
+   * @param painter
+   * @param x
+   * @param y
+   */
+  static void PaintSymmetryDirection(const QString& text, QFontMetrics *metrics, QPainter *painter, int x, int y);
+
 private:
   QVector<qint32> m_KernelWeights;
   bool m_KernelWeightsInited;


### PR DESCRIPTION
This will also make Hex-Low consistent with TSL/EDAX labeling.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>