### PR TITLE
Add second strategy for parallel implementation of SampleSurfaceMesh

### DIFF
--- a/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMesh.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMesh.cpp
@@ -35,11 +35,17 @@
 
 #include "SampleSurfaceMesh.h"
 
+#include <mutex>
+#include <thread>
+
+#include <QtCore/QDateTime>
+
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/partitioner.h>
 #include <tbb/task_scheduler_init.h>
+#include <tbb/tbb_machine.h>
 #endif
 
 #include "SIMPLib/Common/Constants.h"
@@ -51,9 +57,88 @@
 #include "SIMPLib/Geometry/VertexGeom.h"
 #include "SIMPLib/Math/GeometryMath.h"
 #include "SIMPLib/Math/SIMPLibRandom.h"
+#include "SIMPLib/Utilities/TimeUtilities.h"
 
 #include "Sampling/SamplingConstants.h"
 #include "Sampling/SamplingVersion.h"
+
+class SampleSurfaceMeshImplByPoints
+{
+  SampleSurfaceMesh* m_Filter = nullptr;
+  TriangleGeom::Pointer m_Faces;
+  Int32Int32DynamicListArray::Pointer m_FaceIds;
+  VertexGeom::Pointer m_FaceBBs;
+  VertexGeom::Pointer m_Points;
+  size_t m_FeatureId = 0;
+  int32_t* m_PolyIds = nullptr;
+
+public:
+  SampleSurfaceMeshImplByPoints(SampleSurfaceMesh* filter, TriangleGeom::Pointer faces, Int32Int32DynamicListArray::Pointer faceIds, VertexGeom::Pointer faceBBs, VertexGeom::Pointer points,
+                                size_t featureId, int32_t* polyIds)
+  : m_Filter(filter)
+  , m_Faces(faces)
+  , m_FaceIds(faceIds)
+  , m_FaceBBs(faceBBs)
+  , m_Points(points)
+  , m_FeatureId(featureId)
+  , m_PolyIds(polyIds)
+  {
+  }
+  virtual ~SampleSurfaceMeshImplByPoints() = default;
+
+  void checkPoints(size_t start, size_t end) const
+  {
+    float radius = 0.0f;
+    float distToBoundary = 0.0f;
+    int64_t numPoints = m_Points->getNumberOfVertices();
+    FloatArrayType::Pointer llPtr = FloatArrayType::CreateArray(3, "_INTERNAL_USE_ONLY_Lower");
+    FloatArrayType::Pointer urPtr = FloatArrayType::CreateArray(3, "_INTERNAL_USE_ONLY_Upper_Right");
+    float* ll = llPtr->getPointer(0);
+    float* ur = urPtr->getPointer(0);
+    float* point = nullptr;
+    char code = ' ';
+
+    size_t iter = m_FeatureId;
+
+    // find bounding box for current feature
+    GeometryMath::FindBoundingBoxOfFaces(m_Faces.get(), m_FaceIds->getElementList(iter), ll, ur);
+    GeometryMath::FindDistanceBetweenPoints(ll, ur, radius);
+    int64_t pointsVisited = 0;
+    // check points in vertex array to see if they are in the bounding box of the feature
+    for(int64_t i = start; i < end; i++)
+    {
+      // Check for the filter being cancelled.
+      if(m_Filter->getCancel())
+      {
+        return;
+      }
+
+      point = m_Points->getVertexPointer(i);
+      if(m_PolyIds[i] == 0 && GeometryMath::PointInBox(point, ll, ur) == true)
+      {
+        code = GeometryMath::PointInPolyhedron(m_Faces.get(), m_FaceIds->getElementList(iter), m_FaceBBs.get(), point, ll, ur, radius, distToBoundary);
+        if(code == 'i' || code == 'V' || code == 'E' || code == 'F')
+        {
+          m_PolyIds[i] = iter;
+        }
+      }
+      pointsVisited++;
+
+      if(pointsVisited % 1000 == 0)
+      {
+        m_Filter->sendThreadSafeProgressMessage(m_FeatureId, 1000, numPoints);
+      }
+    }
+  }
+
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+  void operator()(const tbb::blocked_range<size_t>& r) const
+  {
+    checkPoints(r.begin(), r.end());
+  }
+#endif
+private:
+};
 
 /**
  * @brief The SampleSurfaceMeshImpl class implements a threaded algorithm that samples a surface mesh based on points passed from subclassed Filters.
@@ -77,9 +162,7 @@ public:
   , m_PolyIds(polyIds)
   {
   }
-  virtual ~SampleSurfaceMeshImpl()
-  {
-  }
+  virtual ~SampleSurfaceMeshImpl() = default;
 
   void checkPoints(size_t start, size_t end) const
   {
@@ -95,7 +178,6 @@ public:
 
     for(size_t iter = start; iter < end; iter++)
     {
-
       // find bounding box for current feature
       GeometryMath::FindBoundingBoxOfFaces(m_Faces.get(), m_FaceIds->getElementList(iter), ll, ur);
       GeometryMath::FindDistanceBetweenPoints(ll, ur, radius);
@@ -254,11 +336,6 @@ void SampleSurfaceMesh::execute()
   DataContainer::Pointer sm = getDataContainerArray()->getDataContainer(m_SurfaceMeshFaceLabelsArrayPath.getDataContainerName());
   SIMPL_RANDOMNG_NEW()
 
-#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
-  tbb::task_scheduler_init init;
-  bool doParallel = true;
-#endif
-
   TriangleGeom::Pointer triangleGeom = sm->getGeometryAs<TriangleGeom>();
 
   // pull down faces
@@ -380,20 +457,73 @@ void SampleSurfaceMesh::execute()
   notifyStatusMessage(getMessagePrefix(), getHumanLabel(), "Sampling triangle geometry ...");
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
-  if(doParallel == true)
+  tbb::task_scheduler_init init;
+  bool doParallel = true;
+#endif
+
+  // C++11 RIGHT HERE....
+  unsigned int nthreads = std::thread::hardware_concurrency();
+  // If the number of featurs is larger than the number of cores to do the work then parallelize over the number of features
+  // otherwise parallelize over the number of triangle points.
+  if(numFeatures > nthreads)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, numFeatures), SampleSurfaceMeshImpl(this, triangleGeom, faceLists, faceBBs, points, polyIds), tbb::auto_partitioner());
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+    if(doParallel == true)
+    {
+      tbb::parallel_for(tbb::blocked_range<size_t>(0, numFeatures), SampleSurfaceMeshImpl(this, triangleGeom, faceLists, faceBBs, points, polyIds), tbb::auto_partitioner());
+    }
+    else
+#endif
+    {
+      SampleSurfaceMeshImpl serial(this, triangleGeom, faceLists, faceBBs, points, polyIds);
+      serial.checkPoints(0, numFeatures);
+    }
   }
   else
-#endif
   {
-    SampleSurfaceMeshImpl serial(this, triangleGeom, faceLists, faceBBs, points, polyIds);
-    serial.checkPoints(0, numFeatures);
+    for(int featureId = 0; featureId < numFeatures; featureId++)
+    {
+      m_NumCompleted = 0;
+      m_StartMillis = QDateTime::currentMSecsSinceEpoch();
+      m_Millis = m_StartMillis;
+      size_t numPoints = points->getNumberOfVertices();
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+      if(doParallel == true)
+      {
+        tbb::parallel_for(tbb::blocked_range<size_t>(0, numPoints), SampleSurfaceMeshImplByPoints(this, triangleGeom, faceLists, faceBBs, points, featureId, polyIds), tbb::auto_partitioner());
+      }
+      else
+#endif
+      {
+        SampleSurfaceMeshImplByPoints serial(this, triangleGeom, faceLists, faceBBs, points, featureId, polyIds);
+        serial.checkPoints(0, numPoints);
+      }
+    }
   }
-
   assign_points(iArray);
 
   notifyStatusMessage(getMessagePrefix(), getHumanLabel(), "Complete");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SampleSurfaceMesh::sendThreadSafeProgressMessage(int featureId, size_t numCompleted, size_t totalFeatures)
+{
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+  qint64 currentMillis = QDateTime::currentMSecsSinceEpoch();
+  m_NumCompleted = m_NumCompleted + numCompleted;
+  if(currentMillis - m_Millis > 1000)
+  {
+    float inverseRate = static_cast<float>(currentMillis - m_Millis) / static_cast<float>(m_NumCompleted - m_LastCompletedPoints);
+    qint64 remainMillis = inverseRate * (totalFeatures - m_NumCompleted);
+    QString ss = QObject::tr("Feature %3 | Points Completed: %1 of %2").arg(m_NumCompleted).arg(totalFeatures).arg(featureId);
+    ss = ss + QObject::tr(" || Est. Time Remain: %1").arg(DREAM3D::convertMillisToHrsMinSecs(remainMillis));
+    notifyStatusMessage(getMessagePrefix(), getHumanLabel(), ss);
+    m_Millis = QDateTime::currentMSecsSinceEpoch();
+    m_LastCompletedPoints = m_NumCompleted;
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMesh.h
+++ b/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMesh.h
@@ -125,6 +125,13 @@ public:
   */
   void preflight() override;
 
+  /**
+   * @brief sendThreadSafeProgressMessage
+   * @param counter
+   * @param max
+   */
+  void sendThreadSafeProgressMessage(int featureId, size_t numCompleted, size_t totalFeatures);
+
 signals:
   /**
    * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
@@ -175,6 +182,10 @@ protected:
 
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, SurfaceMeshFaceLabels)
+  size_t m_NumCompleted = 0;
+  qint64 m_StartMillis = 0;
+  qint64 m_Millis = 0;
+  int64_t m_LastCompletedPoints = 0;
 
 public:
   SampleSurfaceMesh(const SampleSurfaceMesh&) = delete; // Copy Constructor Not Implemented

--- a/Support/PrebuiltPipelines/Examples/ASTMD638_specimen.json
+++ b/Support/PrebuiltPipelines/Examples/ASTMD638_specimen.json
@@ -1,0 +1,498 @@
+{
+    "00": {
+        "FaceAttributeMatrixName": "FaceData",
+        "FaceNormalsArrayName": "FaceNormals",
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Import STL File",
+        "Filter_Name": "ReadStlFile",
+        "Filter_Uuid": "{980c7bfd-20b2-5711-bc3b-0190b9096c34}",
+        "StlFilePath": "Data/Models/ASTMD638_specimen.stl",
+        "SurfaceMeshDataContainerName": "ASTMD638_SurfaceMesh"
+    },
+    "01": {
+        "FilterVersion": "1.2.707",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Create Data Array",
+        "Filter_Name": "CreateDataArray",
+        "Filter_Uuid": "{77f392fb-c1eb-57da-a1b1-e7acf9239fb8}",
+        "InitializationRange": {
+            "Max": 0,
+            "Min": 0
+        },
+        "InitializationType": 0,
+        "InitializationValue": "0",
+        "NewArray": {
+            "Attribute Matrix Name": "FaceData",
+            "Data Array Name": "Array_0",
+            "Data Container Name": "ASTMD638_SurfaceMesh"
+        },
+        "NumberOfComponents": 1,
+        "ScalarType": 4
+    },
+    "02": {
+        "FilterVersion": "1.2.707",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Create Data Array",
+        "Filter_Name": "CreateDataArray",
+        "Filter_Uuid": "{77f392fb-c1eb-57da-a1b1-e7acf9239fb8}",
+        "InitializationRange": {
+            "Max": 0,
+            "Min": 0
+        },
+        "InitializationType": 0,
+        "InitializationValue": "1",
+        "NewArray": {
+            "Attribute Matrix Name": "FaceData",
+            "Data Array Name": "Array_1",
+            "Data Container Name": "ASTMD638_SurfaceMesh"
+        },
+        "NumberOfComponents": 1,
+        "ScalarType": 4
+    },
+    "03": {
+        "FilterVersion": "1.2.707",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Combine Attribute Arrays",
+        "Filter_Name": "CombineAttributeArrays",
+        "Filter_Uuid": "{a6b50fb0-eb7c-5d9b-9691-825d6a4fe772}",
+        "MoveValues": 1,
+        "NormalizeData": 0,
+        "SelectedDataArrayPaths": [
+            {
+                "Attribute Matrix Name": "FaceData",
+                "Data Array Name": "Array_0",
+                "Data Container Name": "ASTMD638_SurfaceMesh"
+            },
+            {
+                "Attribute Matrix Name": "FaceData",
+                "Data Array Name": "Array_1",
+                "Data Container Name": "ASTMD638_SurfaceMesh"
+            }
+        ],
+        "StackedDataArrayName": "FaceLabels"
+    },
+    "04": {
+        "CellAttributeMatrixName": "CellData",
+        "DataContainerName": "ASTMD638_ImageGeom",
+        "FeatureIdsArrayName": "FeatureIds",
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Sample Triangle Geometry on Regular Grid",
+        "Filter_Name": "RegularGridSampleSurfaceMesh",
+        "Filter_Uuid": "{0df3da89-9106-538e-b1a9-6bbf1cf0aa92}",
+        "Origin": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "Resolution": {
+            "x": 0.10000000149011612,
+            "y": 0.10000000149011612,
+            "z": 0.10000000149011612
+        },
+        "SurfaceMeshFaceLabelsArrayPath": {
+            "Attribute Matrix Name": "FaceData",
+            "Data Array Name": "FaceLabels",
+            "Data Container Name": "ASTMD638_SurfaceMesh"
+        },
+        "XPoints": 1800,
+        "YPoints": 190,
+        "ZPoints": 32
+    },
+    "05": {
+        "DestinationArrayName": "Mask",
+        "FilterVersion": "1.2.707",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Threshold Objects 2",
+        "Filter_Name": "MultiThresholdObjects2",
+        "Filter_Uuid": "{686d5393-2b02-5c86-b887-dd81a8ae80f2}",
+        "SelectedThresholds": {
+            "Attribute Matrix Name": "CellData",
+            "Data Container Name": "ASTMD638_ImageGeom",
+            "Thresholds": [
+                {
+                    "Attribute Array Name": "FeatureIds",
+                    "Comparison Operator": 2,
+                    "Comparison Value": 1,
+                    "Union Operator": 0
+                }
+            ]
+        }
+    },
+    "06": {
+        "CellEnsembleAttributeMatrixName": "CellEnsembleData",
+        "CrystalStructuresArrayName": "CrystalStructures",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "StatsGenerator",
+        "Filter_Name": "StatsGeneratorFilter",
+        "Filter_Uuid": "{f642e217-4722-5dd8-9df9-cee71e7b26ba}",
+        "PhaseNamesArrayName": "PhaseName",
+        "PhaseTypesArrayName": "PhaseTypes",
+        "StatsDataArray": {
+            "1": {
+                "AxisODF-Weights": {
+                },
+                "Bin Count": 7,
+                "BinNumber": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "BoundaryArea": 2.33596454002947e-42,
+                "Crystal Symmetry": 1,
+                "FeatureSize Distribution": {
+                    "Average": 1,
+                    "Standard Deviation": 0.20000000298023224
+                },
+                "FeatureSize Vs B Over A Distributions": {
+                    "Alpha": [
+                        15.978363990783691,
+                        15.190934181213379,
+                        15.321611404418945,
+                        15.289162635803223,
+                        15.240915298461914,
+                        15.821465492248535,
+                        15.077518463134766
+                    ],
+                    "Beta": [
+                        1.3108303546905518,
+                        1.5985941886901855,
+                        1.3759998083114624,
+                        1.4414080381393433,
+                        1.357185959815979,
+                        1.6214041709899902,
+                        1.274958610534668
+                    ],
+                    "Distribution Type": "Beta Distribution"
+                },
+                "FeatureSize Vs C Over A Distributions": {
+                    "Alpha": [
+                        15.773932456970215,
+                        15.394630432128906,
+                        15.344663619995117,
+                        15.9539155960083,
+                        15.708008766174316,
+                        15.691307067871094,
+                        15.618109703063965
+                    ],
+                    "Beta": [
+                        1.578046202659607,
+                        1.3954976797103882,
+                        1.4536755084991455,
+                        1.340291976928711,
+                        1.3328419923782349,
+                        1.3954721689224243,
+                        1.3157879114151
+                    ],
+                    "Distribution Type": "Beta Distribution"
+                },
+                "FeatureSize Vs Neighbors Distributions": {
+                    "Average": [
+                        2.079441547393799,
+                        2.3025851249694824,
+                        2.4849066734313965,
+                        2.6390573978424072,
+                        2.7725887298583984,
+                        2.890371799468994,
+                        2.995732307434082
+                    ],
+                    "Distribution Type": "Log Normal Distribution",
+                    "Standard Deviation": [
+                        0.4000000059604645,
+                        0.36666667461395264,
+                        0.3333333432674408,
+                        0.30000001192092896,
+                        0.2666666507720947,
+                        0.23333333432674408,
+                        0.20000000298023224
+                    ]
+                },
+                "FeatureSize Vs Omega3 Distributions": {
+                    "Alpha": [
+                        10.873414993286133,
+                        10.98062801361084,
+                        10.185344696044922,
+                        10.596653938293457,
+                        10.646502494812012,
+                        10.95963191986084,
+                        10.54850959777832
+                    ],
+                    "Beta": [
+                        1.9961856603622437,
+                        1.695103406906128,
+                        1.6361192464828491,
+                        1.739335298538208,
+                        1.6186805963516235,
+                        1.6911628246307373,
+                        1.9604464769363403
+                    ],
+                    "Distribution Type": "Beta Distribution"
+                },
+                "Feature_Diameter_Info": [
+                    1,
+                    7.389056205749512,
+                    1
+                ],
+                "MDF-Weights": {
+                },
+                "Name": "Primary",
+                "ODF-Weights": {
+                },
+                "PhaseFraction": 1,
+                "PhaseType": "Primary"
+            },
+            "Name": "Statistics",
+            "Phase Count": 2
+        },
+        "StatsDataArrayName": "Statistics",
+        "StatsGeneratorDataContainerName": "StatsGeneratorDataContainer"
+    },
+    "07": {
+        "BoxDimensions": "X Range: 0 to 180 (Delta: 180)\nY Range: 0 to 19 (Delta: 19)\nZ Range: 0 to 3.2 (Delta: 3.2)",
+        "CellAttributeMatrixName": "CellData",
+        "DataContainerName": "ASTMD638_Synthetic",
+        "Dimensions": {
+            "x": 1800,
+            "y": 190,
+            "z": 32
+        },
+        "EnsembleAttributeMatrixName": "CellEnsembleData",
+        "EstimateNumberOfFeatures": 1,
+        "EstimatedPrimaryFeatures": "883",
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Initialize Synthetic Volume",
+        "Filter_Name": "InitializeSyntheticVolume",
+        "Filter_Uuid": "{c2ae366b-251f-5dbd-9d70-d790376c0c0d}",
+        "InputPhaseTypesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "PhaseTypes",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "InputStatsArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "Statistics",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "Origin": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "Resolution": {
+            "x": 0.10000000149011612,
+            "y": 0.10000000149011612,
+            "z": 0.10000000149011612
+        }
+    },
+    "08": {
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Establish Shape Types",
+        "Filter_Name": "EstablishShapeTypes",
+        "Filter_Uuid": "{4edbbd35-a96b-5ff1-984a-153d733e2abb}",
+        "InputPhaseTypesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "PhaseTypes",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "ShapeTypeData": [
+            999,
+            0
+        ],
+        "ShapeTypesArrayName": "ShapeTypes"
+    },
+    "09": {
+        "CellPhasesArrayName": "Phases",
+        "FeatureGeneration": 0,
+        "FeatureIdsArrayName": "FeatureIds",
+        "FeatureInputFile": "/Users/mjackson",
+        "FeaturePhasesArrayName": "Phases",
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Pack Primary Phases",
+        "Filter_Name": "PackPrimaryPhases",
+        "Filter_Uuid": "{84305312-0d10-50ca-b89a-fda17a353cc9}",
+        "InputPhaseNamesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "PhaseName",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "InputPhaseTypesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "PhaseTypes",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "InputShapeTypesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "ShapeTypes",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "InputStatsArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "Statistics",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "MaskArrayPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "Mask",
+            "Data Container Name": "ASTMD638_ImageGeom"
+        },
+        "NewAttributeMatrixPath": {
+            "Attribute Matrix Name": "Synthetic Shape Parameters (Primary Phase)",
+            "Data Array Name": "",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "NumFeaturesArrayName": "NumFeatures",
+        "OutputCellAttributeMatrixPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "OutputCellEnsembleAttributeMatrixName": "CellEnsembleData",
+        "OutputCellFeatureAttributeMatrixName": "Grain Data",
+        "PeriodicBoundaries": 0,
+        "SaveGeometricDescriptions": 0,
+        "SelectedAttributeMatrixPath": {
+            "Attribute Matrix Name": "",
+            "Data Array Name": "",
+            "Data Container Name": ""
+        },
+        "UseMask": 1
+    },
+    "10": {
+        "BoundaryCellsArrayName": "BoundaryCells",
+        "CellFeatureAttributeMatrixPath": {
+            "Attribute Matrix Name": "Grain Data",
+            "Data Array Name": "",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "FeatureIdsArrayPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "FeatureIds",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Find Feature Neighbors",
+        "Filter_Name": "FindNeighbors",
+        "Filter_Uuid": "{97cf66f8-7a9b-5ec2-83eb-f8c4c8a17bac}",
+        "NeighborListArrayName": "NeighborList",
+        "NumNeighborsArrayName": "NumNeighbors",
+        "SharedSurfaceAreaListArrayName": "SharedSurfaceAreaList",
+        "StoreBoundaryCells": 0,
+        "StoreSurfaceFeatures": 1,
+        "SurfaceFeaturesArrayName": "SurfaceFeatures"
+    },
+    "11": {
+        "AvgQuatsArrayName": "AvgQuats",
+        "CellEulerAnglesArrayName": "EulerAngles",
+        "CrystalStructuresArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "CrystalStructures",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "FeatureEulerAnglesArrayName": "EulerAngles",
+        "FeatureIdsArrayPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "FeatureIds",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "FeaturePhasesArrayPath": {
+            "Attribute Matrix Name": "Grain Data",
+            "Data Array Name": "Phases",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Match Crystallography",
+        "Filter_Name": "MatchCrystallography",
+        "Filter_Uuid": "{7bfb6e4a-6075-56da-8006-b262d99dff30}",
+        "InputStatsArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "Statistics",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "MaxIterations": 100000,
+        "NeighborListArrayPath": {
+            "Attribute Matrix Name": "Grain Data",
+            "Data Array Name": "NeighborList",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "NumFeaturesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "NumFeatures",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "PhaseTypesArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "PhaseTypes",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "SharedSurfaceAreaListArrayPath": {
+            "Attribute Matrix Name": "Grain Data",
+            "Data Array Name": "SharedSurfaceAreaList",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "SurfaceFeaturesArrayPath": {
+            "Attribute Matrix Name": "Grain Data",
+            "Data Array Name": "SurfaceFeatures",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "VolumesArrayName": "Volumes"
+    },
+    "12": {
+        "CellEulerAnglesArrayPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "EulerAngles",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "CellIPFColorsArrayName": "IPFColor",
+        "CellPhasesArrayPath": {
+            "Attribute Matrix Name": "CellData",
+            "Data Array Name": "Phases",
+            "Data Container Name": "ASTMD638_Synthetic"
+        },
+        "CrystalStructuresArrayPath": {
+            "Attribute Matrix Name": "CellEnsembleData",
+            "Data Array Name": "CrystalStructures",
+            "Data Container Name": "StatsGeneratorDataContainer"
+        },
+        "FilterVersion": "6.5.64",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Generate IPF Colors",
+        "Filter_Name": "GenerateIPFColors",
+        "Filter_Uuid": "{a50e6532-8075-5de5-ab63-945feb0de7f7}",
+        "GoodVoxelsArrayPath": {
+            "Attribute Matrix Name": "\t",
+            "Data Array Name": "\t",
+            "Data Container Name": "\t"
+        },
+        "ReferenceDir": {
+            "x": 0,
+            "y": 0,
+            "z": 1
+        },
+        "UseGoodVoxels": 0
+    },
+    "13": {
+        "FilterVersion": "1.2.707",
+        "Filter_Enabled": true,
+        "Filter_Human_Label": "Write DREAM.3D Data File",
+        "Filter_Name": "DataContainerWriter",
+        "Filter_Uuid": "{3fcd4c43-9d75-5b86-aad4-4441bc914f37}",
+        "OutputFile": "Data/Output/Synthetic/ASTMD638_specimen.dream3d",
+        "WriteTimeSeries": 0,
+        "WriteXdmfFile": 1
+    },
+    "PipelineBuilder": {
+        "Name": "ASTMD638_specimen",
+        "Number_Filters": 14,
+        "Version": 6
+    }
+}


### PR DESCRIPTION
This new strategy kicks in when the number of features is less then the number
of cores on the hardware. The alternate strategy parallelizes over the number
of triangle points.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>