### PR TITLE
Update all classes to properly implement constructors and assignment operators

### DIFF
--- a/Source/EbsdLib/AbstractEbsdFields.h
+++ b/Source/EbsdLib/AbstractEbsdFields.h
@@ -58,7 +58,11 @@ class EbsdLib_EXPORT AbstractEbsdFields
 
     virtual QVector<QString> getFieldNames() = 0;
 
-
+  public:
+    AbstractEbsdFields(const AbstractEbsdFields&) = delete;            // Copy Constructor Not Implemented
+    AbstractEbsdFields(AbstractEbsdFields&&) = delete;                 // Move Constructor Not Implemented
+    AbstractEbsdFields& operator=(const AbstractEbsdFields&) = delete; // Copy Assignment Not Implemented
+    AbstractEbsdFields& operator=(AbstractEbsdFields&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/EbsdHeaderEntry.h
+++ b/Source/EbsdLib/EbsdHeaderEntry.h
@@ -109,9 +109,11 @@
       EbsdHeaderEntry() {}
 
 
-    private:
+    public:
       EbsdHeaderEntry(const EbsdHeaderEntry&) = delete; // Copy Constructor Not Implemented
-      void operator=(const EbsdHeaderEntry&) = delete;  // Move assignment Not Implemented
+      EbsdHeaderEntry(EbsdHeaderEntry&&) = delete;      // Move Constructor Not Implemented
+      EbsdHeaderEntry& operator=(const EbsdHeaderEntry&) = delete; // Copy Assignment Not Implemented
+      EbsdHeaderEntry& operator=(EbsdHeaderEntry&&) = delete;      // Move Assignment Not Implemented
   };
 
 

--- a/Source/EbsdLib/EbsdImporter.h
+++ b/Source/EbsdLib/EbsdImporter.h
@@ -140,9 +140,11 @@ class EbsdLib_EXPORT EbsdImporter
       m_PipelineMessage = "";
     }
 
-  private:
+  public:
     EbsdImporter(const EbsdImporter&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const EbsdImporter&) = delete; // Move assignment Not Implemented
+    EbsdImporter(EbsdImporter&&) = delete;        // Move Constructor Not Implemented
+    EbsdImporter& operator=(const EbsdImporter&) = delete; // Copy Assignment Not Implemented
+    EbsdImporter& operator=(EbsdImporter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/EbsdReader.h
+++ b/Source/EbsdLib/EbsdReader.h
@@ -206,9 +206,11 @@ class EbsdLib_EXPORT EbsdReader
     QMap<QString, EbsdHeaderEntry::Pointer> m_HeaderMap;
 
 
-  private:
+  public:
     EbsdReader(const EbsdReader&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const EbsdReader&) = delete; // Move assignment Not Implemented
+    EbsdReader(EbsdReader&&) = delete;          // Move Constructor Not Implemented
+    EbsdReader& operator=(const EbsdReader&) = delete; // Copy Assignment Not Implemented
+    EbsdReader& operator=(EbsdReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/EbsdSetGetMacros.h
+++ b/Source/EbsdLib/EbsdSetGetMacros.h
@@ -32,16 +32,9 @@
 *    United States Prime Contract Navy N00173-07-C-2068
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-
-
-
-
 #pragma once
 
-#include <string.h>
-
-#include <QtCore/QString>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -124,29 +117,29 @@
 /**
  * @brief Creates a static "New" method that creates an instance of thisClass
  */
-#define EBSD_NEW_SUPERCLASS(thisClass, SuperClass)\
-  typedef SuperClass::Pointer SuperClass##Type;\
-  static SuperClass##Type New##SuperClass(void) \
-  { \
-    SuperClass##Type sharedPtr (new thisClass); \
-    return sharedPtr; \
+#define EBSD_NEW_SUPERCLASS(thisClass, SuperClass)                                                                                                                                                     \
+  typedef SuperClass::Pointer SuperClass##Type;                                                                                                                                                        \
+  static SuperClass##Type New##SuperClass(void)                                                                                                                                                        \
+  {                                                                                                                                                                                                    \
+    SuperClass##Type sharedPtr(new(thisClass));                                                                                                                                                        \
+    return sharedPtr;                                                                                                                                                                                  \
   }
 
 /**
  * @brief Implements a Static 'New' Method for a class
  */
-#define EBSD_STATIC_NEW_MACRO(thisClass) \
-  static Pointer New(void) \
-  { \
-    Pointer sharedPtr (new thisClass); \
-    return sharedPtr; \
+#define EBSD_STATIC_NEW_MACRO(thisClass)                                                                                                                                                               \
+  static Pointer New(void)                                                                                                                                                                             \
+  {                                                                                                                                                                                                    \
+    Pointer sharedPtr(new(thisClass));                                                                                                                                                                 \
+    return sharedPtr;                                                                                                                                                                                  \
   }
 
-#define EBSD_STATIC_NEW_MACRO_WITH_ARGS(thisClass, args) \
-  static Pointer New args \
-  { \
-    Pointer sharedPtr (new thisClass); \
-    return sharedPtr; \
+#define EBSD_STATIC_NEW_MACRO_WITH_ARGS(thisClass, args)                                                                                                                                               \
+  static Pointer New args                                                                                                                                                                              \
+  {                                                                                                                                                                                                    \
+    Pointer sharedPtr(new(thisClass));                                                                                                                                                                 \
+    return sharedPtr;                                                                                                                                                                                  \
   }
 
 /** Macro used to add standard methods to all classes, mainly type
@@ -211,8 +204,11 @@
 /**
 * @brief Creates a "setter" method to set the property.
 */
-#define EBSD_SET_PROPERTY(m_msgType, prpty) \
-  void set##prpty(m_msgType value) { this->m_##prpty = value; }
+#define EBSD_SET_PROPERTY(m_msgType, prpty)                                                                                                                                                            \
+  void set##prpty(const m_msgType& value)                                                                                                                                                              \
+  {                                                                                                                                                                                                    \
+    this->m_##prpty = value;                                                                                                                                                                           \
+  }
 
 /**
 * @brief Creates a "getter" method to retrieve the value of the property.
@@ -237,7 +233,31 @@
   EBSD_SET_PROPERTY(m_msgType, prpty)\
   EBSD_GET_PROPERTY(m_msgType, prpty)
 
+/**
+ * @brief Creates a "setter" method to set the property.
+ */
+#define EBSD_SET_PTR_PROPERTY(m_msgType, prpty)                                                                                                                                                        \
+  void set##prpty(m_msgType value)                                                                                                                                                                     \
+  {                                                                                                                                                                                                    \
+    this->m_##prpty = value;                                                                                                                                                                           \
+  }
 
+/**
+ * @brief Creates a "getter" method to retrieve the value of the property.
+ */
+#define EBSD_GET_PTR_PROPERTY(m_msgType, prpty)                                                                                                                                                        \
+  m_msgType get##prpty()                                                                                                                                                                               \
+  {                                                                                                                                                                                                    \
+    return m_##prpty;                                                                                                                                                                                  \
+  }
+
+#define EBSD_PTR_INSTANCE_PROPERTY(m_msgType, prpty)                                                                                                                                                   \
+private:                                                                                                                                                                                               \
+  m_msgType m_##prpty;                                                                                                                                                                                 \
+                                                                                                                                                                                                       \
+public:                                                                                                                                                                                                \
+  EBSD_SET_PTR_PROPERTY(m_msgType, prpty)                                                                                                                                                              \
+  EBSD_GET_PTR_PROPERTY(m_msgType, prpty)
 
 #define EBSD_SET_2DVECTOR_PROPERTY(m_msgType, prpty, varname)\
   void set##prpty(m_msgType value[2]) {\
@@ -296,23 +316,36 @@
 /**
  * @brief Creates a "setter" method to set the property.
  */
-#define EbsdHeader_SET_PROPERTY( HeaderType, m_msgType, prpty, key) \
-  void set##prpty(m_msgType value) { \
-    HeaderType* p = dynamic_cast<HeaderType*>(m_HeaderMap[key].get()); \
-    if (nullptr != p) { p->setValue(value); } else {\
-      std::cout << "Value for Key: " << key.toStdString() << " was null." << std::endl;} }
+#define EbsdHeader_SET_PROPERTY(HeaderType, m_msgType, prpty, key)                                                                                                                                     \
+  void set##prpty(const m_msgType& value)                                                                                                                                                              \
+  {                                                                                                                                                                                                    \
+    auto p = dynamic_cast<HeaderType*>(m_HeaderMap[key].get());                                                                                                                                        \
+    if(nullptr != p)                                                                                                                                                                                   \
+    {                                                                                                                                                                                                  \
+      p->setValue(value);                                                                                                                                                                              \
+    }                                                                                                                                                                                                  \
+    else                                                                                                                                                                                               \
+    {                                                                                                                                                                                                  \
+      std::cout << "Value for Key: " << key.toStdString() << " was null." << std::endl;                                                                                                                \
+    }                                                                                                                                                                                                  \
+  }
 
 /**
  * @brief Creates a "getter" method to retrieve the value of the property.
  */
-#define EbsdHeader_GET_PROPERTY(HeaderType, m_msgType, prpty, key) \
-  m_msgType get##prpty() { \
-    HeaderType* p = dynamic_cast<HeaderType*>(m_HeaderMap[key].get());\
-    if (nullptr != p) { return p->getValue(); } else {\
-      std::cout << "Value for Key: " << key.toStdString() << " was null." << std::endl; return 0;} }
+#define EbsdHeader_GET_PROPERTY(HeaderType, m_msgType, prpty, key)                                                                                                                                     \
+  m_msgType get##prpty()                                                                                                                                                                               \
+  {                                                                                                                                                                                                    \
+    auto p = dynamic_cast<HeaderType*>(m_HeaderMap[key].get());                                                                                                                                        \
+    if(nullptr != p)                                                                                                                                                                                   \
+    {                                                                                                                                                                                                  \
+      return p->getValue();                                                                                                                                                                            \
+    }                                                                                                                                                                                                  \
+    std::cout << "Value for Key: " << key.toStdString() << " was null." << std::endl;                                                                                                                  \
+    return 0;                                                                                                                                                                                          \
+  }
 
-
-#define EbsdHeader_INSTANCE_PROPERTY(HeaderType, m_msgType, prpty, key)\
+#define EBSDHEADER_INSTANCE_PROPERTY(HeaderType, m_msgType, prpty, key)\
   public:\
   EbsdHeader_SET_PROPERTY(HeaderType, m_msgType, prpty, key)\
   EbsdHeader_GET_PROPERTY(HeaderType, m_msgType, prpty, key)

--- a/Source/EbsdLib/EbsdTransform.h
+++ b/Source/EbsdLib/EbsdTransform.h
@@ -77,13 +77,11 @@ class EbsdLib_EXPORT EbsdTransform
     static Ebsd::EbsdToSampleCoordinateMapping IdentifyStandardTransformation(AxisAngleInput_t sampleTransformation, AxisAngleInput_t eulerTransformation);
 
 
-  protected:
-
-
-
-  private:
+  public:
     EbsdTransform(const EbsdTransform&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const EbsdTransform&) = delete; // Move assignment Not Implemented
+    EbsdTransform(EbsdTransform&&) = delete;       // Move Constructor Not Implemented
+    EbsdTransform& operator=(const EbsdTransform&) = delete; // Copy Assignment Not Implemented
+    EbsdTransform& operator=(EbsdTransform&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/H5EbsdVolumeInfo.h
+++ b/Source/EbsdLib/H5EbsdVolumeInfo.h
@@ -205,9 +205,11 @@ class  EbsdLib_EXPORT H5EbsdVolumeInfo
 
     QString m_Manufacturer;
 
-    H5EbsdVolumeInfo(const H5EbsdVolumeInfo&); //Not Implemented
-    void operator=(const H5EbsdVolumeInfo&); //Not Implemented
-
+  public:
+    H5EbsdVolumeInfo(const H5EbsdVolumeInfo&) = delete;            // Copy Constructor Not Implemented
+    H5EbsdVolumeInfo(H5EbsdVolumeInfo&&) = delete;                 // Move Constructor Not Implemented
+    H5EbsdVolumeInfo& operator=(const H5EbsdVolumeInfo&) = delete; // Copy Assignment Not Implemented
+    H5EbsdVolumeInfo& operator=(H5EbsdVolumeInfo&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/H5EbsdVolumeReader.h
+++ b/Source/EbsdLib/H5EbsdVolumeReader.h
@@ -149,8 +149,11 @@ class EbsdLib_EXPORT H5EbsdVolumeReader : public H5EbsdVolumeInfo
     QSet<QString>         m_ArrayNames;
     bool                  m_ReadAllArrays;
 
+  public:
     H5EbsdVolumeReader(const H5EbsdVolumeReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5EbsdVolumeReader&) = delete;     // Move assignment Not Implemented
+    H5EbsdVolumeReader(H5EbsdVolumeReader&&) = delete;      // Move Constructor Not Implemented
+    H5EbsdVolumeReader& operator=(const H5EbsdVolumeReader&) = delete; // Copy Assignment Not Implemented
+    H5EbsdVolumeReader& operator=(H5EbsdVolumeReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/HKL/CtfFields.h
+++ b/Source/EbsdLib/HKL/CtfFields.h
@@ -78,9 +78,11 @@ class EbsdLib_EXPORT CtfFields : public AbstractEbsdFields
       return features;
     }
 
-  private:
+  public:
     CtfFields(const CtfFields&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const CtfFields&) = delete; // Move assignment Not Implemented
+    CtfFields(CtfFields&&) = delete;           // Move Constructor Not Implemented
+    CtfFields& operator=(const CtfFields&) = delete; // Copy Assignment Not Implemented
+    CtfFields& operator=(CtfFields&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/HKL/CtfHeaderEntry.h
+++ b/Source/EbsdLib/HKL/CtfHeaderEntry.h
@@ -105,8 +105,11 @@ class EbsdLib_EXPORT CtfHeaderEntry : public EbsdHeaderEntry
     T m_value;
     QString m_key;
 
+  public:
     CtfHeaderEntry(const CtfHeaderEntry&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CtfHeaderEntry&) = delete; // Move assignment Not Implemented
+    CtfHeaderEntry(CtfHeaderEntry&&) = delete;      // Move Constructor Not Implemented
+    CtfHeaderEntry& operator=(const CtfHeaderEntry&) = delete; // Copy Assignment Not Implemented
+    CtfHeaderEntry& operator=(CtfHeaderEntry&&) = delete;      // Move Assignment Not Implemented
 };
 
 /**

--- a/Source/EbsdLib/HKL/CtfPhase.h
+++ b/Source/EbsdLib/HKL/CtfPhase.h
@@ -95,8 +95,10 @@ class EbsdLib_EXPORT CtfPhase
 
     void convertEuropeanDecimals(QByteArray& line);
 
-  private:
+  public:
     CtfPhase(const CtfPhase&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const CtfPhase&) = delete; // Move assignment Not Implemented
+    CtfPhase(CtfPhase&&) = delete;            // Move Constructor Not Implemented
+    CtfPhase& operator=(const CtfPhase&) = delete; // Copy Assignment Not Implemented
+    CtfPhase& operator=(CtfPhase&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/EbsdLib/HKL/CtfReader.h
+++ b/Source/EbsdLib/HKL/CtfReader.h
@@ -1,221 +1,250 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
-#include <QtCore/QString>
-#include <QtCore/QMap>
-#include <QtCore/QVector>
 #include <QtCore/QFile>
+#include <QtCore/QMap>
+#include <QtCore/QString>
+#include <QtCore/QVector>
 #include <QtCore/QtDebug>
 
-#include "EbsdLib/EbsdLib.h"
-#include "EbsdLib/EbsdSetGetMacros.h"
-#include "EbsdLib/EbsdConstants.h"
-#include "EbsdLib/EbsdReader.h"
 #include "CtfConstants.h"
 #include "CtfHeaderEntry.h"
 #include "CtfPhase.h"
 #include "DataParser.hpp"
-
+#include "EbsdLib/EbsdConstants.h"
+#include "EbsdLib/EbsdLib.h"
+#include "EbsdLib/EbsdReader.h"
+#include "EbsdLib/EbsdSetGetMacros.h"
 
 /**
-* @class CtfReader CtfReader.h EbsdLib/HKL/CtfReader.h
-* @brief This class is a self contained HKL .ctf file reader and will read a
-* single .ctf file and store all the data in column centric pointers.
-* @author Michael A. Jackson for BlueQuartz Software
-* @date Aug 1, 2011
-* @version 1.0
-*/
+ * @class CtfReader CtfReader.h EbsdLib/HKL/CtfReader.h
+ * @brief This class is a self contained HKL .ctf file reader and will read a
+ * single .ctf file and store all the data in column centric pointers.
+ * @author Michael A. Jackson for BlueQuartz Software
+ * @date Aug 1, 2011
+ * @version 1.0
+ */
 class EbsdLib_EXPORT CtfReader : public EbsdReader
 {
-  public:
-    CtfReader();
-    virtual ~CtfReader();
+public:
+  CtfReader();
+  ~CtfReader() override;
 
-    EBSD_TYPE_MACRO_SUPER(CtfReader, EbsdReader)
+  EBSD_TYPE_MACRO_SUPER(CtfReader, EbsdReader)
 
-    EbsdHeader_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Channel, Ebsd::Ctf::ChannelTextFile)
-    EbsdHeader_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Prj, Ebsd::Ctf::Prj)
-    EbsdHeader_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Author, Ebsd::Ctf::Author)
-    EbsdHeader_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, JobMode, Ebsd::Ctf::JobMode)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, XCells, Ebsd::Ctf::XCells)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, YCells, Ebsd::Ctf::YCells)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, ZCells, Ebsd::Ctf::ZCells)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, XStep, Ebsd::Ctf::XStep)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, YStep, Ebsd::Ctf::YStep)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, ZStep, Ebsd::Ctf::ZStep)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE1, Ebsd::Ctf::AcqE1)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE2, Ebsd::Ctf::AcqE2)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE3, Ebsd::Ctf::AcqE3)
-    EbsdHeader_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Euler, Ebsd::Ctf::Euler)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Mag, Ebsd::Ctf::Mag)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Coverage, Ebsd::Ctf::Coverage)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Device, Ebsd::Ctf::Device)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, KV, Ebsd::Ctf::KV)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, TiltAngle, Ebsd::Ctf::TiltAngle)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, TiltAxis, Ebsd::Ctf::TiltAxis)
-    EbsdHeader_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, NumPhases, Ebsd::Ctf::NumPhases)
+  EBSDHEADER_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Channel, Ebsd::Ctf::ChannelTextFile)
 
-    EBSD_INSTANCE_PROPERTY(QVector<CtfPhase::Pointer>, PhaseVector)
+  EBSDHEADER_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Prj, Ebsd::Ctf::Prj)
 
-    EBSD_POINTER_PROP(Phase, Phase, int)
-    EBSD_POINTER_PROP(X, X, float)
-    EBSD_POINTER_PROP(Y, Y, float)
-    EBSD_POINTER_PROP(Z, Z, float)
-    EBSD_POINTER_PROP(BandCount, Bands, int)
-    EBSD_POINTER_PROP(Error, Error, int)
-    EBSD_POINTER_PROP(Euler1, Euler1, float)
-    EBSD_POINTER_PROP(Euler2, Euler2, float)
-    EBSD_POINTER_PROP(Euler3, Euler3, float)
-    EBSD_POINTER_PROP(MeanAngularDeviation, MAD, float)
-    EBSD_POINTER_PROP(BandContrast, BC, int)
-    EBSD_POINTER_PROP(BandSlope, BS, int)
+  EBSDHEADER_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Author, Ebsd::Ctf::Author)
 
-    /* These will be in a 3D ctf file */
-    EBSD_POINTER_PROP(GrainIndex, GrainIndex, int)
-    EBSD_POINTER_PROP(GrainRandomColourR, GrainRandomColourR, int)
-    EBSD_POINTER_PROP(GrainRandomColourG, GrainRandomColourG, int)
-    EBSD_POINTER_PROP(GrainRandomColourB, GrainRandomColourB, int)
+  EBSDHEADER_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, JobMode, Ebsd::Ctf::JobMode)
 
-    /**
-     * @brief Returns the pointer to the data for a given feature
-     * @param featureName The name of the feature to return the pointer to.
-     */
-    void* getPointerByName(const QString& featureName);
-    void setPointerByName(const QString& name, void* p);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, XCells, Ebsd::Ctf::XCells)
 
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, YCells, Ebsd::Ctf::YCells)
 
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, ZCells, Ebsd::Ctf::ZCells)
 
-    /**
-     * @brief Returns an enumeration value that depicts the numerical
-     * primitive type that the data is stored as (Int, Float, etc).
-     * @param featureName The name of the feature.
-     */
-    Ebsd::NumType getPointerType(const QString& featureName);
-    int getTypeSize(const QString& featureName);
-    DataParser::Pointer getParser(const QString& featureName, void* ptr, size_t size);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, XStep, Ebsd::Ctf::XStep)
 
-    QList<QString> getColumnNames();
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, YStep, Ebsd::Ctf::YStep)
 
-    /**
-    * @brief Reads the complete HKL .ctf file.
-    * @return 1 on success
-    */
-    virtual int readFile();
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, ZStep, Ebsd::Ctf::ZStep)
 
-    /**
-    * @brief Reads ONLY the header portion of the HKL .ctf file
-    * @return 1 on success
-    */
-    virtual int readHeaderOnly();
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE1, Ebsd::Ctf::AcqE1)
 
-    virtual void readOnlySliceIndex(int slice);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE2, Ebsd::Ctf::AcqE2)
 
-    /** @brief Allocates the proper amount of memory (after reading the header portion of the file)
-    * and then splats '0' across all the bytes of the memory allocation
-    */
-    void initPointers(size_t numElements);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, AcqE3, Ebsd::Ctf::AcqE3)
 
-    /** @brief 'free's the allocated memory and sets the pointer to nullptr
-    */
-    void deletePointers();
+  EBSDHEADER_INSTANCE_PROPERTY(CtfStringHeaderEntry, QString, Euler, Ebsd::Ctf::Euler)
 
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Mag, Ebsd::Ctf::Mag)
 
-    virtual int getXDimension();
-    virtual void setXDimension(int xdim);
-    virtual int getYDimension();
-    virtual void setYDimension(int ydim);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Coverage, Ebsd::Ctf::Coverage)
 
-    virtual void printHeader(std::ostream& out);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, Device, Ebsd::Ctf::Device)
 
-    /**
-     * @brief writeFile
-     * @param filepath
-     */
-    virtual int writeFile(QString filepath);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, KV, Ebsd::Ctf::KV)
 
-  protected:
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, TiltAngle, Ebsd::Ctf::TiltAngle)
 
-  private:
-    int m_SingleSliceRead;
-    QMap<QString, DataParser::Pointer> m_NamePointerMap;
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<float>, float, TiltAxis, Ebsd::Ctf::TiltAxis)
 
-    /**
-     * @brief
-     * @param reader
-     * @param headerLines
-     * @return
-     */
-    int getHeaderLines(QFile& reader, QList<QByteArray>& headerLines);
+  EBSDHEADER_INSTANCE_PROPERTY(CtfHeaderEntry<int>, int, NumPhases, Ebsd::Ctf::NumPhases)
 
-    /**
-    * Checks that the line is the header of the columns for the data.
-    *
-    * @param columns
-    *            line values
-    * @return <code>true</code> if the line is the columns header line,
-    *         <code>false</code> otherwise
-    */
-    bool isDataHeaderLine(QVector<QString>& columns);
+  EBSD_INSTANCE_PROPERTY(QVector<CtfPhase::Pointer>, PhaseVector)
 
-    /**
-    *
-    */
-    int parseHeaderLines(QList<QByteArray>& headerLines);
+  EBSD_POINTER_PROP(Phase, Phase, int)
 
-    /**
-       * @brief
-       * @param in The input file stream to read from
-       */
-    int readData(QFile& in);
+  EBSD_POINTER_PROP(X, X, float)
 
-    /**
-    * @brief Reads a line of Data from the ASCII based file
-    * @param line The current line of data
-    * @param row Current Row of Data
-    * @param i The current index into a flat array
-    * @param xCells Number of X Data Points
-    * @param yCells Number of Y Data Points
-    * @param col The current Column of Data
-    */
-    int parseDataLine(QByteArray& line, size_t row, size_t col, size_t i, size_t xCells, size_t yCells );
+  EBSD_POINTER_PROP(Y, Y, float)
 
-    CtfReader(const CtfReader&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const CtfReader&) = delete; // Move assignment Not Implemented
+  EBSD_POINTER_PROP(Z, Z, float)
+
+  EBSD_POINTER_PROP(BandCount, Bands, int)
+
+  EBSD_POINTER_PROP(Error, Error, int)
+
+  EBSD_POINTER_PROP(Euler1, Euler1, float)
+
+  EBSD_POINTER_PROP(Euler2, Euler2, float)
+
+  EBSD_POINTER_PROP(Euler3, Euler3, float)
+
+  EBSD_POINTER_PROP(MeanAngularDeviation, MAD, float)
+
+  EBSD_POINTER_PROP(BandContrast, BC, int)
+
+  EBSD_POINTER_PROP(BandSlope, BS, int)
+
+  /* These will be in a 3D ctf file */
+  EBSD_POINTER_PROP(GrainIndex, GrainIndex, int)
+
+  EBSD_POINTER_PROP(GrainRandomColourR, GrainRandomColourR, int)
+
+  EBSD_POINTER_PROP(GrainRandomColourG, GrainRandomColourG, int)
+
+  EBSD_POINTER_PROP(GrainRandomColourB, GrainRandomColourB, int)
+
+  /**
+   * @brief Returns the pointer to the data for a given feature
+   * @param featureName The name of the feature to return the pointer to.
+   */
+  void* getPointerByName(const QString& featureName) override;
+  void setPointerByName(const QString& name, void* p);
+
+  /**
+   * @brief Returns an enumeration value that depicts the numerical
+   * primitive type that the data is stored as (Int, Float, etc).
+   * @param featureName The name of the feature.
+   */
+  Ebsd::NumType getPointerType(const QString& featureName) override;
+  int getTypeSize(const QString& featureName);
+  DataParser::Pointer getParser(const QString& featureName, void* ptr, size_t size);
+
+  QList<QString> getColumnNames();
+
+  /**
+   * @brief Reads the complete HKL .ctf file.
+   * @return 1 on success
+   */
+  int readFile() override;
+
+  /**
+   * @brief Reads ONLY the header portion of the HKL .ctf file
+   * @return 1 on success
+   */
+  int readHeaderOnly() override;
+
+  void readOnlySliceIndex(int slice);
+
+  /** @brief Allocates the proper amount of memory (after reading the header portion of the file)
+   * and then splats '0' across all the bytes of the memory allocation
+   */
+  void initPointers(size_t numElements) override;
+
+  /** @brief 'free's the allocated memory and sets the pointer to nullptr
+   */
+  void deletePointers() override;
+
+  int getXDimension() override;
+  void setXDimension(int xdim) override;
+  int getYDimension() override;
+  void setYDimension(int ydim) override;
+
+  void printHeader(std::ostream& out);
+
+  /**
+   * @brief writeFile
+   * @param filepath
+   */
+  int writeFile(QString filepath);
+
+protected:
+private:
+  int m_SingleSliceRead;
+  QMap<QString, DataParser::Pointer> m_NamePointerMap;
+
+  /**
+   * @brief
+   * @param reader
+   * @param headerLines
+   * @return
+   */
+  int getHeaderLines(QFile& reader, QList<QByteArray>& headerLines);
+
+  /**
+   * Checks that the line is the header of the columns for the data.
+   *
+   * @param columns
+   *            line values
+   * @return <code>true</code> if the line is the columns header line,
+   *         <code>false</code> otherwise
+   */
+  bool isDataHeaderLine(QVector<QString>& columns);
+
+  /**
+   *
+   */
+  int parseHeaderLines(QList<QByteArray>& headerLines);
+
+  /**
+   * @brief
+   * @param in The input file stream to read from
+   */
+  int readData(QFile& in);
+
+  /**
+   * @brief Reads a line of Data from the ASCII based file
+   * @param line The current line of data
+   * @param row Current Row of Data
+   * @param i The current index into a flat array
+   * @param xCells Number of X Data Points
+   * @param yCells Number of Y Data Points
+   * @param col The current Column of Data
+   */
+  int parseDataLine(QByteArray& line, size_t row, size_t col, size_t i, size_t xCells, size_t yCells);
+
+public:
+  CtfReader(const CtfReader&) = delete;            // Copy Constructor Not Implemented
+  CtfReader(CtfReader&&) = delete;                 // Move Constructor Not Implemented
+  CtfReader& operator=(const CtfReader&) = delete; // Copy Assignment Not Implemented
+  CtfReader& operator=(CtfReader&&) = delete;      // Move Assignment Not Implemented
 };
-
-
-

--- a/Source/EbsdLib/HKL/DataParser.hpp
+++ b/Source/EbsdLib/HKL/DataParser.hpp
@@ -45,7 +45,7 @@ class DataParser
     EBSD_SHARED_POINTERS(DataParser)
     EBSD_TYPE_MACRO(DataParser)
 
-    virtual ~DataParser() {}
+    virtual ~DataParser() = default;
 
     virtual bool allocateArray(size_t numberOfElements) { (void)(numberOfElements); return false;}
     virtual void* getVoidPointer() { return nullptr; }
@@ -59,11 +59,19 @@ class DataParser
 
     virtual void parse(const QByteArray& token, size_t index) {}
   protected:
-    DataParser() {}
+    DataParser()
+    : m_ManageMemory(false)
+    , m_Size(0)
+    , m_ColumnName("")
+    , m_ColumnIndex(0)
+    {
+    }
 
-  private:
-    DataParser(const DataParser&); // Copy Constructor Not Implemented
-    void operator=(const DataParser&); // Move assignment Not Implemented
+  public:
+    DataParser(const DataParser&) = delete;            // Copy Constructor Not Implemented
+    DataParser(DataParser&&) = delete;                 // Move Constructor Not Implemented
+    DataParser& operator=(const DataParser&) = delete; // Copy Assignment Not Implemented
+    DataParser& operator=(DataParser&&) = delete;      // Move Assignment Not Implemented
 };
 
 // -----------------------------------------------------------------------------
@@ -80,9 +88,9 @@ class Int32Parser : public DataParser
       return sharedPtr;
     }
 
-    virtual ~Int32Parser()
+    ~Int32Parser() override
     {
-      if (m_Ptr != nullptr && getManageMemory() == true)
+      if(m_Ptr != nullptr && getManageMemory())
       {
 #if defined ( SIMPL_USE_SSE ) && defined ( __SSE2__ )
         _mm_free(m_Ptr );
@@ -93,9 +101,16 @@ class Int32Parser : public DataParser
       }
     }
 
-    EBSD_INSTANCE_PROPERTY(int32_t*, Ptr)
+    void setPtr(int32_t* value)
+    {
+      this->m_Ptr = value;
+    }
+    int32_t* getPtr()
+    {
+      return m_Ptr;
+    }
 
-    virtual bool allocateArray(size_t numberOfElements)
+    bool allocateArray(size_t numberOfElements) override
     {
 #if defined ( SIMPL_USE_SSE ) && defined ( __SSE2__ )
       m_Ptr = static_cast<int32_t*>( _mm_malloc (numberOfElements * sizeof(T), 16) );
@@ -105,13 +120,18 @@ class Int32Parser : public DataParser
       return (m_Ptr != nullptr);
     }
 
-    virtual void* getVoidPointer() { return reinterpret_cast<void*>(m_Ptr); }
-    virtual void  setVoidPointer(void* p) { m_Ptr = reinterpret_cast<int32_t*>(p); }
+    void* getVoidPointer() override
+    {
+      return reinterpret_cast<void*>(m_Ptr);
+    }
+    void setVoidPointer(void* p) override
+    {
+      m_Ptr = reinterpret_cast<int32_t*>(p);
+    }
 
     int32_t* getPointer(size_t offset) { return m_Ptr + offset; }
 
-
-    virtual void parse(const QByteArray& token, size_t index)
+    void parse(const QByteArray& token, size_t index) override
     {
       Q_ASSERT(index < getSize());
       bool ok = false;
@@ -129,10 +149,13 @@ class Int32Parser : public DataParser
     }
 
   private:
+    int32_t* m_Ptr;
 
-
-    Int32Parser(const Int32Parser&); // Copy Constructor Not Implemented
-    void operator=(const Int32Parser&); // Move assignment Not Implemented
+  public:
+    Int32Parser(const Int32Parser&) = delete;            // Copy Constructor Not Implemented
+    Int32Parser(Int32Parser&&) = delete;                 // Move Constructor Not Implemented
+    Int32Parser& operator=(const Int32Parser&) = delete; // Copy Assignment Not Implemented
+    Int32Parser& operator=(Int32Parser&&) = delete;      // Move Assignment Not Implemented
 };
 
 // -----------------------------------------------------------------------------
@@ -149,9 +172,9 @@ class FloatParser : public DataParser
       return sharedPtr;
     }
 
-    virtual ~FloatParser()
+    ~FloatParser() override
     {
-      if (m_Ptr != nullptr && getManageMemory() == true)
+      if(m_Ptr != nullptr && getManageMemory())
       {
 #if defined ( SIMPL_USE_SSE ) && defined ( __SSE2__ )
         _mm_free(m_Ptr );
@@ -162,9 +185,16 @@ class FloatParser : public DataParser
       }
     }
 
-    EBSD_INSTANCE_PROPERTY(float*, Ptr)
+    void setPtr(float* value)
+    {
+      this->m_Ptr = value;
+    }
+    float* getPtr()
+    {
+      return m_Ptr;
+    }
 
-    virtual bool allocateArray(size_t numberOfElements)
+    bool allocateArray(size_t numberOfElements) override
     {
 #if defined ( SIMPL_USE_SSE ) && defined ( __SSE2__ )
       m_Ptr = static_cast<float*>( _mm_malloc (numberOfElements * sizeof(T), 16) );
@@ -174,12 +204,18 @@ class FloatParser : public DataParser
       return (m_Ptr != nullptr);
     }
 
-    virtual void* getVoidPointer() { return reinterpret_cast<void*>(m_Ptr); }
-    virtual void  setVoidPointer(void* p) { m_Ptr = reinterpret_cast<float*>(p); }
+    void* getVoidPointer() override
+    {
+      return reinterpret_cast<void*>(m_Ptr);
+    }
+    void setVoidPointer(void* p) override
+    {
+      m_Ptr = reinterpret_cast<float*>(p);
+    }
 
     float* getPointer(size_t offset) { return m_Ptr + offset; }
 
-    virtual void parse(const QByteArray& token, size_t index)
+    void parse(const QByteArray& token, size_t index) override
     {
       bool ok = false;
       m_Ptr[index] = token.toFloat(&ok);
@@ -196,9 +232,13 @@ class FloatParser : public DataParser
     }
 
   private:
+    float* m_Ptr;
 
-    FloatParser(const FloatParser&); // Copy Constructor Not Implemented
-    void operator=(const FloatParser&); // Move assignment Not Implemented
+  public:
+    FloatParser(const FloatParser&) = delete;            // Copy Constructor Not Implemented
+    FloatParser(FloatParser&&) = delete;                 // Move Constructor Not Implemented
+    FloatParser& operator=(const FloatParser&) = delete; // Copy Assignment Not Implemented
+    FloatParser& operator=(FloatParser&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/HKL/H5CtfImporter.h
+++ b/Source/EbsdLib/HKL/H5CtfImporter.h
@@ -63,7 +63,7 @@ class EbsdLib_EXPORT H5CtfImporter : public EbsdImporter
     EBSD_TYPE_MACRO_SUPER(H5CtfImporter, EbsdImporter)
     EBSD_STATIC_NEW_SUPERCLASS(EbsdImporter, H5CtfImporter)
 
-    virtual ~H5CtfImporter();
+    ~H5CtfImporter() override;
 
     /**
      * @brief Imports a specific file into the HDF5 file
@@ -86,27 +86,27 @@ class EbsdLib_EXPORT H5CtfImporter : public EbsdImporter
      * @param x Number of X Voxels (out)
      * @param y Number of Y Voxels (out)
      */
-    virtual void getDims(int64_t& x, int64_t& y);
+    void getDims(int64_t& x, int64_t& y) override;
 
     /**
      * @brief Returns the x and y resolution of the voxels
      * @param x The x resolution (out)
      * @param y The y resolution (out)
      */
-    virtual void getResolution(float& x, float& y);
+    void getResolution(float& x, float& y) override;
 
     /**
      * @brief Return the number of slices imported
      * @return
      */
-    virtual int numberOfSlicesImported();
+    int numberOfSlicesImported() override;
 
     /**
      * @brief This function sets the version of the H5Ebsd file that will be written.
      * @param version
      * @return
      */
-    virtual void setFileVersion(uint32_t version);
+    void setFileVersion(uint32_t version) override;
 
   protected:
     H5CtfImporter();
@@ -123,8 +123,11 @@ class EbsdLib_EXPORT H5CtfImporter : public EbsdImporter
     int m_NumSlicesImported;
     int   m_FileVersion;
 
+  public:
     H5CtfImporter(const H5CtfImporter&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const H5CtfImporter&) = delete; // Move assignment Not Implemented
+    H5CtfImporter(H5CtfImporter&&) = delete;       // Move Constructor Not Implemented
+    H5CtfImporter& operator=(const H5CtfImporter&) = delete; // Copy Assignment Not Implemented
+    H5CtfImporter& operator=(H5CtfImporter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/HKL/H5CtfReader.h
+++ b/Source/EbsdLib/HKL/H5CtfReader.h
@@ -78,7 +78,7 @@ class EbsdLib_EXPORT H5CtfReader : public CtfReader
     EBSD_SHARED_POINTERS(H5CtfReader)
     EBSD_STATIC_NEW_MACRO(H5CtfReader)
     EBSD_TYPE_MACRO_SUPER(H5CtfReader, CtfReader)
-    virtual ~H5CtfReader();
+    ~H5CtfReader() override;
 
     /**
      * @brief The HDF5 path to find the EBSD data
@@ -89,7 +89,7 @@ class EbsdLib_EXPORT H5CtfReader : public CtfReader
      * @brief Reads the file
      * @return error condition
      */
-    virtual int readFile();
+    int readFile() override;
 
     /**
      * @brief Reads the header section of the file
@@ -102,7 +102,7 @@ class EbsdLib_EXPORT H5CtfReader : public CtfReader
     * @brief Reads ONLY the header portion of the HKL .ctf file
     * @return 1 on success
     */
-    virtual int readHeaderOnly();
+    int readHeaderOnly() override;
 
     /**
      * @brief Returns a vector of AngPhase objects corresponding to the phases
@@ -114,14 +114,14 @@ class EbsdLib_EXPORT H5CtfReader : public CtfReader
      * @brief Sets the names of the arrays to read out of the file
      * @param names
      */
-    virtual void setArraysToRead(QSet<QString> names);
+    void setArraysToRead(QSet<QString> names);
 
     /**
      * @brief Over rides the setArraysToReads to tell the reader to load ALL the data from the HDF5 file. If the
      * ArrayNames to read is empty and this is true then all arrays will be read.
      * @param b
      */
-    virtual void readAllArrays(bool b);
+    void readAllArrays(bool b);
 
   protected:
     H5CtfReader();
@@ -139,8 +139,11 @@ class EbsdLib_EXPORT H5CtfReader : public CtfReader
     QSet<QString> m_ArrayNames;
     bool                  m_ReadAllArrays;
 
+  public:
     H5CtfReader(const H5CtfReader&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const H5CtfReader&) = delete; // Move assignment Not Implemented
+    H5CtfReader(H5CtfReader&&) = delete;         // Move Constructor Not Implemented
+    H5CtfReader& operator=(const H5CtfReader&) = delete; // Copy Assignment Not Implemented
+    H5CtfReader& operator=(H5CtfReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/HKL/H5CtfVolumeReader.h
+++ b/Source/EbsdLib/HKL/H5CtfVolumeReader.h
@@ -60,7 +60,7 @@ class EbsdLib_EXPORT H5CtfVolumeReader : public H5EbsdVolumeReader
     EBSD_STATIC_NEW_SUPERCLASS(H5EbsdVolumeReader, H5CtfVolumeReader)
     EBSD_TYPE_MACRO_SUPER(H5CtfVolumeReader, H5EbsdVolumeReader)
 
-    virtual ~H5CtfVolumeReader();
+    ~H5CtfVolumeReader() override;
 
     EBSD_POINTER_PROPERTY(Phase, Phase, int)
     EBSD_POINTER_PROPERTY(X, X, float)
@@ -127,9 +127,6 @@ class EbsdLib_EXPORT H5CtfVolumeReader : public H5EbsdVolumeReader
   private:
     QVector<CtfPhase::Pointer> m_Phases;
 
-    H5CtfVolumeReader(const H5CtfVolumeReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const H5CtfVolumeReader&) = delete;    // Move assignment Not Implemented
-
     /**
      * @brief Allocats a contiguous chunk of memory to store values from the .ang file
      * @param numberOfElements The number of elements in the Array. This method can
@@ -169,7 +166,11 @@ class EbsdLib_EXPORT H5CtfVolumeReader : public H5EbsdVolumeReader
       }
     }
 
-
+  public:
+    H5CtfVolumeReader(const H5CtfVolumeReader&) = delete;            // Copy Constructor Not Implemented
+    H5CtfVolumeReader(H5CtfVolumeReader&&) = delete;                 // Move Constructor Not Implemented
+    H5CtfVolumeReader& operator=(const H5CtfVolumeReader&) = delete; // Copy Assignment Not Implemented
+    H5CtfVolumeReader& operator=(H5CtfVolumeReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/TSL/AngFields.h
+++ b/Source/EbsdLib/TSL/AngFields.h
@@ -77,9 +77,11 @@ class EbsdLib_EXPORT AngFields : public AbstractEbsdFields
     }
 
 
-  private:
+  public:
     AngFields(const AngFields&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const AngFields&) = delete; // Move assignment Not Implemented
+    AngFields(AngFields&&) = delete;           // Move Constructor Not Implemented
+    AngFields& operator=(const AngFields&) = delete; // Copy Assignment Not Implemented
+    AngFields& operator=(AngFields&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/TSL/AngHeaderEntry.h
+++ b/Source/EbsdLib/TSL/AngHeaderEntry.h
@@ -100,8 +100,11 @@ class EbsdLib_EXPORT AngHeaderEntry : public EbsdHeaderEntry
     T m_value;
     QString m_key;
 
+  public:
     AngHeaderEntry(const AngHeaderEntry&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AngHeaderEntry&) = delete; // Move assignment Not Implemented
+    AngHeaderEntry(AngHeaderEntry&&) = delete;      // Move Constructor Not Implemented
+    AngHeaderEntry& operator=(const AngHeaderEntry&) = delete; // Copy Assignment Not Implemented
+    AngHeaderEntry& operator=(AngHeaderEntry&&) = delete;      // Move Assignment Not Implemented
 };
 
 /**

--- a/Source/EbsdLib/TSL/AngPhase.h
+++ b/Source/EbsdLib/TSL/AngPhase.h
@@ -196,9 +196,11 @@ class EbsdLib_EXPORT AngPhase
   protected:
     AngPhase();
 
-  private:
+  public:
     AngPhase(const AngPhase&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const AngPhase&) = delete; // Move assignment Not Implemented
+    AngPhase(AngPhase&&) = delete;            // Move Constructor Not Implemented
+    AngPhase& operator=(const AngPhase&) = delete; // Copy Assignment Not Implemented
+    AngPhase& operator=(AngPhase&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/TSL/AngReader.h
+++ b/Source/EbsdLib/TSL/AngReader.h
@@ -1,166 +1,180 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-
-
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
-#include <QtCore/QString>
-#include <QtCore/QFile>
 #include <QtCore/QByteArray>
+#include <QtCore/QFile>
+#include <QtCore/QString>
 
 #include <map>
 
-
-#include "EbsdLib/EbsdSetGetMacros.h"
-#include "EbsdLib/EbsdLib.h"
-#include "EbsdLib/EbsdConstants.h"
-#include "EbsdLib/EbsdReader.h"
 #include "AngConstants.h"
 #include "AngHeaderEntry.h"
 #include "AngPhase.h"
-
-
+#include "EbsdLib/EbsdConstants.h"
+#include "EbsdLib/EbsdLib.h"
+#include "EbsdLib/EbsdReader.h"
+#include "EbsdLib/EbsdSetGetMacros.h"
 
 /**
-* @class AngReader AngReader.h EbsdLib/TSL/AngReader.h
-* @brief This class is a self contained TSL OIM .ang file reader and will read a
-* single .ang file and store all the data in column centric pointers.
-* @author Michael A. Jackson for BlueQuartz Software
-* @date Mar 1, 2010
-* @version 1.0
-*/
+ * @class AngReader AngReader.h EbsdLib/TSL/AngReader.h
+ * @brief This class is a self contained TSL OIM .ang file reader and will read a
+ * single .ang file and store all the data in column centric pointers.
+ * @author Michael A. Jackson for BlueQuartz Software
+ * @date Mar 1, 2010
+ * @version 1.0
+ */
 class EbsdLib_EXPORT AngReader : public EbsdReader
 {
-  public:
-    AngReader();
-    virtual ~AngReader();
+public:
+  AngReader();
+  ~AngReader() override;
 
-    /** @brief Header Values from the TSL ang file */
+  /** @brief Header Values from the TSL ang file */
 
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, TEMpixPerum, Ebsd::Ang::TEMPIXPerUM)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStar, Ebsd::Ang::XStar)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStar, Ebsd::Ang::YStar)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, ZStar, Ebsd::Ang::ZStar)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, WorkingDistance, Ebsd::Ang::WorkingDistance)
-    EbsdHeader_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, Grid, Ebsd::Ang::Grid)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStep, Ebsd::Ang::XStep)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStep, Ebsd::Ang::YStep)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumOddCols, Ebsd::Ang::NColsOdd)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumEvenCols, Ebsd::Ang::NColsEven)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumRows, Ebsd::Ang::NRows)
-    EbsdHeader_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, OIMOperator, Ebsd::Ang::OPERATOR)
-    EbsdHeader_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, SampleID, Ebsd::Ang::SAMPLEID)
-    EbsdHeader_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, SCANID, Ebsd::Ang::SCANID)
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, TEMpixPerum, Ebsd::Ang::TEMPIXPerUM)
 
-    EBSD_INSTANCE_PROPERTY(QVector<AngPhase::Pointer>, PhaseVector)
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStar, Ebsd::Ang::XStar)
 
-    EBSD_INSTANCE_PROPERTY(bool, ReadHexGrid)
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStar, Ebsd::Ang::YStar)
 
-    EBSD_POINTER_PROPERTY(Phi1, Phi1, float)
-    EBSD_POINTER_PROPERTY(Phi, Phi, float)
-    EBSD_POINTER_PROPERTY(Phi2, Phi2, float)
-    EBSD_POINTER_PROPERTY(XPosition, X, float)
-    EBSD_POINTER_PROPERTY(YPosition, Y, float)
-    EBSD_POINTER_PROPERTY(ImageQuality, Iq, float)
-    EBSD_POINTER_PROPERTY(ConfidenceIndex, Ci, float)
-    EBSD_POINTER_PROPERTY(PhaseData, PhaseData, int)
-    EBSD_POINTER_PROPERTY(SEMSignal, SEMSignal, float)
-    EBSD_POINTER_PROPERTY(Fit, Fit, float)
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, ZStar, Ebsd::Ang::ZStar)
 
-    /**
-     * @brief Returns the pointer to the data for a given feature
-     * @param featureName The name of the feature to return the pointer to.
-     */
-    void* getPointerByName(const QString& featureName);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, WorkingDistance, Ebsd::Ang::WorkingDistance)
 
-    /**
-     * @brief Returns an enumeration value that depicts the numerical
-     * primitive type that the data is stored as (Int, Float, etc).
-     * @param featureName The name of the feature.
-     */
-    Ebsd::NumType getPointerType(const QString& featureName);
+  EBSDHEADER_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, Grid, Ebsd::Ang::Grid)
 
-    /**
-    * @brief Reads the complete TSL .ang file.
-    * @return 1 on success
-    */
-    virtual int readFile();
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStep, Ebsd::Ang::XStep)
 
-    /**
-    * @brief Reads ONLY the header portion of the TSL .ang file
-    * @return 1 on success
-    */
-    virtual int readHeaderOnly();
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStep, Ebsd::Ang::YStep)
 
-    /** @brief Allocates the proper amount of memory (after reading the header portion of the file)
-      * and then splats '0' across all the bytes of the memory allocation
-      */
-    virtual void initPointers(size_t numElements);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumOddCols, Ebsd::Ang::NColsOdd)
 
-    /** @brief 'free's the allocated memory and sets the pointer to nullptr
-    */
-    virtual void deletePointers();
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumEvenCols, Ebsd::Ang::NColsEven)
 
-    virtual int getXDimension();
-    virtual void setXDimension(int xdim);
-    virtual int getYDimension();
-    virtual void setYDimension(int ydim);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumRows, Ebsd::Ang::NRows)
 
-  protected:
+  EBSDHEADER_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, OIMOperator, Ebsd::Ang::OPERATOR)
 
+  EBSDHEADER_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, SampleID, Ebsd::Ang::SAMPLEID)
 
-  private:
-    AngPhase::Pointer   m_CurrentPhase;
-    int m_ErrorColumn = 0;
+  EBSDHEADER_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, SCANID, Ebsd::Ang::SCANID)
 
-    void readData(QFile& in, QByteArray& buf);
+  EBSD_INSTANCE_PROPERTY(QVector<AngPhase::Pointer>, PhaseVector)
 
-    /** @brief Parses the value from a single line of the header section of the TSL .ang file
-    * @param line The line to parse
-    */
-    void parseHeaderLine(QByteArray& buf);
+  EBSD_INSTANCE_PROPERTY(bool, ReadHexGrid)
 
-    /** @brief Parses the data from a line of data from the TSL .ang file
-      * @param line The line of data to parse
-      */
-    void parseDataLine(QByteArray& line, size_t i);
+  EBSD_POINTER_PROPERTY(Phi1, Phi1, float)
 
-    AngReader(const AngReader&);    // Copy Constructor Not Implemented
-    void operator=(const AngReader&); // Move assignment Not Implemented
+  EBSD_POINTER_PROPERTY(Phi, Phi, float)
+
+  EBSD_POINTER_PROPERTY(Phi2, Phi2, float)
+
+  EBSD_POINTER_PROPERTY(XPosition, X, float)
+
+  EBSD_POINTER_PROPERTY(YPosition, Y, float)
+
+  EBSD_POINTER_PROPERTY(ImageQuality, Iq, float)
+
+  EBSD_POINTER_PROPERTY(ConfidenceIndex, Ci, float)
+
+  EBSD_POINTER_PROPERTY(PhaseData, PhaseData, int)
+
+  EBSD_POINTER_PROPERTY(SEMSignal, SEMSignal, float)
+
+  EBSD_POINTER_PROPERTY(Fit, Fit, float)
+
+  /**
+   * @brief Returns the pointer to the data for a given feature
+   * @param featureName The name of the feature to return the pointer to.
+   */
+  void* getPointerByName(const QString& featureName) override;
+
+  /**
+   * @brief Returns an enumeration value that depicts the numerical
+   * primitive type that the data is stored as (Int, Float, etc).
+   * @param featureName The name of the feature.
+   */
+  Ebsd::NumType getPointerType(const QString& featureName) override;
+
+  /**
+   * @brief Reads the complete TSL .ang file.
+   * @return 1 on success
+   */
+  int readFile() override;
+
+  /**
+   * @brief Reads ONLY the header portion of the TSL .ang file
+   * @return 1 on success
+   */
+  int readHeaderOnly() override;
+
+  /** @brief Allocates the proper amount of memory (after reading the header portion of the file)
+   * and then splats '0' across all the bytes of the memory allocation
+   */
+  void initPointers(size_t numElements) override;
+
+  /** @brief 'free's the allocated memory and sets the pointer to nullptr
+   */
+  void deletePointers() override;
+
+  int getXDimension() override;
+  void setXDimension(int xdim) override;
+  int getYDimension() override;
+  void setYDimension(int ydim) override;
+
+private:
+  AngPhase::Pointer m_CurrentPhase;
+  int m_ErrorColumn = 0;
+
+  void readData(QFile& in, QByteArray& buf);
+
+  /** @brief Parses the value from a single line of the header section of the TSL .ang file
+   * @param line The line to parse
+   */
+  void parseHeaderLine(QByteArray& buf);
+
+  /** @brief Parses the data from a line of data from the TSL .ang file
+   * @param line The line of data to parse
+   */
+  void parseDataLine(QByteArray& line, size_t i);
+
+public:
+  AngReader(const AngReader&) = delete;            // Copy Constructor Not Implemented
+  AngReader(AngReader&&) = delete;                 // Move Constructor Not Implemented
+  AngReader& operator=(const AngReader&) = delete; // Copy Assignment Not Implemented
+  AngReader& operator=(AngReader&&) = delete;      // Move Assignment Not Implemented
 };
-
-

--- a/Source/EbsdLib/TSL/H5AngImporter.h
+++ b/Source/EbsdLib/TSL/H5AngImporter.h
@@ -66,7 +66,7 @@ class EbsdLib_EXPORT H5AngImporter : public EbsdImporter
     EBSD_TYPE_MACRO(H5AngImporter)
     EBSD_STATIC_NEW_SUPERCLASS(EbsdImporter, H5AngImporter)
 
-    virtual ~H5AngImporter();
+    ~H5AngImporter() override;
 
     /**
      * @brief Imports a specific file into the HDF5 file
@@ -130,8 +130,11 @@ class EbsdLib_EXPORT H5AngImporter : public EbsdImporter
     float yRes;
     int   m_FileVersion;
 
+  public:
     H5AngImporter(const H5AngImporter&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const H5AngImporter&) = delete; // Move assignment Not Implemented
+    H5AngImporter(H5AngImporter&&) = delete;       // Move Constructor Not Implemented
+    H5AngImporter& operator=(const H5AngImporter&) = delete; // Copy Assignment Not Implemented
+    H5AngImporter& operator=(H5AngImporter&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/TSL/H5AngReader.h
+++ b/Source/EbsdLib/TSL/H5AngReader.h
@@ -107,7 +107,7 @@ class EbsdLib_EXPORT H5AngReader : public AngReader
     EBSD_SHARED_POINTERS(H5AngReader)
     EBSD_STATIC_NEW_MACRO(H5AngReader)
     EBSD_TYPE_MACRO(H5AngReader)
-    virtual ~H5AngReader();
+    ~H5AngReader() override;
 
     /**
      * @brief The HDF5 path to find the EBSD data
@@ -143,14 +143,14 @@ class EbsdLib_EXPORT H5AngReader : public AngReader
      * @brief Sets the names of the arrays to read out of the file
      * @param names
      */
-    virtual void setArraysToRead(QSet<QString> names);
+    void setArraysToRead(QSet<QString> names);
 
     /**
      * @brief Over rides the setArraysToReads to tell the reader to load ALL the data from the HDF5 file. If the
      * ArrayNames to read is empty and this is true then all arrays will be read.
      * @param b
      */
-    virtual void readAllArrays(bool b);
+    void readAllArrays(bool b);
 
   protected:
     H5AngReader();
@@ -174,8 +174,11 @@ class EbsdLib_EXPORT H5AngReader : public AngReader
     QSet<QString>         m_ArrayNames;
     bool                  m_ReadAllArrays;
 
+  public:
     H5AngReader(const H5AngReader&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const H5AngReader&) = delete; // Move assignment Not Implemented
+    H5AngReader(H5AngReader&&) = delete;         // Move Constructor Not Implemented
+    H5AngReader& operator=(const H5AngReader&) = delete; // Copy Assignment Not Implemented
+    H5AngReader& operator=(H5AngReader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/EbsdLib/TSL/H5AngVolumeReader.h
+++ b/Source/EbsdLib/TSL/H5AngVolumeReader.h
@@ -61,8 +61,7 @@ class EbsdLib_EXPORT H5AngVolumeReader : public H5EbsdVolumeReader
     EBSD_SHARED_POINTERS(H5AngVolumeReader)
     EBSD_STATIC_NEW_SUPERCLASS(H5EbsdVolumeReader, H5AngVolumeReader)
 
-    virtual ~H5AngVolumeReader();
-
+    ~H5AngVolumeReader() override;
 
     EBSD_POINTER_PROPERTY(Phi1, Phi1, float)
     EBSD_POINTER_PROPERTY(Phi, Phi, float)
@@ -121,8 +120,11 @@ class EbsdLib_EXPORT H5AngVolumeReader : public H5EbsdVolumeReader
   private:
     QVector<AngPhase::Pointer> m_Phases;
 
-    H5AngVolumeReader(const H5AngVolumeReader&);    // Copy Constructor Not Implemented
-    void operator=(const H5AngVolumeReader&);       // Move assignment Not Implemented
+  public:
+    H5AngVolumeReader(const H5AngVolumeReader&) = delete;            // Copy Constructor Not Implemented
+    H5AngVolumeReader(H5AngVolumeReader&&) = delete;                 // Move Constructor Not Implemented
+    H5AngVolumeReader& operator=(const H5AngVolumeReader&) = delete; // Copy Assignment Not Implemented
+    H5AngVolumeReader& operator=(H5AngVolumeReader&&) = delete;      // Move Assignment Not Implemented
 
     /**
      * @brief Allocats a contiguous chunk of memory to store values from the .ang file

--- a/Source/EbsdLib/TSL/H5OIMReader.h
+++ b/Source/EbsdLib/TSL/H5OIMReader.h
@@ -1,52 +1,51 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
 #include <hdf5.h>
 
+#include <QtCore/QSet>
 #include <QtCore/QString>
 #include <QtCore/QVector>
-#include <QtCore/QSet>
 
 #include "EbsdLib/EbsdLib.h"
 #include "EbsdLib/EbsdSetGetMacros.h"
 
-#include "AngReader.h"
 #include "AngPhase.h"
+#include "AngReader.h"
 
 /**
  * @class H5OIMReader H5OIMReader.h EbsdLib/TSL/H5OIMReader.h
@@ -87,102 +86,111 @@
  */
 class EbsdLib_EXPORT H5OIMReader : public AngReader
 {
-  public:
-    EBSD_SHARED_POINTERS(H5OIMReader)
-    EBSD_STATIC_NEW_MACRO(H5OIMReader)
-    EBSD_TYPE_MACRO(H5OIMReader)
-    virtual ~H5OIMReader();
+public:
+  EBSD_SHARED_POINTERS(H5OIMReader)
+  EBSD_STATIC_NEW_MACRO(H5OIMReader)
+  EBSD_TYPE_MACRO(H5OIMReader)
+  ~H5OIMReader() override;
 
-    /**
-     * @brief The HDF5 path to find the EBSD data
-     */
-    EBSD_INSTANCE_STRING_PROPERTY(HDF5Path)
-    EBSD_INSTANCE_PROPERTY(bool, ReadPatternData)
-    EBSD_INSTANCE_PROPERTY(uint8_t*, PatternData)
-    EBSD_INSTANCE_2DVECTOR_PROPERTY(int, PatternDims)
+  /**
+   * @brief The HDF5 path to find the EBSD data
+   */
+  EBSD_INSTANCE_STRING_PROPERTY(HDF5Path)
 
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumColumns, Ebsd::Ang::nColumns)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumRows, Ebsd::Ang::nRows)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStep, Ebsd::Ang::StepX)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStep, Ebsd::Ang::StepY)
-    EbsdHeader_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, Grid, Ebsd::Ang::GridType)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, PatternWidth, Ebsd::Ang::PatternWidth)
-    EbsdHeader_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, PatternHeight, Ebsd::Ang::PatternHeight)
+  EBSD_INSTANCE_PROPERTY(bool, ReadPatternData)
 
+  EBSD_PTR_INSTANCE_PROPERTY(uint8_t*, PatternData)
 
-    /**
-     * @brief Reads the file
-     * @return error condition
-     */
-    virtual int readFile();
+  EBSD_INSTANCE_2DVECTOR_PROPERTY(int, PatternDims)
 
-    /**
-     * @brief readScanNames
-     * @return
-     */
-    virtual int readScanNames(QStringList& names);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumColumns, Ebsd::Ang::nColumns)
 
-    /**
-     * @brief Reads the header section of the file
-     * @param Valid HDF5 Group ID
-     * @return error condition
-     */
-    int readHeader(hid_t parId);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, NumRows, Ebsd::Ang::nRows)
 
-    /**
-    * @brief Reads ONLY the header portion of the TSL .ang file
-    * @return 1 on success
-    */
-    virtual int readHeaderOnly();
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, XStep, Ebsd::Ang::StepX)
 
-    /**
-     * @brief Returns a vector of AngPhase objects corresponding to the phases
-     * present in the file
-     */
-    // QVector<AngPhase::Pointer> getPhases() { return m_Phases; }
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<float>, float, YStep, Ebsd::Ang::StepY)
 
-    /**
-     * @brief Sets the names of the arrays to read out of the file
-     * @param names
-     */
-    virtual void setArraysToRead(QSet<QString> names);
+  EBSDHEADER_INSTANCE_PROPERTY(AngStringHeaderEntry, QString, Grid, Ebsd::Ang::GridType)
 
-    /**
-     * @brief Over rides the setArraysToReads to tell the reader to load ALL the data from the HDF5 file. If the
-     * ArrayNames to read is empty and this is true then all arrays will be read.
-     * @param b
-     */
-    virtual void readAllArrays(bool b);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, PatternWidth, Ebsd::Ang::PatternWidth)
 
-    virtual int getXDimension();
-    virtual void setXDimension(int xdim);
-    virtual int getYDimension();
-    virtual void setYDimension(int ydim);
+  EBSDHEADER_INSTANCE_PROPERTY(AngHeaderEntry<int>, int, PatternHeight, Ebsd::Ang::PatternHeight)
 
-  protected:
-    H5OIMReader();
+  /**
+   * @brief Reads the file
+   * @return error condition
+   */
+  int readFile() override;
 
-    /**
-     * @brief Reads the data associated with HKL Families for a given phase.
-     * @param hklGid Valid HDF5 Group ID where the HKL Family data is located.
-     * @param phase The AngPhase to parse the HKL Family data
-     */
-    int readHKLFamilies(hid_t hklGid, AngPhase::Pointer phase);
+  /**
+   * @brief readScanNames
+   * @return
+   */
+  int readScanNames(QStringList& names);
 
-    /**
-     * @brief Reads the data section of the file
-     * @param Valid HDF5 Group ID
-     * @return error condition
-     */
-    int readData(hid_t parId);
+  /**
+   * @brief Reads the header section of the file
+   * @param Valid HDF5 Group ID
+   * @return error condition
+   */
+  int readHeader(hid_t parId);
 
-  private:
-    // QVector<AngPhase::Pointer> m_Phases;
-    QSet<QString>         m_ArrayNames;
-    bool                  m_ReadAllArrays;
+  /**
+   * @brief Reads ONLY the header portion of the TSL .ang file
+   * @return 1 on success
+   */
+  int readHeaderOnly() override;
 
-    H5OIMReader(const H5OIMReader&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const H5OIMReader&) = delete; // Move assignment Not Implemented
+  /**
+   * @brief Returns a vector of AngPhase objects corresponding to the phases
+   * present in the file
+   */
+  // QVector<AngPhase::Pointer> getPhases() { return m_Phases; }
+
+  /**
+   * @brief Sets the names of the arrays to read out of the file
+   * @param names
+   */
+  void setArraysToRead(QSet<QString> names);
+
+  /**
+   * @brief Over rides the setArraysToReads to tell the reader to load ALL the data from the HDF5 file. If the
+   * ArrayNames to read is empty and this is true then all arrays will be read.
+   * @param b
+   */
+  void readAllArrays(bool b);
+
+  int getXDimension() override;
+  void setXDimension(int xdim) override;
+  int getYDimension() override;
+  void setYDimension(int ydim) override;
+
+protected:
+  H5OIMReader();
+
+  /**
+   * @brief Reads the data associated with HKL Families for a given phase.
+   * @param hklGid Valid HDF5 Group ID where the HKL Family data is located.
+   * @param phase The AngPhase to parse the HKL Family data
+   */
+  int readHKLFamilies(hid_t hklGid, AngPhase::Pointer phase);
+
+  /**
+   * @brief Reads the data section of the file
+   * @param Valid HDF5 Group ID
+   * @return error condition
+   */
+  int readData(hid_t parId);
+
+private:
+  // QVector<AngPhase::Pointer> m_Phases;
+  QSet<QString> m_ArrayNames;
+  bool m_ReadAllArrays;
+
+public:
+  H5OIMReader(const H5OIMReader&) = delete;            // Copy Constructor Not Implemented
+  H5OIMReader(H5OIMReader&&) = delete;                 // Move Constructor Not Implemented
+  H5OIMReader& operator=(const H5OIMReader&) = delete; // Copy Assignment Not Implemented
+  H5OIMReader& operator=(H5OIMReader&&) = delete;      // Move Assignment Not Implemented
 };
-
-

--- a/Source/OrientationLib/IO/AngleFileLoader.h
+++ b/Source/OrientationLib/IO/AngleFileLoader.h
@@ -87,9 +87,11 @@ class OrientationLib_EXPORT AngleFileLoader
     AngleFileLoader();
 
 
-  private:
+  public:
     AngleFileLoader(const AngleFileLoader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AngleFileLoader&) = delete;  // Move assignment Not Implemented
+    AngleFileLoader(AngleFileLoader&&) = delete;      // Move Constructor Not Implemented
+    AngleFileLoader& operator=(const AngleFileLoader&) = delete; // Copy Assignment Not Implemented
+    AngleFileLoader& operator=(AngleFileLoader&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/CubicLowOps.h
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.h
@@ -181,9 +181,11 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
     float _calcMisoQuat(const QuatF quatsym[24], int numsym,
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
-  private:
+  public:
     CubicLowOps(const CubicLowOps&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const CubicLowOps&) = delete; // Move assignment Not Implemented
+    CubicLowOps(CubicLowOps&&) = delete;         // Move Constructor Not Implemented
+    CubicLowOps& operator=(const CubicLowOps&) = delete; // Copy Assignment Not Implemented
+    CubicLowOps& operator=(CubicLowOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/CubicOps.h
+++ b/Source/OrientationLib/LaueOps/CubicOps.h
@@ -202,9 +202,11 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
      */
     std::vector< std::pair<double, double> > rodri2pair(std::vector<double>, std::vector<double>, std::vector<double>);
 
-  private:
+  public:
     CubicOps(const CubicOps&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const CubicOps&) = delete; // Move assignment Not Implemented
+    CubicOps(CubicOps&&) = delete;            // Move Constructor Not Implemented
+    CubicOps& operator=(const CubicOps&) = delete; // Copy Assignment Not Implemented
+    CubicOps& operator=(CubicOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.h
@@ -182,9 +182,11 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     HexagonalLowOps(const HexagonalLowOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const HexagonalLowOps&) = delete;  // Move assignment Not Implemented
+    HexagonalLowOps(HexagonalLowOps&&) = delete;      // Move Constructor Not Implemented
+    HexagonalLowOps& operator=(const HexagonalLowOps&) = delete; // Copy Assignment Not Implemented
+    HexagonalLowOps& operator=(HexagonalLowOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/HexagonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.cpp
@@ -1293,7 +1293,7 @@ void HexagonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatA
 #endif
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
-  if (doParallel == true)
+  if(doParallel)
   {
     tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
                       Detail::HexagonalHigh::GenerateSphereCoordsImpl(eulers, xyz0001, xyz1010, xyz1120), tbb::auto_partitioner());
@@ -1483,7 +1483,7 @@ QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConf
   tbb::task_scheduler_init init;
   bool doParallel = true;
 
-  if(doParallel == true)
+  if(doParallel)
   {
     std::shared_ptr<tbb::task_group> g(new tbb::task_group);
     g->run(ComputeStereographicProjection(xyz001.get(), &config, intensity001.get()));
@@ -1574,7 +1574,7 @@ QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConf
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 
-  if(doParallel == true)
+  if(doParallel)
   {
     std::shared_ptr<tbb::task_group> g(new tbb::task_group);
     g->run(GeneratePoleFigureRgbaImageImpl(intensity001.get(), &config, image001.get()));

--- a/Source/OrientationLib/LaueOps/HexagonalOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.h
@@ -186,9 +186,11 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     HexagonalOps(const HexagonalOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const HexagonalOps&) = delete; // Move assignment Not Implemented
+    HexagonalOps(HexagonalOps&&) = delete;        // Move Constructor Not Implemented
+    HexagonalOps& operator=(const HexagonalOps&) = delete; // Copy Assignment Not Implemented
+    HexagonalOps& operator=(HexagonalOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/LaueOps.h
+++ b/Source/OrientationLib/LaueOps/LaueOps.h
@@ -221,9 +221,11 @@ class OrientationLib_EXPORT LaueOps
     void _calcDetermineHomochoricValues(uint64_t seed, float init[3], float step[3], int32_t phi[3], int choose, float& r1, float& r2, float& r3);
     int _calcODFBin(float dim[3], float bins[3], float step[3], FOrientArrayType homochoric);
 
-  private:
+  public:
     LaueOps(const LaueOps&) = delete;        // Copy Constructor Not Implemented
-    void operator=(const LaueOps&) = delete; // Move assignment Not Implemented
+    LaueOps(LaueOps&&) = delete;             // Move Constructor Not Implemented
+    LaueOps& operator=(const LaueOps&) = delete; // Copy Assignment Not Implemented
+    LaueOps& operator=(LaueOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.h
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.h
@@ -180,9 +180,11 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
     float _calcMisoQuat(const QuatF quatsym[24], int numsym,
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
-  private:
+  public:
     MonoclinicOps(const MonoclinicOps&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const MonoclinicOps&) = delete; // Move assignment Not Implemented
+    MonoclinicOps(MonoclinicOps&&) = delete;       // Move Constructor Not Implemented
+    MonoclinicOps& operator=(const MonoclinicOps&) = delete; // Copy Assignment Not Implemented
+    MonoclinicOps& operator=(MonoclinicOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
@@ -185,9 +185,11 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     OrthoRhombicOps(const OrthoRhombicOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OrthoRhombicOps&) = delete;  // Move assignment Not Implemented
+    OrthoRhombicOps(OrthoRhombicOps&&) = delete;      // Move Constructor Not Implemented
+    OrthoRhombicOps& operator=(const OrthoRhombicOps&) = delete; // Copy Assignment Not Implemented
+    OrthoRhombicOps& operator=(OrthoRhombicOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/SO3Sampler.h
+++ b/Source/OrientationLib/LaueOps/SO3Sampler.h
@@ -99,9 +99,11 @@ class OrientationLib_EXPORT SO3Sampler
   protected:
     SO3Sampler();
 
-  private:
+  public:
     SO3Sampler(const SO3Sampler&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const SO3Sampler&) = delete; // Move assignment Not Implemented
+    SO3Sampler(SO3Sampler&&) = delete;          // Move Constructor Not Implemented
+    SO3Sampler& operator=(const SO3Sampler&) = delete; // Copy Assignment Not Implemented
+    SO3Sampler& operator=(SO3Sampler&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.h
@@ -181,9 +181,11 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     TetragonalLowOps(const TetragonalLowOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TetragonalLowOps&) = delete;   // Move assignment Not Implemented
+    TetragonalLowOps(TetragonalLowOps&&) = delete;      // Move Constructor Not Implemented
+    TetragonalLowOps& operator=(const TetragonalLowOps&) = delete; // Copy Assignment Not Implemented
+    TetragonalLowOps& operator=(TetragonalLowOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/TetragonalOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.h
@@ -181,9 +181,11 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     TetragonalOps(const TetragonalOps&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const TetragonalOps&) = delete; // Move assignment Not Implemented
+    TetragonalOps(TetragonalOps&&) = delete;       // Move Constructor Not Implemented
+    TetragonalOps& operator=(const TetragonalOps&) = delete; // Copy Assignment Not Implemented
+    TetragonalOps& operator=(TetragonalOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/TriclinicOps.h
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.h
@@ -180,9 +180,11 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
     float _calcMisoQuat(const QuatF quatsym[24], int numsym,
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
-  private:
+  public:
     TriclinicOps(const TriclinicOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const TriclinicOps&) = delete; // Move assignment Not Implemented
+    TriclinicOps(TriclinicOps&&) = delete;        // Move Constructor Not Implemented
+    TriclinicOps& operator=(const TriclinicOps&) = delete; // Copy Assignment Not Implemented
+    TriclinicOps& operator=(TriclinicOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.h
@@ -183,9 +183,11 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     TrigonalLowOps(const TrigonalLowOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const TrigonalLowOps&) = delete; // Move assignment Not Implemented
+    TrigonalLowOps(TrigonalLowOps&&) = delete;      // Move Constructor Not Implemented
+    TrigonalLowOps& operator=(const TrigonalLowOps&) = delete; // Copy Assignment Not Implemented
+    TrigonalLowOps& operator=(TrigonalLowOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/LaueOps/TrigonalOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.h
@@ -182,9 +182,11 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
                         QuatF& q1, QuatF& q2,
                         float& n1, float& n2, float& n3);
 
-  private:
+  public:
     TrigonalOps(const TrigonalOps&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const TrigonalOps&) = delete; // Move assignment Not Implemented
+    TrigonalOps(TrigonalOps&&) = delete;         // Move Constructor Not Implemented
+    TrigonalOps& operator=(const TrigonalOps&) = delete; // Copy Assignment Not Implemented
+    TrigonalOps& operator=(TrigonalOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/OrientationMath/OrientationMath.h
+++ b/Source/OrientationLib/OrientationMath/OrientationMath.h
@@ -174,9 +174,11 @@ class OrientationLib_EXPORT OrientationMath
     OrientationMath();
 
 
-  private:
+  public:
     OrientationMath(const OrientationMath&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OrientationMath&) = delete;  // Move assignment Not Implemented
+    OrientationMath(OrientationMath&&) = delete;      // Move Constructor Not Implemented
+    OrientationMath& operator=(const OrientationMath&) = delete; // Copy Assignment Not Implemented
+    OrientationMath& operator=(OrientationMath&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/Test/GenerateFunctionList.h
+++ b/Source/OrientationLib/Test/GenerateFunctionList.h
@@ -109,7 +109,10 @@ class GenerateFunctionList
     std::vector<EntryType> m_Combinations;
     std::vector<EntryType> m_Permutations;
 
+  public:
     GenerateFunctionList(const GenerateFunctionList&) = delete; // Copy Constructor Not Implemented
-    void operator=(const GenerateFunctionList&) = delete;       // Move assignment Not Implemented
+    GenerateFunctionList(GenerateFunctionList&&) = delete;      // Move Constructor Not Implemented
+    GenerateFunctionList& operator=(const GenerateFunctionList&) = delete; // Copy Assignment Not Implemented
+    GenerateFunctionList& operator=(GenerateFunctionList&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/OrientationLib/Texture/TexturePreset.h
+++ b/Source/OrientationLib/Texture/TexturePreset.h
@@ -85,9 +85,11 @@ class OrientationLib_EXPORT TexturePreset
   protected:
     TexturePreset();
 
-  private:
+  public:
     TexturePreset(const TexturePreset&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const TexturePreset&) = delete; // Move assignment Not Implemented
+    TexturePreset(TexturePreset&&) = delete;       // Move Constructor Not Implemented
+    TexturePreset& operator=(const TexturePreset&) = delete; // Copy Assignment Not Implemented
+    TexturePreset& operator=(TexturePreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/Utilities/ComputeStereographicProjection.h
+++ b/Source/OrientationLib/Utilities/ComputeStereographicProjection.h
@@ -71,6 +71,12 @@ class OrientationLib_EXPORT ComputeStereographicProjection
     FloatArrayType*     m_XYZCoords = nullptr;
     PoleFigureConfiguration_t* m_Config = nullptr;
     DoubleArrayType*    m_Intensity = nullptr;
+
+  public:
+    ComputeStereographicProjection(const ComputeStereographicProjection&) = delete; // Copy Constructor Not Implemented
+    ComputeStereographicProjection(ComputeStereographicProjection&&) = default;
+    ComputeStereographicProjection& operator=(const ComputeStereographicProjection&) = delete; // Copy Assignment Not Implemented
+    ComputeStereographicProjection& operator=(ComputeStereographicProjection&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/Utilities/LambertUtilities.h
+++ b/Source/OrientationLib/Utilities/LambertUtilities.h
@@ -70,8 +70,10 @@ class OrientationLib_EXPORT LambertUtilities
       LambertUtilities();
 
 
-  private:
+  public:
     LambertUtilities(const LambertUtilities&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LambertUtilities&) = delete;   // Move assignment Not Implemented
+    LambertUtilities(LambertUtilities&&) = delete;      // Move Constructor Not Implemented
+    LambertUtilities& operator=(const LambertUtilities&) = delete; // Copy Assignment Not Implemented
+    LambertUtilities& operator=(LambertUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/OrientationLib/Utilities/ModifiedLambertProjection.h
+++ b/Source/OrientationLib/Utilities/ModifiedLambertProjection.h
@@ -186,8 +186,11 @@ class OrientationLib_EXPORT ModifiedLambertProjection
     DoubleArrayType::Pointer m_NorthSquare;
     DoubleArrayType::Pointer m_SouthSquare;
 
+  public:
     ModifiedLambertProjection(const ModifiedLambertProjection&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ModifiedLambertProjection&) = delete;            // Move assignment Not Implemented
+    ModifiedLambertProjection(ModifiedLambertProjection&&) = delete;      // Move Constructor Not Implemented
+    ModifiedLambertProjection& operator=(const ModifiedLambertProjection&) = delete; // Copy Assignment Not Implemented
+    ModifiedLambertProjection& operator=(ModifiedLambertProjection&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/Utilities/ModifiedLambertProjectionArray.h
+++ b/Source/OrientationLib/Utilities/ModifiedLambertProjectionArray.h
@@ -363,8 +363,11 @@ class OrientationLib_EXPORT ModifiedLambertProjectionArray : public IDataArray
     QString m_Name;
     bool m_IsAllocated;
 
+  public:
     ModifiedLambertProjectionArray(const ModifiedLambertProjectionArray&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ModifiedLambertProjectionArray&) = delete;                 // Move assignment Not Implemented
+    ModifiedLambertProjectionArray(ModifiedLambertProjectionArray&&) = delete;      // Move Constructor Not Implemented
+    ModifiedLambertProjectionArray& operator=(const ModifiedLambertProjectionArray&) = delete; // Copy Assignment Not Implemented
+    ModifiedLambertProjectionArray& operator=(ModifiedLambertProjectionArray&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/OrientationLib/Utilities/PoleFigureUtilities.h
+++ b/Source/OrientationLib/Utilities/PoleFigureUtilities.h
@@ -131,9 +131,11 @@ class OrientationLib_EXPORT PoleFigureUtilities
     void GenerateOrthoPoleFigures(FloatArrayType* eulers, int lambertDimension, int poleFigureDim, DoubleArrayType::Pointer& intensity100, DoubleArrayType::Pointer& intensity010,
                                   DoubleArrayType::Pointer& intensity001);
 
-  private:
+  public:
     PoleFigureUtilities(const PoleFigureUtilities&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PoleFigureUtilities&) = delete;      // Move assignment Not Implemented
+    PoleFigureUtilities(PoleFigureUtilities&&) = delete;      // Move Constructor Not Implemented
+    PoleFigureUtilities& operator=(const PoleFigureUtilities&) = delete; // Copy Assignment Not Implemented
+    PoleFigureUtilities& operator=(PoleFigureUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 
 /**

--- a/Source/Plugins/EMMPM/EMMPMFilters/EMMPMFilter.h
+++ b/Source/Plugins/EMMPM/EMMPMFilters/EMMPMFilter.h
@@ -261,7 +261,9 @@ private:
 
   EMMPM_Data::Pointer m_Data;
 
-  EMMPMFilter(const EMMPMFilter&);    // Copy Constructor Not Implemented
+public:
+  EMMPMFilter(const EMMPMFilter&) = delete;            // Copy Constructor Not Implemented
+  EMMPMFilter(EMMPMFilter&&) = delete;                 // Move Constructor Not Implemented
   EMMPMFilter& operator=(const EMMPMFilter&) = delete; // Copy Assignment Not Implemented
   EMMPMFilter& operator=(EMMPMFilter&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/EMMPM/EMMPMFilters/MultiEmmpmFilter.h
+++ b/Source/Plugins/EMMPM/EMMPMFilters/MultiEmmpmFilter.h
@@ -155,7 +155,10 @@ private:
   DEFINE_DATAARRAY_VARIABLE(uint8_t, InputImage)
   DEFINE_DATAARRAY_VARIABLE(uint8_t, OutputImage)
 
+public:
   MultiEmmpmFilter(const MultiEmmpmFilter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const MultiEmmpmFilter&);            // Move assignment Not Implemented
+  MultiEmmpmFilter(MultiEmmpmFilter&&) = delete;      // Move Constructor Not Implemented
+  MultiEmmpmFilter& operator=(const MultiEmmpmFilter&) = delete; // Copy Assignment Not Implemented
+  MultiEmmpmFilter& operator=(MultiEmmpmFilter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Common/EMMPMInputParser.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Common/EMMPMInputParser.h
@@ -96,8 +96,10 @@ class EMMPMLib_EXPORT EMMPMInputParser
      */
     char* copyFilenameToNewCharBuffer( const std::string& fname);
 
-  private:
+  public:
     EMMPMInputParser(const EMMPMInputParser&) = delete; // Copy Constructor Not Implemented
-    void operator=(const EMMPMInputParser&) = delete;   // Move assignment Not Implemented
+    EMMPMInputParser(EMMPMInputParser&&) = delete;      // Move Constructor Not Implemented
+    EMMPMInputParser& operator=(const EMMPMInputParser&) = delete; // Copy Assignment Not Implemented
+    EMMPMInputParser& operator=(EMMPMInputParser&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Common/StatsDelegate.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Common/StatsDelegate.h
@@ -60,8 +60,10 @@ class EMMPMLib_EXPORT StatsDelegate
 
     StatsDelegate();
 
-  private:
+  public:
     StatsDelegate(const StatsDelegate&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const StatsDelegate&) = delete; // Move assignment Not Implemented
+    StatsDelegate(StatsDelegate&&) = delete;       // Move Constructor Not Implemented
+    StatsDelegate& operator=(const StatsDelegate&) = delete; // Copy Assignment Not Implemented
+    StatsDelegate& operator=(StatsDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Core/EMCalculation.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Core/EMCalculation.h
@@ -88,8 +88,10 @@ class EMMPMLib_EXPORT EMCalculation : public Observable
   protected:
     EMCalculation();
 
-  private:
+  public:
     EMCalculation(const EMCalculation&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const EMCalculation&) = delete; // Move assignment Not Implemented
+    EMCalculation(EMCalculation&&) = delete;       // Move Constructor Not Implemented
+    EMCalculation& operator=(const EMCalculation&) = delete; // Copy Assignment Not Implemented
+    EMCalculation& operator=(EMCalculation&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPM.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPM.h
@@ -89,9 +89,11 @@ class EMMPMLib_EXPORT EMMPM : public Observable
   protected:
     EMMPM();
 
-  private:
+  public:
     EMMPM(const EMMPM&) = delete;          // Copy Constructor Not Implemented
-    void operator=(const EMMPM&) = delete; // Move assignment Not Implemented
+    EMMPM(EMMPM&&) = delete;               // Move Constructor Not Implemented
+    EMMPM& operator=(const EMMPM&) = delete; // Copy Assignment Not Implemented
+    EMMPM& operator=(EMMPM&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPMUtilities.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPMUtilities.h
@@ -129,8 +129,10 @@ class EMMPMLib_EXPORT EMMPMUtilities
     {
     }
 
-  private:
+  public:
     EMMPMUtilities(const EMMPMUtilities&) = delete; // Copy Constructor Not Implemented
-    void operator=(const EMMPMUtilities&) = delete; // Move assignment Not Implemented
+    EMMPMUtilities(EMMPMUtilities&&) = delete;      // Move Constructor Not Implemented
+    EMMPMUtilities& operator=(const EMMPMUtilities&) = delete; // Copy Assignment Not Implemented
+    EMMPMUtilities& operator=(EMMPMUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPM_Data.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Core/EMMPM_Data.h
@@ -189,8 +189,10 @@ class EMMPMLib_EXPORT EMMPM_Data
 
   protected:
     EMMPM_Data();
-  private:
+  public:
     EMMPM_Data(const EMMPM_Data&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const EMMPM_Data&) = delete; // Move assignment Not Implemented
+    EMMPM_Data(EMMPM_Data&&) = delete;          // Move Constructor Not Implemented
+    EMMPM_Data& operator=(const EMMPM_Data&) = delete; // Copy Assignment Not Implemented
+    EMMPM_Data& operator=(EMMPM_Data&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMLib/Core/MPMCalculation.h
+++ b/Source/Plugins/EMMPM/EMMPMLib/Core/MPMCalculation.h
@@ -86,7 +86,10 @@ class EMMPMLib_EXPORT MPMCalculation : public Observable
                   int colStart, int colEnd,
                   real_t* yk);
 
+  public:
     MPMCalculation(const MPMCalculation&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MPMCalculation&) = delete; // Move assignment Not Implemented
+    MPMCalculation(MPMCalculation&&) = delete;      // Move Constructor Not Implemented
+    MPMCalculation& operator=(const MPMCalculation&) = delete; // Copy Assignment Not Implemented
+    MPMCalculation& operator=(MPMCalculation&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/EMMPMPlugin.h
+++ b/Source/Plugins/EMMPM/EMMPMPlugin.h
@@ -156,7 +156,10 @@ class EMMPM_EXPORT EMMPMPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     EMMPMPlugin(const EMMPMPlugin&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const EMMPMPlugin&) = delete; // Move assignment Not Implemented
+    EMMPMPlugin(EMMPMPlugin&&) = delete;         // Move Constructor Not Implemented
+    EMMPMPlugin& operator=(const EMMPMPlugin&) = delete; // Copy Assignment Not Implemented
+    EMMPMPlugin& operator=(EMMPMPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/FilterParameters/EMMPMFilterParameter.h
+++ b/Source/Plugins/EMMPM/FilterParameters/EMMPMFilterParameter.h
@@ -98,8 +98,10 @@ class EMMPMFilterParameter : public FilterParameter
      */
     EMMPMFilterParameter();
 
-  private:
+  public:
     EMMPMFilterParameter(const EMMPMFilterParameter&) = delete; // Copy Constructor Not Implemented
-    void operator=(const EMMPMFilterParameter&) = delete;       // Move assignment Not Implemented
+    EMMPMFilterParameter(EMMPMFilterParameter&&) = delete;      // Move Constructor Not Implemented
+    EMMPMFilterParameter& operator=(const EMMPMFilterParameter&) = delete; // Copy Assignment Not Implemented
+    EMMPMFilterParameter& operator=(EMMPMFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/EMMPM/Gui/FilterParameterWidgets/EMMPMWidget.h
+++ b/Source/Plugins/EMMPM/Gui/FilterParameterWidgets/EMMPMWidget.h
@@ -108,7 +108,10 @@ private:
 
   DynamicTableData getDynamicTableData(QTableWidget* tableWidget);
 
-  EMMPMWidget(const EMMPMWidget&);             // Copy Constructor Not Implemented
-  void operator=(const EMMPMWidget&) = delete; // Move assignment Not Implemented
+public:
+  EMMPMWidget(const EMMPMWidget&) = delete;            // Copy Constructor Not Implemented
+  EMMPMWidget(EMMPMWidget&&) = delete;                 // Move Constructor Not Implemented
+  EMMPMWidget& operator=(const EMMPMWidget&) = delete; // Copy Assignment Not Implemented
+  EMMPMWidget& operator=(EMMPMWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Generic/GenericPlugin.h
+++ b/Source/Plugins/Generic/GenericPlugin.h
@@ -184,7 +184,10 @@ class Generic_EXPORT GenericPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     GenericPlugin(const GenericPlugin&) = delete;  // Copy Constructor Not Implemented
-    void operator=(const GenericPlugin&) = delete; // Move assignment Not Implemented
+    GenericPlugin(GenericPlugin&&) = delete;       // Move Constructor Not Implemented
+    GenericPlugin& operator=(const GenericPlugin&) = delete; // Copy Assignment Not Implemented
+    GenericPlugin& operator=(GenericPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/Gui/FilterParameterWidgets/ReadASCIIDataWidget.h
+++ b/Source/Plugins/IO/Gui/FilterParameterWidgets/ReadASCIIDataWidget.h
@@ -94,7 +94,10 @@ private:
   QThread* m_WorkerThread;
   LineCounterObject* m_LineCounter;
 
+public:
   ReadASCIIDataWidget(const ReadASCIIDataWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ReadASCIIDataWidget&) = delete;      // Move assignment Not Implemented
+  ReadASCIIDataWidget(ReadASCIIDataWidget&&) = delete;      // Move Constructor Not Implemented
+  ReadASCIIDataWidget& operator=(const ReadASCIIDataWidget&) = delete; // Copy Assignment Not Implemented
+  ReadASCIIDataWidget& operator=(ReadASCIIDataWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/DxReader.h
+++ b/Source/Plugins/IO/IOFilters/DxReader.h
@@ -201,7 +201,10 @@ private:
   size_t m_Dims[3];
   QFile m_InStream;
 
-  DxReader(const DxReader&);       // Copy Constructor Not Implemented
-  void operator=(const DxReader&) = delete; // Move assignment Not Implemented
+public:
+  DxReader(const DxReader&) = delete;            // Copy Constructor Not Implemented
+  DxReader(DxReader&&) = delete;                 // Move Constructor Not Implemented
+  DxReader& operator=(const DxReader&) = delete; // Copy Assignment Not Implemented
+  DxReader& operator=(DxReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/DxWriter.h
+++ b/Source/Plugins/IO/IOFilters/DxWriter.h
@@ -149,7 +149,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-  DxWriter(const DxWriter&);       // Copy Constructor Not Implemented
-  void operator=(const DxWriter&) = delete; // Move assignment Not Implemented
+public:
+  DxWriter(const DxWriter&) = delete;            // Copy Constructor Not Implemented
+  DxWriter(DxWriter&&) = delete;                 // Move Constructor Not Implemented
+  DxWriter& operator=(const DxWriter&) = delete; // Copy Assignment Not Implemented
+  DxWriter& operator=(DxWriter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/ImportAvxmMDSim.h
+++ b/Source/Plugins/IO/IOFilters/ImportAvxmMDSim.h
@@ -146,6 +146,7 @@ public:
   /* Rule of 5: All special member functions should be defined if any are defined.
    * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all
    */
+public:
   ImportAvxmMDSim(const ImportAvxmMDSim&) = delete;            // Copy Constructor
   ImportAvxmMDSim& operator=(const ImportAvxmMDSim&) = delete; // Copy Assignment
   ImportAvxmMDSim(ImportAvxmMDSim&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/IO/IOFilters/LammpsFileWriter.h
+++ b/Source/Plugins/IO/IOFilters/LammpsFileWriter.h
@@ -174,7 +174,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   LammpsFileWriter(const LammpsFileWriter&) = delete; // Copy Constructor Not Implemented
   LammpsFileWriter(LammpsFileWriter&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/IO/IOFilters/LosAlamosFFTWriter.h
+++ b/Source/Plugins/IO/IOFilters/LosAlamosFFTWriter.h
@@ -156,7 +156,10 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, CellPhases)
   DEFINE_DATAARRAY_VARIABLE(float, CellEulerAngles)
 
+public:
   LosAlamosFFTWriter(const LosAlamosFFTWriter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const LosAlamosFFTWriter&);              // Move assignment Not Implemented
+  LosAlamosFFTWriter(LosAlamosFFTWriter&&) = delete;      // Move Constructor Not Implemented
+  LosAlamosFFTWriter& operator=(const LosAlamosFFTWriter&) = delete; // Copy Assignment Not Implemented
+  LosAlamosFFTWriter& operator=(LosAlamosFFTWriter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/PhReader.h
+++ b/Source/Plugins/IO/IOFilters/PhReader.h
@@ -200,7 +200,10 @@ private:
   size_t m_Dims[3];
   FILE* m_InStream;
 
-  PhReader(const PhReader&);       // Not Implemented
-  void operator=(const PhReader&); // Not Implemented
+public:
+  PhReader(const PhReader&) = delete;            // Copy Constructor Not Implemented
+  PhReader(PhReader&&) = delete;                 // Move Constructor Not Implemented
+  PhReader& operator=(const PhReader&) = delete; // Copy Assignment Not Implemented
+  PhReader& operator=(PhReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/PhWriter.h
+++ b/Source/Plugins/IO/IOFilters/PhWriter.h
@@ -145,7 +145,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
-  PhWriter(const PhWriter&);       // Copy Constructor Not Implemented
-  void operator=(const PhWriter&) = delete; // Move assignment Not Implemented
+public:
+  PhWriter(const PhWriter&) = delete;            // Copy Constructor Not Implemented
+  PhWriter(PhWriter&&) = delete;                 // Move Constructor Not Implemented
+  PhWriter& operator=(const PhWriter&) = delete; // Copy Assignment Not Implemented
+  PhWriter& operator=(PhWriter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/ReadStlFile.h
+++ b/Source/Plugins/IO/IOFilters/ReadStlFile.h
@@ -197,7 +197,9 @@ private:
    */
   void eliminate_duplicate_nodes();
 
-  ReadStlFile(const ReadStlFile&);    // Copy Constructor Not Implemented
+public:
+  ReadStlFile(const ReadStlFile&) = delete;            // Copy Constructor Not Implemented
+  ReadStlFile(ReadStlFile&&) = delete;                 // Move Constructor Not Implemented
   ReadStlFile& operator=(const ReadStlFile&) = delete; // Copy Assignment Not Implemented
   ReadStlFile& operator=(ReadStlFile&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/IO/IOFilters/SPParksSitesWriter.h
+++ b/Source/Plugins/IO/IOFilters/SPParksSitesWriter.h
@@ -146,7 +146,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
+public:
   SPParksSitesWriter(const SPParksSitesWriter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SPParksSitesWriter&);              // Move assignment Not Implemented
+  SPParksSitesWriter(SPParksSitesWriter&&) = delete;      // Move Constructor Not Implemented
+  SPParksSitesWriter& operator=(const SPParksSitesWriter&) = delete; // Copy Assignment Not Implemented
+  SPParksSitesWriter& operator=(SPParksSitesWriter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/VASPReader.h
+++ b/Source/Plugins/IO/IOFilters/VASPReader.h
@@ -186,7 +186,10 @@ class IO_EXPORT VASPReader : public FileReader
     QVector<int> atomNumbers;
     int totalAtoms;
 
+  public:
     VASPReader(const VASPReader&) = delete;     // Copy Constructor Not Implemented
-    void operator=(const VASPReader&) = delete; // Move assignment Not Implemented
+    VASPReader(VASPReader&&) = delete;          // Move Constructor Not Implemented
+    VASPReader& operator=(const VASPReader&) = delete; // Copy Assignment Not Implemented
+    VASPReader& operator=(VASPReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/IOFilters/WriteStlFile.h
+++ b/Source/Plugins/IO/IOFilters/WriteStlFile.h
@@ -209,7 +209,9 @@ private:
    */
   int32_t writeNumTrianglesToFile(const QString& filename, int32_t triCount);
 
-  WriteStlFile(const WriteStlFile&);   // Copy Constructor Not Implemented
+public:
+  WriteStlFile(const WriteStlFile&) = delete;            // Copy Constructor Not Implemented
+  WriteStlFile(WriteStlFile&&) = delete;                 // Move Constructor Not Implemented
   WriteStlFile& operator=(const WriteStlFile&) = delete; // Copy Assignment Not Implemented
   WriteStlFile& operator=(WriteStlFile&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/IO/IOFilters/util/IOSupport.h
+++ b/Source/Plugins/IO/IOFilters/util/IOSupport.h
@@ -90,9 +90,11 @@ class  IOSupport : public Observable
   protected:
     IOSupport();
 
-  private:
+  public:
     IOSupport(const IOSupport&) = delete;      // Copy Constructor Not Implemented
-    void operator=(const IOSupport&) = delete; // Move assignment Not Implemented
+    IOSupport(IOSupport&&) = delete;           // Move Constructor Not Implemented
+    IOSupport& operator=(const IOSupport&) = delete; // Copy Assignment Not Implemented
+    IOSupport& operator=(IOSupport&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/IO/IOPlugin.h
+++ b/Source/Plugins/IO/IOPlugin.h
@@ -186,7 +186,10 @@ class IO_EXPORT IOPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     IOPlugin(const IOPlugin&) = delete;       // Copy Constructor Not Implemented
-    void operator=(const IOPlugin&) = delete; // Move assignment Not Implemented
+    IOPlugin(IOPlugin&&) = delete;            // Move Constructor Not Implemented
+    IOPlugin& operator=(const IOPlugin&) = delete; // Copy Assignment Not Implemented
+    IOPlugin& operator=(IOPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/IO/Test/GenerateFeatureIds.h
+++ b/Source/Plugins/IO/Test/GenerateFeatureIds.h
@@ -224,6 +224,6 @@ protected:
 
 private:
   CreateImageGeomDataContainer(const CreateImageGeomDataContainer&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CreateImageGeomDataContainer&);               // Move assignment Not Implemented
+  void operator=(const CreateImageGeomDataContainer&) = delete;               // Move assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/ConvertHexGridToSquareGridFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/ConvertHexGridToSquareGridFilterParameter.h
@@ -75,8 +75,10 @@ public:
 protected:
   ConvertHexGridToSquareGridFilterParameter();
 
-private:
+public:
   ConvertHexGridToSquareGridFilterParameter(const ConvertHexGridToSquareGridFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ConvertHexGridToSquareGridFilterParameter&) = delete;                            // Move assignment Not Implemented
+  ConvertHexGridToSquareGridFilterParameter(ConvertHexGridToSquareGridFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ConvertHexGridToSquareGridFilterParameter& operator=(const ConvertHexGridToSquareGridFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ConvertHexGridToSquareGridFilterParameter& operator=(ConvertHexGridToSquareGridFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdToH5EbsdFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdToH5EbsdFilterParameter.h
@@ -76,8 +76,10 @@ public:
 protected:
   EbsdToH5EbsdFilterParameter();
 
-private:
+public:
   EbsdToH5EbsdFilterParameter(const EbsdToH5EbsdFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EbsdToH5EbsdFilterParameter&) = delete;              // Move assignment Not Implemented
+  EbsdToH5EbsdFilterParameter(EbsdToH5EbsdFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  EbsdToH5EbsdFilterParameter& operator=(const EbsdToH5EbsdFilterParameter&) = delete; // Copy Assignment Not Implemented
+  EbsdToH5EbsdFilterParameter& operator=(EbsdToH5EbsdFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/EnsembleInfoFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/EnsembleInfoFilterParameter.h
@@ -140,8 +140,10 @@ protected:
    */
   EnsembleInfoFilterParameter();
 
-private:
+public:
   EnsembleInfoFilterParameter(const EnsembleInfoFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EnsembleInfoFilterParameter&);                       // Move assignment Not Implemented
+  EnsembleInfoFilterParameter(EnsembleInfoFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  EnsembleInfoFilterParameter& operator=(const EnsembleInfoFilterParameter&) = delete; // Copy Assignment Not Implemented
+  EnsembleInfoFilterParameter& operator=(EnsembleInfoFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/OrientationUtilityFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/OrientationUtilityFilterParameter.h
@@ -55,8 +55,10 @@ public:
 protected:
   OrientationUtilityFilterParameter();
 
-private:
+public:
   OrientationUtilityFilterParameter(const OrientationUtilityFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OrientationUtilityFilterParameter&) = delete;                    // Move assignment Not Implemented
+  OrientationUtilityFilterParameter(OrientationUtilityFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  OrientationUtilityFilterParameter& operator=(const OrientationUtilityFilterParameter&) = delete; // Copy Assignment Not Implemented
+  OrientationUtilityFilterParameter& operator=(OrientationUtilityFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/ReadEdaxH5DataFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/ReadEdaxH5DataFilterParameter.h
@@ -76,8 +76,10 @@ public:
 protected:
   ReadEdaxH5DataFilterParameter();
 
-private:
+public:
   ReadEdaxH5DataFilterParameter(const ReadEdaxH5DataFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ReadEdaxH5DataFilterParameter&) = delete;                // Move assignment Not Implemented
+  ReadEdaxH5DataFilterParameter(ReadEdaxH5DataFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ReadEdaxH5DataFilterParameter& operator=(const ReadEdaxH5DataFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ReadEdaxH5DataFilterParameter& operator=(ReadEdaxH5DataFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/ReadH5EbsdFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/ReadH5EbsdFilterParameter.h
@@ -86,8 +86,10 @@ public:
 protected:
   ReadH5EbsdFilterParameter();
 
-private:
+public:
   ReadH5EbsdFilterParameter(const ReadH5EbsdFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ReadH5EbsdFilterParameter&);                     // Move assignment Not Implemented
+  ReadH5EbsdFilterParameter(ReadH5EbsdFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  ReadH5EbsdFilterParameter& operator=(const ReadH5EbsdFilterParameter&) = delete; // Copy Assignment Not Implemented
+  ReadH5EbsdFilterParameter& operator=(ReadH5EbsdFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.h
@@ -178,7 +178,10 @@ class ConvertHexGridToSquareGridWidget : public FilterParameterWidget, private U
 
     bool m_DidCausePreflight;
 
+  public:
     ConvertHexGridToSquareGridWidget(const ConvertHexGridToSquareGridWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConvertHexGridToSquareGridWidget&) = delete;                   // Move assignment Not Implemented
+    ConvertHexGridToSquareGridWidget(ConvertHexGridToSquareGridWidget&&) = delete;      // Move Constructor Not Implemented
+    ConvertHexGridToSquareGridWidget& operator=(const ConvertHexGridToSquareGridWidget&) = delete; // Copy Assignment Not Implemented
+    ConvertHexGridToSquareGridWidget& operator=(ConvertHexGridToSquareGridWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdToH5EbsdWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdToH5EbsdWidget.h
@@ -208,7 +208,10 @@ class EbsdToH5EbsdWidget : public FilterParameterWidget, private Ui::EbsdToH5Ebs
     QString  m_CurrentText = "";
     bool     m_DidCausePreflight = false;
 
+  public:
     EbsdToH5EbsdWidget(const EbsdToH5EbsdWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const EbsdToH5EbsdWidget&) = delete;     // Move assignment Not Implemented
+    EbsdToH5EbsdWidget(EbsdToH5EbsdWidget&&) = delete;      // Move Constructor Not Implemented
+    EbsdToH5EbsdWidget& operator=(const EbsdToH5EbsdWidget&) = delete; // Copy Assignment Not Implemented
+    EbsdToH5EbsdWidget& operator=(EbsdToH5EbsdWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoCreationWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoCreationWidget.h
@@ -176,7 +176,10 @@ private:
    */
   EnsembleInfoTableModel* createEnsembleInfoModel();
 
+public:
   EnsembleInfoCreationWidget(const EnsembleInfoCreationWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EnsembleInfoCreationWidget&);                      // Move assignment Not Implemented
+  EnsembleInfoCreationWidget(EnsembleInfoCreationWidget&&) = delete;      // Move Constructor Not Implemented
+  EnsembleInfoCreationWidget& operator=(const EnsembleInfoCreationWidget&) = delete; // Copy Assignment Not Implemented
+  EnsembleInfoCreationWidget& operator=(EnsembleInfoCreationWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoItemDelegate.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoItemDelegate.h
@@ -83,7 +83,10 @@ private:
   QStringList m_PhaseTypeList;
   int m_NumberOfPhases;
 
+public:
   EnsembleInfoItemDelegate(const EnsembleInfoItemDelegate&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EnsembleInfoItemDelegate&);                    // Move assignment Not Implemented
+  EnsembleInfoItemDelegate(EnsembleInfoItemDelegate&&) = delete;      // Move Constructor Not Implemented
+  EnsembleInfoItemDelegate& operator=(const EnsembleInfoItemDelegate&) = delete; // Copy Assignment Not Implemented
+  EnsembleInfoItemDelegate& operator=(EnsembleInfoItemDelegate&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoTableModel.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoTableModel.h
@@ -162,7 +162,10 @@ private:
 
   EnsembleInfo m_EnsembleInfo;
 
+public:
   EnsembleInfoTableModel(const EnsembleInfoTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EnsembleInfoTableModel&);                  // Move assignment Not Implemented
+  EnsembleInfoTableModel(EnsembleInfoTableModel&&) = delete;      // Move Constructor Not Implemented
+  EnsembleInfoTableModel& operator=(const EnsembleInfoTableModel&) = delete; // Copy Assignment Not Implemented
+  EnsembleInfoTableModel& operator=(EnsembleInfoTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/OrientationUtilityWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/OrientationUtilityWidget.h
@@ -86,7 +86,10 @@ private:
 
   QList<OrientationWidget*> m_OrientationWidgets;
 
+public:
   OrientationUtilityWidget(const OrientationUtilityWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OrientationUtilityWidget&) = delete;           // Move assignment Not Implemented
+  OrientationUtilityWidget(OrientationUtilityWidget&&) = delete;      // Move Constructor Not Implemented
+  OrientationUtilityWidget& operator=(const OrientationUtilityWidget&) = delete; // Copy Assignment Not Implemented
+  OrientationUtilityWidget& operator=(OrientationUtilityWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadEdaxH5DataWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadEdaxH5DataWidget.h
@@ -93,8 +93,11 @@ class ReadEdaxH5DataWidget : public FilterParameterWidget, private Ui::ReadEdaxH
 
     void sortList(DREAM3DListWidget* listWidget, Qt::SortOrder order);
 
+  public:
     ReadEdaxH5DataWidget(const ReadEdaxH5DataWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ReadEdaxH5DataWidget&) = delete;       // Move assignment Not Implemented
+    ReadEdaxH5DataWidget(ReadEdaxH5DataWidget&&) = delete;      // Move Constructor Not Implemented
+    ReadEdaxH5DataWidget& operator=(const ReadEdaxH5DataWidget&) = delete; // Copy Assignment Not Implemented
+    ReadEdaxH5DataWidget& operator=(ReadEdaxH5DataWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadH5EbsdWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadH5EbsdWidget.h
@@ -175,8 +175,11 @@ class ReadH5EbsdWidget : public FilterParameterWidget, private Ui::ReadH5EbsdWid
     bool m_NewFileLoaded;
     bool m_Version4Warning;
 
+  public:
     ReadH5EbsdWidget(const ReadH5EbsdWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ReadH5EbsdWidget&) = delete;   // Move assignment Not Implemented
+    ReadH5EbsdWidget(ReadH5EbsdWidget&&) = delete;      // Move Constructor Not Implemented
+    ReadH5EbsdWidget& operator=(const ReadH5EbsdWidget&) = delete; // Copy Assignment Not Implemented
+    ReadH5EbsdWidget& operator=(ReadH5EbsdWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/AxisAngleWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/AxisAngleWidget.h
@@ -58,7 +58,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   AxisAngleWidget(const AxisAngleWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AxisAngleWidget&) = delete;  // Move assignment Not Implemented
+  AxisAngleWidget(AxisAngleWidget&&) = delete;      // Move Constructor Not Implemented
+  AxisAngleWidget& operator=(const AxisAngleWidget&) = delete; // Copy Assignment Not Implemented
+  AxisAngleWidget& operator=(AxisAngleWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/CubochoricWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/CubochoricWidget.h
@@ -59,7 +59,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   CubochoricWidget(const CubochoricWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CubochoricWidget&) = delete;   // Move assignment Not Implemented
+  CubochoricWidget(CubochoricWidget&&) = delete;      // Move Constructor Not Implemented
+  CubochoricWidget& operator=(const CubochoricWidget&) = delete; // Copy Assignment Not Implemented
+  CubochoricWidget& operator=(CubochoricWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/EulerWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/EulerWidget.h
@@ -61,7 +61,10 @@ private:
   QVector<double> toDegrees(QVector<double> data);
   QVector<double> toRadians(QVector<double> data);
 
+public:
   EulerWidget(const EulerWidget&) = delete;    // Copy Constructor Not Implemented
-  void operator=(const EulerWidget&) = delete; // Move assignment Not Implemented
+  EulerWidget(EulerWidget&&) = delete;         // Move Constructor Not Implemented
+  EulerWidget& operator=(const EulerWidget&) = delete; // Copy Assignment Not Implemented
+  EulerWidget& operator=(EulerWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/HomochoricWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/HomochoricWidget.h
@@ -57,7 +57,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   HomochoricWidget(const HomochoricWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const HomochoricWidget&) = delete;   // Move assignment Not Implemented
+  HomochoricWidget(HomochoricWidget&&) = delete;      // Move Constructor Not Implemented
+  HomochoricWidget& operator=(const HomochoricWidget&) = delete; // Copy Assignment Not Implemented
+  HomochoricWidget& operator=(HomochoricWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OmWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OmWidget.h
@@ -57,7 +57,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   OmWidget(const OmWidget&) = delete;       // Copy Constructor Not Implemented
-  void operator=(const OmWidget&) = delete; // Move assignment Not Implemented
+  OmWidget(OmWidget&&) = delete;            // Move Constructor Not Implemented
+  OmWidget& operator=(const OmWidget&) = delete; // Copy Assignment Not Implemented
+  OmWidget& operator=(OmWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.h
@@ -64,7 +64,10 @@ private:
   OrientationConverter<double>::OrientationType m_InputType;
   bool m_HasErrors;
 
+public:
   OrientationUtilityCalculator(const OrientationUtilityCalculator&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OrientationUtilityCalculator&) = delete;               // Move assignment Not Implemented
+  OrientationUtilityCalculator(OrientationUtilityCalculator&&) = delete;      // Move Constructor Not Implemented
+  OrientationUtilityCalculator& operator=(const OrientationUtilityCalculator&) = delete; // Copy Assignment Not Implemented
+  OrientationUtilityCalculator& operator=(OrientationUtilityCalculator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationWidget.h
@@ -67,8 +67,10 @@ protected slots:
   virtual void updateData(OrientationUtilityCalculator* calculator);
   void updateAngleMeasurement(bool isRadians);
 
-private:
+public:
   OrientationWidget(const OrientationWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OrientationWidget&) = delete;    // Move assignment Not Implemented
+  OrientationWidget(OrientationWidget&&) = delete;      // Move Constructor Not Implemented
+  OrientationWidget& operator=(const OrientationWidget&) = delete; // Copy Assignment Not Implemented
+  OrientationWidget& operator=(OrientationWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/QEbsdReferenceFrameDialog.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/QEbsdReferenceFrameDialog.h
@@ -123,7 +123,10 @@ private:
   QImage m_BaseImage;
   QImage m_DisplayedImage;
 
+public:
   QEbsdReferenceFrameDialog(const QEbsdReferenceFrameDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const QEbsdReferenceFrameDialog&);                     // Move assignment Not Implemented
+  QEbsdReferenceFrameDialog(QEbsdReferenceFrameDialog&&) = delete;      // Move Constructor Not Implemented
+  QEbsdReferenceFrameDialog& operator=(const QEbsdReferenceFrameDialog&) = delete; // Copy Assignment Not Implemented
+  QEbsdReferenceFrameDialog& operator=(QEbsdReferenceFrameDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/QuatWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/QuatWidget.h
@@ -57,7 +57,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   QuatWidget(const QuatWidget&) = delete;     // Copy Constructor Not Implemented
-  void operator=(const QuatWidget&) = delete; // Move assignment Not Implemented
+  QuatWidget(QuatWidget&&) = delete;          // Move Constructor Not Implemented
+  QuatWidget& operator=(const QuatWidget&) = delete; // Copy Assignment Not Implemented
+  QuatWidget& operator=(QuatWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/RodriguesWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/RodriguesWidget.h
@@ -57,7 +57,10 @@ private:
 
   QVector<double> getValues();
 
+public:
   RodriguesWidget(const RodriguesWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RodriguesWidget&) = delete;  // Move assignment Not Implemented
+  RodriguesWidget(RodriguesWidget&&) = delete;      // Move Constructor Not Implemented
+  RodriguesWidget& operator=(const RodriguesWidget&) = delete; // Copy Assignment Not Implemented
+  RodriguesWidget& operator=(RodriguesWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.h
@@ -175,7 +175,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   ConvertOrientations(const ConvertOrientations&) = delete; // Copy Constructor Not Implemented
   ConvertOrientations(ConvertOrientations&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EbsdToH5Ebsd.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EbsdToH5Ebsd.h
@@ -190,8 +190,9 @@ protected:
    */
   void initialize();
 
-private:
-  EbsdToH5Ebsd(const EbsdToH5Ebsd&);   // Copy Constructor Not Implemented
+public:
+  EbsdToH5Ebsd(const EbsdToH5Ebsd&) = delete;            // Copy Constructor Not Implemented
+  EbsdToH5Ebsd(EbsdToH5Ebsd&&) = delete;                 // Move Constructor Not Implemented
   EbsdToH5Ebsd& operator=(const EbsdToH5Ebsd&) = delete; // Copy Assignment Not Implemented
   EbsdToH5Ebsd& operator=(EbsdToH5Ebsd&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EnsembleInfoReader.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EnsembleInfoReader.h
@@ -178,7 +178,10 @@ private:
   PhaseType::Type m_ptype;
   uint32_t m_crystruct;
 
-  EnsembleInfoReader(const EnsembleInfoReader&); // Not Implemented
-  void operator=(const EnsembleInfoReader&);     // Not Implemented
+public:
+  EnsembleInfoReader(const EnsembleInfoReader&) = delete;            // Copy Constructor Not Implemented
+  EnsembleInfoReader(EnsembleInfoReader&&) = delete;                 // Move Constructor Not Implemented
+  EnsembleInfoReader& operator=(const EnsembleInfoReader&) = delete; // Copy Assignment Not Implemented
+  EnsembleInfoReader& operator=(EnsembleInfoReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.h
@@ -176,7 +176,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(float, Quats)
   DEFINE_DATAARRAY_VARIABLE(float, AvgCAxes)
 
-  FindAvgCAxes(const FindAvgCAxes&);   // Copy Constructor Not Implemented
+public:
+  FindAvgCAxes(const FindAvgCAxes&) = delete;            // Copy Constructor Not Implemented
+  FindAvgCAxes(FindAvgCAxes&&) = delete;                 // Move Constructor Not Implemented
   FindAvgCAxes& operator=(const FindAvgCAxes&) = delete; // Copy Assignment Not Implemented
   FindAvgCAxes& operator=(FindAvgCAxes&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.h
@@ -223,7 +223,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, Poles)
   DEFINE_DATAARRAY_VARIABLE(int32_t, SlipSystems)
 
-  FindSchmids(const FindSchmids&);    // Copy Constructor Not Implemented
+public:
+  FindSchmids(const FindSchmids&) = delete;            // Copy Constructor Not Implemented
+  FindSchmids(FindSchmids&&) = delete;                 // Move Constructor Not Implemented
   FindSchmids& operator=(const FindSchmids&) = delete; // Copy Assignment Not Implemented
   FindSchmids& operator=(FindSchmids&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateOrientationMatrixTranspose.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateOrientationMatrixTranspose.h
@@ -135,6 +135,7 @@ public:
   /* Rule of 5: All special member functions should be defined if any are defined.
    * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all
    */
+public:
   GenerateOrientationMatrixTranspose(const GenerateOrientationMatrixTranspose&) = delete;            // Copy Constructor Not Implemented
   GenerateOrientationMatrixTranspose& operator=(const GenerateOrientationMatrixTranspose&) = delete; // Copy Assignment Not Implemented
   GenerateOrientationMatrixTranspose(GenerateOrientationMatrixTranspose&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateQuaternionConjugate.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateQuaternionConjugate.h
@@ -135,6 +135,7 @@ public:
   /* Rule of 5: All special member functions should be defined if any are defined.
    * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all
    */
+public:
   GenerateQuaternionConjugate(const GenerateQuaternionConjugate&) = delete;            // Copy Constructor Not Implemented
   GenerateQuaternionConjugate& operator=(const GenerateQuaternionConjugate&) = delete; // Copy Assignment Not Implemented
   GenerateQuaternionConjugate(GenerateQuaternionConjugate&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/INLWriter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/INLWriter.h
@@ -174,7 +174,10 @@ private:
 
   StringDataArray::WeakPointer m_MaterialNamePtr;
 
-  INLWriter(const INLWriter&);      // Copy Constructor Not Implemented
-  void operator=(const INLWriter&) = delete; // Move assignment Not Implemented
+public:
+  INLWriter(const INLWriter&) = delete;            // Copy Constructor Not Implemented
+  INLWriter(INLWriter&&) = delete;                 // Move Constructor Not Implemented
+  INLWriter& operator=(const INLWriter&) = delete; // Copy Assignment Not Implemented
+  INLWriter& operator=(INLWriter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/CubicIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/CubicIPFLegendPainter.h
@@ -50,8 +50,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   CubicIPFLegendPainter(const CubicIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CubicIPFLegendPainter&);                 // Move assignment Not Implemented
+  CubicIPFLegendPainter(CubicIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  CubicIPFLegendPainter& operator=(const CubicIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  CubicIPFLegendPainter& operator=(CubicIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/CubicLowIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/CubicLowIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   CubicLowIPFLegendPainter(const CubicLowIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CubicLowIPFLegendPainter&);                    // Move assignment Not Implemented
+  CubicLowIPFLegendPainter(CubicLowIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  CubicLowIPFLegendPainter& operator=(const CubicLowIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  CubicLowIPFLegendPainter& operator=(CubicLowIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/HexagonalIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/HexagonalIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   HexagonalIPFLegendPainter(const HexagonalIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const HexagonalIPFLegendPainter&);                     // Move assignment Not Implemented
+  HexagonalIPFLegendPainter(HexagonalIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  HexagonalIPFLegendPainter& operator=(const HexagonalIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  HexagonalIPFLegendPainter& operator=(HexagonalIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/HexagonalLowIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/HexagonalLowIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   HexagonalLowIPFLegendPainter(const HexagonalLowIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const HexagonalLowIPFLegendPainter&);                        // Move assignment Not Implemented
+  HexagonalLowIPFLegendPainter(HexagonalLowIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  HexagonalLowIPFLegendPainter& operator=(const HexagonalLowIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  HexagonalLowIPFLegendPainter& operator=(HexagonalLowIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/IPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/IPFLegendPainter.h
@@ -61,8 +61,10 @@ public:
  */
   void paintSymmetryDirection(const QString& text, QFontMetrics* metrics, QPainter* painter, int x, int y);
 
-private:
+public:
   IPFLegendPainter(const IPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const IPFLegendPainter&);            // Move assignment Not Implemented
+  IPFLegendPainter(IPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  IPFLegendPainter& operator=(const IPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  IPFLegendPainter& operator=(IPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/MonoclinicIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/MonoclinicIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   MonoclinicIPFLegendPainter(const MonoclinicIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const MonoclinicIPFLegendPainter&);                      // Move assignment Not Implemented
+  MonoclinicIPFLegendPainter(MonoclinicIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  MonoclinicIPFLegendPainter& operator=(const MonoclinicIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  MonoclinicIPFLegendPainter& operator=(MonoclinicIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/OrthorhombicIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/OrthorhombicIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   OrthorhombicIPFLegendPainter(const OrthorhombicIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const OrthorhombicIPFLegendPainter&);                        // Move assignment Not Implemented
+  OrthorhombicIPFLegendPainter(OrthorhombicIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  OrthorhombicIPFLegendPainter& operator=(const OrthorhombicIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  OrthorhombicIPFLegendPainter& operator=(OrthorhombicIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TetragonalIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TetragonalIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   TetragonalIPFLegendPainter(const TetragonalIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TetragonalIPFLegendPainter&);                      // Move assignment Not Implemented
+  TetragonalIPFLegendPainter(TetragonalIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  TetragonalIPFLegendPainter& operator=(const TetragonalIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  TetragonalIPFLegendPainter& operator=(TetragonalIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TetragonalLowIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TetragonalLowIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   TetragonalLowIPFLegendPainter(const TetragonalLowIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TetragonalLowIPFLegendPainter&);                         // Move assignment Not Implemented
+  TetragonalLowIPFLegendPainter(TetragonalLowIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  TetragonalLowIPFLegendPainter& operator=(const TetragonalLowIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  TetragonalLowIPFLegendPainter& operator=(TetragonalLowIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TriclinicIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TriclinicIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   TriclinicIPFLegendPainter(const TriclinicIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TriclinicIPFLegendPainter&);                     // Move assignment Not Implemented
+  TriclinicIPFLegendPainter(TriclinicIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  TriclinicIPFLegendPainter& operator=(const TriclinicIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  TriclinicIPFLegendPainter& operator=(TriclinicIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TrigonalIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TrigonalIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   TrigonalIPFLegendPainter(const TrigonalIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TrigonalIPFLegendPainter&);                    // Move assignment Not Implemented
+  TrigonalIPFLegendPainter(TrigonalIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  TrigonalIPFLegendPainter& operator=(const TrigonalIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  TrigonalIPFLegendPainter& operator=(TrigonalIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TrigonalLowIPFLegendPainter.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/IPFLegendHelpers/TrigonalLowIPFLegendPainter.h
@@ -51,8 +51,10 @@ public:
 protected:
   QImage overlayText(int pixelWidth, int pixelHeight, QImage image, LaueOps* ops);
 
-private:
+public:
   TrigonalLowIPFLegendPainter(const TrigonalLowIPFLegendPainter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TrigonalLowIPFLegendPainter&);                       // Move assignment Not Implemented
+  TrigonalLowIPFLegendPainter(TrigonalLowIPFLegendPainter&&) = delete;      // Move Constructor Not Implemented
+  TrigonalLowIPFLegendPainter& operator=(const TrigonalLowIPFLegendPainter&) = delete; // Copy Assignment Not Implemented
+  TrigonalLowIPFLegendPainter& operator=(TrigonalLowIPFLegendPainter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/OrientationUtility.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/OrientationUtility.h
@@ -124,7 +124,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   OrientationUtility(const OrientationUtility&) = delete; // Copy Constructor Not Implemented
   OrientationUtility(OrientationUtility&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.h
@@ -236,7 +236,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(uint32_t, CrystalStructures)
   DEFINE_DATAARRAY_VARIABLE(float, LatticeConstants)
 
-  ReadAngData(const ReadAngData&);    // Copy Constructor Not Implemented
+public:
+  ReadAngData(const ReadAngData&) = delete;            // Copy Constructor Not Implemented
+  ReadAngData(ReadAngData&&) = delete;                 // Move Constructor Not Implemented
   ReadAngData& operator=(const ReadAngData&) = delete; // Copy Assignment Not Implemented
   ReadAngData& operator=(ReadAngData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadCtfData.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadCtfData.h
@@ -255,7 +255,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(uint32_t, CrystalStructures)
   DEFINE_DATAARRAY_VARIABLE(float, LatticeConstants)
 
-  ReadCtfData(const ReadCtfData&);    // Copy Constructor Not Implemented
+public:
+  ReadCtfData(const ReadCtfData&) = delete;            // Copy Constructor Not Implemented
+  ReadCtfData(ReadCtfData&&) = delete;                 // Move Constructor Not Implemented
   ReadCtfData& operator=(const ReadCtfData&) = delete; // Copy Assignment Not Implemented
   ReadCtfData& operator=(ReadCtfData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadH5Ebsd.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadH5Ebsd.h
@@ -339,7 +339,9 @@ private:
 
   StringDataArray::WeakPointer m_MaterialNamesPtr;
 
-  ReadH5Ebsd(const ReadH5Ebsd&);     // Copy Constructor Not Implemented
+public:
+  ReadH5Ebsd(const ReadH5Ebsd&) = delete;            // Copy Constructor Not Implemented
+  ReadH5Ebsd(ReadH5Ebsd&&) = delete;                 // Move Constructor Not Implemented
   ReadH5Ebsd& operator=(const ReadH5Ebsd&) = delete; // Copy Assignment Not Implemented
   ReadH5Ebsd& operator=(ReadH5Ebsd&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/RodriguesConvertor.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/RodriguesConvertor.h
@@ -165,6 +165,7 @@ class RodriguesConvertor : public AbstractFilter
     /* Rule of 5: All special member functions should be defined if any are defined.
     * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all
     */
+  public:
     RodriguesConvertor(const RodriguesConvertor&) = delete;             // Copy Constructor Not Implemented
     RodriguesConvertor& operator=(const RodriguesConvertor&) = delete;  // Copy Assignment Not Implemented
     RodriguesConvertor(RodriguesConvertor&&) = delete;                  // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteIPFStandardTriangle.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteIPFStandardTriangle.h
@@ -196,7 +196,6 @@ protected:
    */
   QImage overlayText(QImage image, LaueOps* ops);
 
-private:
 public:
   WriteIPFStandardTriangle(const WriteIPFStandardTriangle&) = delete; // Copy Constructor Not Implemented
   WriteIPFStandardTriangle(WriteIPFStandardTriangle&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/YSChoiAbaqusReader.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/YSChoiAbaqusReader.h
@@ -36,9 +36,8 @@
 
 #pragma once
 
-#include <string.h> // needed for the ::memcpy function below
 #include <QtCore/QString>
-
+#include <cstring> // needed for the ::memcpy function below
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/Constants.h"
@@ -71,7 +70,7 @@ class OrientationAnalysis_EXPORT YSChoiAbaqusReader : public FileReader
     SIMPL_FILTER_NEW_MACRO(YSChoiAbaqusReader)
     SIMPL_TYPE_MACRO_SUPER_OVERRIDE(YSChoiAbaqusReader, FileReader)
 
-    virtual ~YSChoiAbaqusReader();
+    ~YSChoiAbaqusReader() override;
 
     SIMPL_FILTER_PARAMETER(QString, DataContainerName)
     Q_PROPERTY(QString DataContainerName READ getDataContainerName WRITE setDataContainerName)
@@ -183,7 +182,7 @@ class OrientationAnalysis_EXPORT YSChoiAbaqusReader : public FileReader
     /**
      * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
      */
-    void dataCheck();
+    void dataCheck() override;
 
     /**
      * @brief Initializes all the private instance variables.
@@ -205,7 +204,10 @@ class OrientationAnalysis_EXPORT YSChoiAbaqusReader : public FileReader
 
     void updateEnsembleInstancePointers();
 
+  public:
     YSChoiAbaqusReader(const YSChoiAbaqusReader&) = delete; // Copy Constructor Not Implemented
-    void operator=(const YSChoiAbaqusReader&) = delete;     // Move assignment Not Implemented
+    YSChoiAbaqusReader(YSChoiAbaqusReader&&) = delete;      // Move Constructor Not Implemented
+    YSChoiAbaqusReader& operator=(const YSChoiAbaqusReader&) = delete; // Copy Assignment Not Implemented
+    YSChoiAbaqusReader& operator=(YSChoiAbaqusReader&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisPlugin.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisPlugin.h
@@ -186,8 +186,11 @@ class OrientationAnalysis_EXPORT OrientationAnalysisPlugin : public QObject, pub
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     OrientationAnalysisPlugin(const OrientationAnalysisPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OrientationAnalysisPlugin&) = delete;            // Move assignment Not Implemented
+    OrientationAnalysisPlugin(OrientationAnalysisPlugin&&) = delete;      // Move Constructor Not Implemented
+    OrientationAnalysisPlugin& operator=(const OrientationAnalysisPlugin&) = delete; // Copy Assignment Not Implemented
+    OrientationAnalysisPlugin& operator=(OrientationAnalysisPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Processing/ProcessingFilters/FillBadData.h
+++ b/Source/Plugins/Processing/ProcessingFilters/FillBadData.h
@@ -178,7 +178,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
   DEFINE_DATAARRAY_VARIABLE(int32_t, CellPhases)
 
-  FillBadData(const FillBadData&);    // Copy Constructor Not Implemented
+public:
+  FillBadData(const FillBadData&) = delete;            // Copy Constructor Not Implemented
+  FillBadData(FillBadData&&) = delete;                 // Move Constructor Not Implemented
   FillBadData& operator=(const FillBadData&) = delete; // Copy Assignment Not Implemented
   FillBadData& operator=(FillBadData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Processing/ProcessingPlugin.h
+++ b/Source/Plugins/Processing/ProcessingPlugin.h
@@ -187,8 +187,11 @@ class Processing_EXPORT ProcessingPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     ProcessingPlugin(const ProcessingPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ProcessingPlugin&) = delete;   // Move assignment Not Implemented
+    ProcessingPlugin(ProcessingPlugin&&) = delete;      // Move Constructor Not Implemented
+    ProcessingPlugin& operator=(const ProcessingPlugin&) = delete; // Copy Assignment Not Implemented
+    ProcessingPlugin& operator=(ProcessingPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSections.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSections.h
@@ -185,7 +185,9 @@ private:
   size_t m_Progress = 0;
   size_t m_TotalProgress = 0;
 
+public:
   AlignSections(const AlignSections&) = delete;  // Copy Constructor Not Implemented
+  AlignSections(AlignSections&&) = delete;       // Move Constructor Not Implemented
   AlignSections& operator=(const AlignSections&) = delete; // Copy Assignment Not Implemented
   AlignSections& operator=(AlignSections&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeature.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeature.h
@@ -149,7 +149,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(bool, GoodVoxels)
 
+public:
   AlignSectionsFeature(const AlignSectionsFeature&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AlignSectionsFeature&);                // Move assignment Not Implemented
+  AlignSectionsFeature(AlignSectionsFeature&&) = delete;      // Move Constructor Not Implemented
+  AlignSectionsFeature& operator=(const AlignSectionsFeature&) = delete; // Copy Assignment Not Implemented
+  AlignSectionsFeature& operator=(AlignSectionsFeature&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeatureCentroid.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeatureCentroid.h
@@ -154,7 +154,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(bool, GoodVoxels)
 
+public:
   AlignSectionsFeatureCentroid(const AlignSectionsFeatureCentroid&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AlignSectionsFeatureCentroid&);                        // Move assignment Not Implemented
+  AlignSectionsFeatureCentroid(AlignSectionsFeatureCentroid&&) = delete;      // Move Constructor Not Implemented
+  AlignSectionsFeatureCentroid& operator=(const AlignSectionsFeatureCentroid&) = delete; // Copy Assignment Not Implemented
+  AlignSectionsFeatureCentroid& operator=(AlignSectionsFeatureCentroid&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsList.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsList.h
@@ -147,8 +147,10 @@ protected:
    */
   virtual void find_shifts(std::vector<int64_t>& xshifts, std::vector<int64_t>& yshifts);
 
-private:
+public:
   AlignSectionsList(const AlignSectionsList&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AlignSectionsList&);             // Move assignment Not Implemented
+  AlignSectionsList(AlignSectionsList&&) = delete;      // Move Constructor Not Implemented
+  AlignSectionsList& operator=(const AlignSectionsList&) = delete; // Copy Assignment Not Implemented
+  AlignSectionsList& operator=(AlignSectionsList&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.h
@@ -175,7 +175,10 @@ private:
 
   uint64_t m_RandomSeed;
 
+public:
   AlignSectionsMisorientation(const AlignSectionsMisorientation&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AlignSectionsMisorientation&);                       // Move assignment Not Implemented
+  AlignSectionsMisorientation(AlignSectionsMisorientation&&) = delete;      // Move Constructor Not Implemented
+  AlignSectionsMisorientation& operator=(const AlignSectionsMisorientation&) = delete; // Copy Assignment Not Implemented
+  AlignSectionsMisorientation& operator=(AlignSectionsMisorientation&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.h
@@ -184,7 +184,10 @@ private:
   Int32ArrayType::Pointer m_MIFeaturesPtr;
   uint64_t m_RandomSeed;
 
+public:
   AlignSectionsMutualInformation(const AlignSectionsMutualInformation&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AlignSectionsMutualInformation&);                          // Move assignment Not Implemented
+  AlignSectionsMutualInformation(AlignSectionsMutualInformation&&) = delete;      // Move Constructor Not Implemented
+  AlignSectionsMutualInformation& operator=(const AlignSectionsMutualInformation&) = delete; // Copy Assignment Not Implemented
+  AlignSectionsMutualInformation& operator=(AlignSectionsMutualInformation&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.h
@@ -221,7 +221,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
+public:
   CAxisSegmentFeatures(const CAxisSegmentFeatures&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CAxisSegmentFeatures&);                // Move assignment Not Implemented
+  CAxisSegmentFeatures(CAxisSegmentFeatures&&) = delete;      // Move Constructor Not Implemented
+  CAxisSegmentFeatures& operator=(const CAxisSegmentFeatures&) = delete; // Copy Assignment Not Implemented
+  CAxisSegmentFeatures& operator=(CAxisSegmentFeatures&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.h
@@ -223,7 +223,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
+public:
   EBSDSegmentFeatures(const EBSDSegmentFeatures&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EBSDSegmentFeatures&);               // Move assignment Not Implemented
+  EBSDSegmentFeatures(EBSDSegmentFeatures&&) = delete;      // Move Constructor Not Implemented
+  EBSDSegmentFeatures& operator=(const EBSDSegmentFeatures&) = delete; // Copy Assignment Not Implemented
+  EBSDSegmentFeatures& operator=(EBSDSegmentFeatures&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/GroupFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/GroupFeatures.h
@@ -211,7 +211,9 @@ private:
   NeighborList<int32_t>::WeakPointer m_ContiguousNeighborList;
   NeighborList<int32_t>::WeakPointer m_NonContiguousNeighborList;
 
+public:
   GroupFeatures(const GroupFeatures&) = delete;  // Copy Constructor Not Implemented
+  GroupFeatures(GroupFeatures&&) = delete;       // Move Constructor Not Implemented
   GroupFeatures& operator=(const GroupFeatures&) = delete; // Copy Assignment Not Implemented
   GroupFeatures& operator=(GroupFeatures&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/GroupMicroTextureRegions.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/GroupMicroTextureRegions.h
@@ -234,7 +234,10 @@ private:
 
   size_t m_TotalRandomNumbersGenerated;
 
+public:
   GroupMicroTextureRegions(const GroupMicroTextureRegions&) = delete; // Copy Constructor Not Implemented
-  void operator=(const GroupMicroTextureRegions&);                    // Move assignment Not Implemented
+  GroupMicroTextureRegions(GroupMicroTextureRegions&&) = delete;      // Move Constructor Not Implemented
+  GroupMicroTextureRegions& operator=(const GroupMicroTextureRegions&) = delete; // Copy Assignment Not Implemented
+  GroupMicroTextureRegions& operator=(GroupMicroTextureRegions&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.h
@@ -239,7 +239,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
+public:
   MergeColonies(const MergeColonies&) = delete;  // Copy Constructor Not Implemented
-  void operator=(const MergeColonies&) = delete; // Move assignment Not Implemented
+  MergeColonies(MergeColonies&&) = delete;       // Move Constructor Not Implemented
+  MergeColonies& operator=(const MergeColonies&) = delete; // Copy Assignment Not Implemented
+  MergeColonies& operator=(MergeColonies&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.h
@@ -214,7 +214,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
-  MergeTwins(const MergeTwins&);     // Copy Constructor Not Implemented
-  void operator=(const MergeTwins&) = delete; // Move assignment Not Implemented
+public:
+  MergeTwins(const MergeTwins&) = delete;            // Copy Constructor Not Implemented
+  MergeTwins(MergeTwins&&) = delete;                 // Move Constructor Not Implemented
+  MergeTwins& operator=(const MergeTwins&) = delete; // Copy Assignment Not Implemented
+  MergeTwins& operator=(MergeTwins&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/ScalarSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/ScalarSegmentFeatures.h
@@ -209,7 +209,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
+public:
   ScalarSegmentFeatures(const ScalarSegmentFeatures&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ScalarSegmentFeatures&);                 // Move assignment Not Implemented
+  ScalarSegmentFeatures(ScalarSegmentFeatures&&) = delete;      // Move Constructor Not Implemented
+  ScalarSegmentFeatures& operator=(const ScalarSegmentFeatures&) = delete; // Copy Assignment Not Implemented
+  ScalarSegmentFeatures& operator=(ScalarSegmentFeatures&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/SegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/SegmentFeatures.h
@@ -172,7 +172,6 @@ protected:
    */
   virtual bool determineGrouping(int64_t referencepoint, int64_t neighborpoint, int32_t gnum);
 
-private:
 public:
   SegmentFeatures(const SegmentFeatures&) = delete; // Copy Constructor Not Implemented
   SegmentFeatures(SegmentFeatures&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/SineParamsSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/SineParamsSegmentFeatures.h
@@ -210,7 +210,10 @@ private:
 
   bool m_MissingGoodVoxels;
 
+public:
   SineParamsSegmentFeatures(const SineParamsSegmentFeatures&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SineParamsSegmentFeatures&);                     // Move assignment Not Implemented
+  SineParamsSegmentFeatures(SineParamsSegmentFeatures&&) = delete;      // Move Constructor Not Implemented
+  SineParamsSegmentFeatures& operator=(const SineParamsSegmentFeatures&) = delete; // Copy Assignment Not Implemented
+  SineParamsSegmentFeatures& operator=(SineParamsSegmentFeatures&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/VectorSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/VectorSegmentFeatures.h
@@ -206,7 +206,10 @@ private:
    */
   void updateFeatureInstancePointers();
 
+public:
   VectorSegmentFeatures(const VectorSegmentFeatures&) = delete; // Copy Constructor Not Implemented
-  void operator=(const VectorSegmentFeatures&);                 // Move assignment Not Implemented
+  VectorSegmentFeatures(VectorSegmentFeatures&&) = delete;      // Move Constructor Not Implemented
+  VectorSegmentFeatures& operator=(const VectorSegmentFeatures&) = delete; // Copy Assignment Not Implemented
+  VectorSegmentFeatures& operator=(VectorSegmentFeatures&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Reconstruction/ReconstructionPlugin.h
+++ b/Source/Plugins/Reconstruction/ReconstructionPlugin.h
@@ -186,8 +186,11 @@ class Reconstruction_EXPORT ReconstructionPlugin : public QObject, public ISIMPL
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     ReconstructionPlugin(const ReconstructionPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ReconstructionPlugin&) = delete;       // Move assignment Not Implemented
+    ReconstructionPlugin(ReconstructionPlugin&&) = delete;      // Move Constructor Not Implemented
+    ReconstructionPlugin& operator=(const ReconstructionPlugin&) = delete; // Copy Assignment Not Implemented
+    ReconstructionPlugin& operator=(ReconstructionPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Sampling/SamplingFilters/AppendImageGeometryZSlice.h
+++ b/Source/Plugins/Sampling/SamplingFilters/AppendImageGeometryZSlice.h
@@ -168,7 +168,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   AppendImageGeometryZSlice(const AppendImageGeometryZSlice&) = delete; // Copy Constructor Not Implemented
   AppendImageGeometryZSlice(AppendImageGeometryZSlice&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Sampling/SamplingFilters/NearestPointFuseRegularGrids.h
+++ b/Source/Plugins/Sampling/SamplingFilters/NearestPointFuseRegularGrids.h
@@ -163,7 +163,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   NearestPointFuseRegularGrids(const NearestPointFuseRegularGrids&) = delete; // Copy Constructor Not Implemented
   NearestPointFuseRegularGrids(NearestPointFuseRegularGrids&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Sampling/SamplingFilters/RegularGridSampleSurfaceMesh.h
+++ b/Source/Plugins/Sampling/SamplingFilters/RegularGridSampleSurfaceMesh.h
@@ -178,7 +178,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
+public:
   RegularGridSampleSurfaceMesh(const RegularGridSampleSurfaceMesh&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RegularGridSampleSurfaceMesh&);                        // Move assignment Not Implemented
+  RegularGridSampleSurfaceMesh(RegularGridSampleSurfaceMesh&&) = delete;      // Move Constructor Not Implemented
+  RegularGridSampleSurfaceMesh& operator=(const RegularGridSampleSurfaceMesh&) = delete; // Copy Assignment Not Implemented
+  RegularGridSampleSurfaceMesh& operator=(RegularGridSampleSurfaceMesh&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Sampling/SamplingFilters/RegularizeZSpacing.h
+++ b/Source/Plugins/Sampling/SamplingFilters/RegularizeZSpacing.h
@@ -167,7 +167,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   RegularizeZSpacing(const RegularizeZSpacing&) = delete; // Copy Constructor Not Implemented
   RegularizeZSpacing(RegularizeZSpacing&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Sampling/SamplingFilters/RotateSampleRefFrame.h
+++ b/Source/Plugins/Sampling/SamplingFilters/RotateSampleRefFrame.h
@@ -173,7 +173,6 @@ protected:
    */
   void initialize();
 
-private:
 public:
   RotateSampleRefFrame(const RotateSampleRefFrame&) = delete; // Copy Constructor Not Implemented
   RotateSampleRefFrame(RotateSampleRefFrame&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMeshSpecifiedPoints.h
+++ b/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMeshSpecifiedPoints.h
@@ -166,7 +166,10 @@ private:
    */
   void updateVertexInstancePointers();
 
+public:
   SampleSurfaceMeshSpecifiedPoints(const SampleSurfaceMeshSpecifiedPoints&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SampleSurfaceMeshSpecifiedPoints&);                            // Move assignment Not Implemented
+  SampleSurfaceMeshSpecifiedPoints(SampleSurfaceMeshSpecifiedPoints&&) = delete;      // Move Constructor Not Implemented
+  SampleSurfaceMeshSpecifiedPoints& operator=(const SampleSurfaceMeshSpecifiedPoints&) = delete; // Copy Assignment Not Implemented
+  SampleSurfaceMeshSpecifiedPoints& operator=(SampleSurfaceMeshSpecifiedPoints&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Sampling/SamplingFilters/UncertainRegularGridSampleSurfaceMesh.h
+++ b/Source/Plugins/Sampling/SamplingFilters/UncertainRegularGridSampleSurfaceMesh.h
@@ -187,7 +187,10 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, FeatureIds)
 
+public:
   UncertainRegularGridSampleSurfaceMesh(const UncertainRegularGridSampleSurfaceMesh&) = delete; // Copy Constructor Not Implemented
-  void operator=(const UncertainRegularGridSampleSurfaceMesh&);                                 // Move assignment Not Implemented
+  UncertainRegularGridSampleSurfaceMesh(UncertainRegularGridSampleSurfaceMesh&&) = delete;      // Move Constructor Not Implemented
+  UncertainRegularGridSampleSurfaceMesh& operator=(const UncertainRegularGridSampleSurfaceMesh&) = delete; // Copy Assignment Not Implemented
+  UncertainRegularGridSampleSurfaceMesh& operator=(UncertainRegularGridSampleSurfaceMesh&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Sampling/SamplingFilters/WarpRegularGrid.h
+++ b/Source/Plugins/Sampling/SamplingFilters/WarpRegularGrid.h
@@ -207,7 +207,6 @@ protected:
    */
   void determine_warped_coordinates(float x, float y, float& newX, float& newY);
 
-private:
 public:
   WarpRegularGrid(const WarpRegularGrid&) = delete; // Copy Constructor Not Implemented
   WarpRegularGrid(WarpRegularGrid&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/Sampling/SamplingPlugin.h
+++ b/Source/Plugins/Sampling/SamplingPlugin.h
@@ -156,8 +156,11 @@ class Sampling_EXPORT SamplingPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     SamplingPlugin(const SamplingPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SamplingPlugin&) = delete; // Move assignment Not Implemented
+    SamplingPlugin(SamplingPlugin&&) = delete;      // Move Constructor Not Implemented
+    SamplingPlugin& operator=(const SamplingPlugin&) = delete; // Copy Assignment Not Implemented
+    SamplingPlugin& operator=(SamplingPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Sampling/Test/GenerateFeatureIds.h
+++ b/Source/Plugins/Sampling/Test/GenerateFeatureIds.h
@@ -220,8 +220,10 @@ protected:
     m->addAttributeMatrix(attrMat->getName(), attrMat);
   }
 
-private:
-  CreateDataContainer(const CreateDataContainer&) = delete; // Copy Constructor Not Implemented
-  void operator=(const CreateDataContainer&);               // Move assignment Not Implemented
+public:
+  CreateDataContainer(const CreateDataContainer&) = delete;            // Copy Constructor Not Implemented
+  CreateDataContainer(CreateDataContainer&&) = delete;                 // Move Constructor Not Implemented
+  CreateDataContainer& operator=(const CreateDataContainer&) = delete; // Copy Assignment Not Implemented
+  CreateDataContainer& operator=(CreateDataContainer&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/Statistics/DistributionAnalysisOps/BetaOps.h
+++ b/Source/Plugins/Statistics/DistributionAnalysisOps/BetaOps.h
@@ -63,9 +63,11 @@ class BetaOps : public DistributionAnalysisOps
   protected:
     BetaOps();
 
-  private:
+  public:
     BetaOps(const BetaOps&) = delete;        // Copy Constructor Not Implemented
-    void operator=(const BetaOps&) = delete; // Move assignment Not Implemented
+    BetaOps(BetaOps&&) = delete;             // Move Constructor Not Implemented
+    BetaOps& operator=(const BetaOps&) = delete; // Copy Assignment Not Implemented
+    BetaOps& operator=(BetaOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Statistics/DistributionAnalysisOps/DistributionAnalysisOps.h
+++ b/Source/Plugins/Statistics/DistributionAnalysisOps/DistributionAnalysisOps.h
@@ -66,9 +66,11 @@ class DistributionAnalysisOps
   protected:
     DistributionAnalysisOps();
 
-  private:
+  public:
     DistributionAnalysisOps(const DistributionAnalysisOps&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DistributionAnalysisOps&) = delete;          // Move assignment Not Implemented
+    DistributionAnalysisOps(DistributionAnalysisOps&&) = delete;      // Move Constructor Not Implemented
+    DistributionAnalysisOps& operator=(const DistributionAnalysisOps&) = delete; // Copy Assignment Not Implemented
+    DistributionAnalysisOps& operator=(DistributionAnalysisOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Statistics/DistributionAnalysisOps/LogNormalOps.h
+++ b/Source/Plugins/Statistics/DistributionAnalysisOps/LogNormalOps.h
@@ -64,9 +64,11 @@ class LogNormalOps : public DistributionAnalysisOps
   protected:
     LogNormalOps();
 
-  private:
+  public:
     LogNormalOps(const LogNormalOps&) = delete;   // Copy Constructor Not Implemented
-    void operator=(const LogNormalOps&) = delete; // Move assignment Not Implemented
+    LogNormalOps(LogNormalOps&&) = delete;        // Move Constructor Not Implemented
+    LogNormalOps& operator=(const LogNormalOps&) = delete; // Copy Assignment Not Implemented
+    LogNormalOps& operator=(LogNormalOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Statistics/DistributionAnalysisOps/PowerLawOps.h
+++ b/Source/Plugins/Statistics/DistributionAnalysisOps/PowerLawOps.h
@@ -64,9 +64,11 @@ class PowerLawOps : public DistributionAnalysisOps
   protected:
     PowerLawOps();
 
-  private:
+  public:
     PowerLawOps(const PowerLawOps&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const PowerLawOps&) = delete; // Move assignment Not Implemented
+    PowerLawOps(PowerLawOps&&) = delete;         // Move Constructor Not Implemented
+    PowerLawOps& operator=(const PowerLawOps&) = delete; // Copy Assignment Not Implemented
+    PowerLawOps& operator=(PowerLawOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Statistics/StatisticsFilters/FindNeighbors.h
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindNeighbors.h
@@ -202,7 +202,9 @@ private:
   NeighborList<int32_t>::WeakPointer m_NeighborList;
   NeighborList<float>::WeakPointer m_SharedSurfaceAreaList;
 
+public:
   FindNeighbors(const FindNeighbors&) = delete;  // Copy Constructor Not Implemented
+  FindNeighbors(FindNeighbors&&) = delete;       // Move Constructor Not Implemented
   FindNeighbors& operator=(const FindNeighbors&) = delete; // Copy Assignment Not Implemented
   FindNeighbors& operator=(FindNeighbors&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Statistics/StatisticsFilters/FindShapes.h
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindShapes.h
@@ -232,7 +232,9 @@ private:
 
   double m_ScaleFactor;
 
-  FindShapes(const FindShapes&);     // Copy Constructor Not Implemented
+public:
+  FindShapes(const FindShapes&) = delete;            // Copy Constructor Not Implemented
+  FindShapes(FindShapes&&) = delete;                 // Move Constructor Not Implemented
   FindShapes& operator=(const FindShapes&) = delete; // Copy Assignment Not Implemented
   FindShapes& operator=(FindShapes&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Statistics/StatisticsFilters/FindSizes.h
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindSizes.h
@@ -205,7 +205,9 @@ private:
   DEFINE_DATAARRAY_VARIABLE(float, EquivalentDiameters)
   DEFINE_DATAARRAY_VARIABLE(int32_t, NumElements)
 
-  FindSizes(const FindSizes&);                     // Copy Constructor Not Implemented
+public:
+  FindSizes(const FindSizes&) = delete;            // Copy Constructor Not Implemented
+  FindSizes(FindSizes&&) = delete;                 // Move Constructor Not Implemented
   FindSizes& operator=(const FindSizes&) = delete; // Copy Assignment Not Implemented
   FindSizes& operator=(FindSizes&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Statistics/StatisticsFilters/QuiltCellData.h
+++ b/Source/Plugins/Statistics/StatisticsFilters/QuiltCellData.h
@@ -195,7 +195,9 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(float, OutputArray)
 
+public:
   QuiltCellData(const QuiltCellData&) = delete;  // Copy Constructor Not Implemented
+  QuiltCellData(QuiltCellData&&) = delete;       // Move Constructor Not Implemented
   QuiltCellData& operator=(const QuiltCellData&) = delete; // Copy Assignment Not Implemented
   QuiltCellData& operator=(QuiltCellData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/Statistics/StatisticsFilters/util/MomentInvariants2D.h
+++ b/Source/Plugins/Statistics/StatisticsFilters/util/MomentInvariants2D.h
@@ -251,9 +251,11 @@ class MomentInvariants2D
     int factorial(int n) const;
 
 
-  private:
+  public:
     MomentInvariants2D(const MomentInvariants2D&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MomentInvariants2D&) = delete;     // Move assignment Not Implemented
+    MomentInvariants2D(MomentInvariants2D&&) = delete;      // Move Constructor Not Implemented
+    MomentInvariants2D& operator=(const MomentInvariants2D&) = delete; // Copy Assignment Not Implemented
+    MomentInvariants2D& operator=(MomentInvariants2D&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/Statistics/StatisticsPlugin.h
+++ b/Source/Plugins/Statistics/StatisticsPlugin.h
@@ -187,8 +187,11 @@ class Statistics_EXPORT StatisticsPlugin : public QObject, public ISIMPLibPlugin
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     StatisticsPlugin(const StatisticsPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatisticsPlugin&) = delete;   // Move assignment Not Implemented
+    StatisticsPlugin(StatisticsPlugin&&) = delete;      // Move Constructor Not Implemented
+    StatisticsPlugin& operator=(const StatisticsPlugin&) = delete; // Copy Assignment Not Implemented
+    StatisticsPlugin& operator=(StatisticsPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindNRingNeighbors.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindNRingNeighbors.h
@@ -103,8 +103,11 @@ class FindNRingNeighbors
   private:
     UniqueFaceIds_t  m_NRingTriangles;
 
+  public:
     FindNRingNeighbors(const FindNRingNeighbors&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FindNRingNeighbors&) = delete;     // Move assignment Not Implemented
+    FindNRingNeighbors(FindNRingNeighbors&&) = delete;      // Move Constructor Not Implemented
+    FindNRingNeighbors& operator=(const FindNRingNeighbors&) = delete; // Copy Assignment Not Implemented
+    FindNRingNeighbors& operator=(FindNRingNeighbors&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/util/TriangleOps.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/util/TriangleOps.h
@@ -81,9 +81,11 @@ class TriangleOps
   protected:
     TriangleOps();
 
-  private:
+  public:
     TriangleOps(const TriangleOps&) = delete;    // Copy Constructor Not Implemented
-    void operator=(const TriangleOps&) = delete; // Move assignment Not Implemented
+    TriangleOps(TriangleOps&&) = delete;         // Move Constructor Not Implemented
+    TriangleOps& operator=(const TriangleOps&) = delete; // Copy Assignment Not Implemented
+    TriangleOps& operator=(TriangleOps&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingPlugin.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingPlugin.h
@@ -186,8 +186,11 @@ class SurfaceMeshing_EXPORT SurfaceMeshingPlugin : public QObject, public ISIMPL
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     SurfaceMeshingPlugin(const SurfaceMeshingPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SurfaceMeshingPlugin&) = delete;       // Move assignment Not Implemented
+    SurfaceMeshingPlugin(SurfaceMeshingPlugin&&) = delete;      // Move Constructor Not Implemented
+    SurfaceMeshingPlugin& operator=(const SurfaceMeshingPlugin&) = delete; // Copy Assignment Not Implemented
+    SurfaceMeshingPlugin& operator=(SurfaceMeshingPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/SyntheticBuilding/FilterParameters/StatsGeneratorFilterParameter.h
+++ b/Source/Plugins/SyntheticBuilding/FilterParameters/StatsGeneratorFilterParameter.h
@@ -65,8 +65,10 @@ public:
 protected:
   StatsGeneratorFilterParameter();
 
-private:
+public:
   StatsGeneratorFilterParameter(const StatsGeneratorFilterParameter&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGeneratorFilterParameter&);                         // Move assignment Not Implemented
+  StatsGeneratorFilterParameter(StatsGeneratorFilterParameter&&) = delete;      // Move Constructor Not Implemented
+  StatsGeneratorFilterParameter& operator=(const StatsGeneratorFilterParameter&) = delete; // Copy Assignment Not Implemented
+  StatsGeneratorFilterParameter& operator=(StatsGeneratorFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.h
@@ -168,8 +168,11 @@ class InitializeSyntheticVolumeWidget : public FilterParameterWidget, private Ui
     DataArraySelectionFilterParameter::Pointer     m_PhaseTypesPath;
     DataArraySelectionFilterParameter::Pointer     m_CrystalStructuresPath;
 
+  public:
     InitializeSyntheticVolumeWidget(const InitializeSyntheticVolumeWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const InitializeSyntheticVolumeWidget&) = delete;                  // Move assignment Not Implemented
+    InitializeSyntheticVolumeWidget(InitializeSyntheticVolumeWidget&&) = delete;      // Move Constructor Not Implemented
+    InitializeSyntheticVolumeWidget& operator=(const InitializeSyntheticVolumeWidget&) = delete; // Copy Assignment Not Implemented
+    InitializeSyntheticVolumeWidget& operator=(InitializeSyntheticVolumeWidget&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.h
@@ -134,7 +134,10 @@ private:
   bool m_NeedDataLoad = false;
   AttributeMatrix::Pointer m_CellEnsembleAttrMat = AttributeMatrix::NullPointer();
 
+public:
   StatsGeneratorWidget(const StatsGeneratorWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGeneratorWidget&) = delete;       // Move assignment Not Implemented
+  StatsGeneratorWidget(StatsGeneratorWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGeneratorWidget& operator=(const StatsGeneratorWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGeneratorWidget& operator=(StatsGeneratorWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Utilities/PoleFigureImageUtilities.h
@@ -87,7 +87,10 @@ private:
   QVector<qint32> m_KernelWeights;
   bool m_KernelWeightsInited;
 
+public:
   PoleFigureImageUtilities(const PoleFigureImageUtilities&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PoleFigureImageUtilities&) = delete;           // Move assignment Not Implemented
+  PoleFigureImageUtilities(PoleFigureImageUtilities&&) = delete;      // Move Constructor Not Implemented
+  PoleFigureImageUtilities& operator=(const PoleFigureImageUtilities&) = delete; // Copy Assignment Not Implemented
+  PoleFigureImageUtilities& operator=(PoleFigureImageUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/BoundaryPhaseWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/BoundaryPhaseWidget.h
@@ -92,7 +92,10 @@ private:
   QList<QWidget*> m_WidgetList;
   QwtPlotGrid* m_grid;
 
+public:
   BoundaryPhaseWidget(const BoundaryPhaseWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const BoundaryPhaseWidget&) = delete;      // Move assignment Not Implemented
+  BoundaryPhaseWidget(BoundaryPhaseWidget&&) = delete;      // Move Constructor Not Implemented
+  BoundaryPhaseWidget& operator=(const BoundaryPhaseWidget&) = delete; // Copy Assignment Not Implemented
+  BoundaryPhaseWidget& operator=(BoundaryPhaseWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/EditPhaseDialog.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/EditPhaseDialog.h
@@ -94,7 +94,10 @@ private:
   QDoubleValidator* m_PhaseFractionValidator = nullptr;
   QDoubleValidator* m_PptFractionValidator = nullptr;
 
+public:
   EditPhaseDialog(const EditPhaseDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const EditPhaseDialog&) = delete;  // Move assignment Not Implemented
+  EditPhaseDialog(EditPhaseDialog&&) = delete;      // Move Constructor Not Implemented
+  EditPhaseDialog& operator=(const EditPhaseDialog&) = delete; // Copy Assignment Not Implemented
+  EditPhaseDialog& operator=(EditPhaseDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/MatrixPhaseWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/MatrixPhaseWidget.h
@@ -91,7 +91,10 @@ private:
   QList<QWidget*> m_WidgetList;
   QwtPlotGrid* m_grid;
 
+public:
   MatrixPhaseWidget(const MatrixPhaseWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const MatrixPhaseWidget&) = delete;    // Move assignment Not Implemented
+  MatrixPhaseWidget(MatrixPhaseWidget&&) = delete;      // Move Constructor Not Implemented
+  MatrixPhaseWidget& operator=(const MatrixPhaseWidget&) = delete; // Copy Assignment Not Implemented
+  MatrixPhaseWidget& operator=(MatrixPhaseWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/PoleFigureMaker.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/PoleFigureMaker.h
@@ -136,7 +136,10 @@ private:
   QVector<qint32> m_KernelWeights;
   bool m_KernelWeightsInited;
 
+public:
   PoleFigureMaker(const PoleFigureMaker&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PoleFigureMaker&) = delete;  // Move assignment Not Implemented
+  PoleFigureMaker(PoleFigureMaker&&) = delete;      // Move Constructor Not Implemented
+  PoleFigureMaker& operator=(const PoleFigureMaker&) = delete; // Copy Assignment Not Implemented
+  PoleFigureMaker& operator=(PoleFigureMaker&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrecipitatePhaseWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrecipitatePhaseWidget.h
@@ -98,7 +98,10 @@ private:
 
   StatsGenRDFWidget* m_RdfPlot = nullptr;
 
+public:
   PrecipitatePhaseWidget(const PrecipitatePhaseWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrecipitatePhaseWidget&) = delete;         // Move assignment Not Implemented
+  PrecipitatePhaseWidget(PrecipitatePhaseWidget&&) = delete;      // Move Constructor Not Implemented
+  PrecipitatePhaseWidget& operator=(const PrecipitatePhaseWidget&) = delete; // Copy Assignment Not Implemented
+  PrecipitatePhaseWidget& operator=(PrecipitatePhaseWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/Presets/Dialogs/PrimaryRecrystallizedPresetDialog.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/Presets/Dialogs/PrimaryRecrystallizedPresetDialog.h
@@ -63,7 +63,10 @@ protected:
 private:
   QLineEdit* percentRecystallized;
 
+public:
   PrimaryRecrystallizedPresetDialog(const PrimaryRecrystallizedPresetDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrimaryRecrystallizedPresetDialog&) = delete;                    // Move assignment Not Implemented
+  PrimaryRecrystallizedPresetDialog(PrimaryRecrystallizedPresetDialog&&) = delete;      // Move Constructor Not Implemented
+  PrimaryRecrystallizedPresetDialog& operator=(const PrimaryRecrystallizedPresetDialog&) = delete; // Copy Assignment Not Implemented
+  PrimaryRecrystallizedPresetDialog& operator=(PrimaryRecrystallizedPresetDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/Presets/Dialogs/RolledPresetDialog.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/Presets/Dialogs/RolledPresetDialog.h
@@ -70,7 +70,10 @@ private:
   QLineEdit* B;
   QLineEdit* C;
 
+public:
   RolledPresetDialog(const RolledPresetDialog&) = delete; // Copy Constructor Not Implemented
-  void operator=(const RolledPresetDialog&) = delete;     // Move assignment Not Implemented
+  RolledPresetDialog(RolledPresetDialog&&) = delete;      // Move Constructor Not Implemented
+  RolledPresetDialog& operator=(const RolledPresetDialog&) = delete; // Copy Assignment Not Implemented
+  RolledPresetDialog& operator=(RolledPresetDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrimaryPhaseWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrimaryPhaseWidget.h
@@ -131,7 +131,10 @@ private:
   QButtonGroup m_DistButtonGroup;
   bool m_ResetData = false;
 
+public:
   PrimaryPhaseWidget(const PrimaryPhaseWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrimaryPhaseWidget&);              // Move assignment Not Implemented
+  PrimaryPhaseWidget(PrimaryPhaseWidget&&) = delete;      // Move Constructor Not Implemented
+  PrimaryPhaseWidget& operator=(const PrimaryPhaseWidget&) = delete; // Copy Assignment Not Implemented
+  PrimaryPhaseWidget& operator=(PrimaryPhaseWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.h
@@ -129,7 +129,10 @@ private:
   QButtonGroup m_ODFGroup;
   QString m_OpenDialogLastDirectory; // Must be last in the list
 
+public:
   StatsGenAxisODFWidget(const StatsGenAxisODFWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenAxisODFWidget&) = delete;        // Move assignment Not Implemented
+  StatsGenAxisODFWidget(StatsGenAxisODFWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenAxisODFWidget& operator=(const StatsGenAxisODFWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenAxisODFWidget& operator=(StatsGenAxisODFWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
@@ -97,7 +97,10 @@ private:
 
   QString m_OpenDialogLastFilePath; // Must be last in the list
 
+public:
   StatsGenMDFWidget(const StatsGenMDFWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenMDFWidget&) = delete;    // Move assignment Not Implemented
+  StatsGenMDFWidget(StatsGenMDFWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenMDFWidget& operator=(const StatsGenMDFWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenMDFWidget& operator=(StatsGenMDFWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.h
@@ -155,7 +155,10 @@ private:
 
   QString m_OpenDialogLastFilePath; // Must be last in the list
 
+public:
   StatsGenODFWidget(const StatsGenODFWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenODFWidget&) = delete;    // Move assignment Not Implemented
+  StatsGenODFWidget(StatsGenODFWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenODFWidget& operator=(const StatsGenODFWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenODFWidget& operator=(StatsGenODFWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.h
@@ -129,7 +129,10 @@ private:
   QTableView* m_TableView = nullptr;
   QPoint m_ContextMenuPoint;
 
+public:
   StatsGenPlotWidget(const StatsGenPlotWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenPlotWidget&) = delete;     // Move assignment Not Implemented
+  StatsGenPlotWidget(StatsGenPlotWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenPlotWidget& operator=(const StatsGenPlotWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenPlotWidget& operator=(StatsGenPlotWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenRDFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenRDFWidget.h
@@ -159,7 +159,10 @@ private:
    */
   bool validateInput();
 
+public:
   StatsGenRDFWidget(const StatsGenRDFWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenRDFWidget&) = delete;    // Move assignment Not Implemented
+  StatsGenRDFWidget(StatsGenRDFWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenRDFWidget& operator=(const StatsGenRDFWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenRDFWidget& operator=(StatsGenRDFWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenWidget.h
@@ -105,9 +105,10 @@ public:
   //  signals:
   //    void phaseParametersChanged();
 
-protected:
-private:
+public:
   StatsGenWidget(const StatsGenWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGenWidget&) = delete; // Move assignment Not Implemented
+  StatsGenWidget(StatsGenWidget&&) = delete;      // Move Constructor Not Implemented
+  StatsGenWidget& operator=(const StatsGenWidget&) = delete; // Copy Assignment Not Implemented
+  StatsGenWidget& operator=(StatsGenWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGAbstractTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGAbstractTableModel.h
@@ -217,8 +217,10 @@ public:
 
   virtual void setColumnData(int col, QVector<float>& data) = 0;
 
-private:
+public:
   SGAbstractTableModel(const SGAbstractTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGAbstractTableModel&) = delete;       // Move assignment Not Implemented
+  SGAbstractTableModel(SGAbstractTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGAbstractTableModel& operator=(const SGAbstractTableModel&) = delete; // Copy Assignment Not Implemented
+  SGAbstractTableModel& operator=(SGAbstractTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.h
@@ -142,7 +142,10 @@ private:
   QVector<float> m_Beta;
   QVector<SIMPL::Rgb> m_Colors;
 
+public:
   SGBetaTableModel(const SGBetaTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGBetaTableModel&) = delete;   // Move assignment Not Implemented
+  SGBetaTableModel(SGBetaTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGBetaTableModel& operator=(const SGBetaTableModel&) = delete; // Copy Assignment Not Implemented
+  SGBetaTableModel& operator=(SGBetaTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.h
@@ -142,7 +142,10 @@ private:
   QVector<float> m_StdDev;
   QVector<SIMPL::Rgb> m_Colors;
 
+public:
   SGLogNormalTableModel(const SGLogNormalTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGLogNormalTableModel&) = delete;        // Move assignment Not Implemented
+  SGLogNormalTableModel(SGLogNormalTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGLogNormalTableModel& operator=(const SGLogNormalTableModel&) = delete; // Copy Assignment Not Implemented
+  SGLogNormalTableModel& operator=(SGLogNormalTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
@@ -175,7 +175,10 @@ private:
   QVector<QString> m_Axis;
   QVector<float> m_Weights;
 
+public:
   SGMDFTableModel(const SGMDFTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGMDFTableModel&) = delete;  // Move assignment Not Implemented
+  SGMDFTableModel(SGMDFTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGMDFTableModel& operator=(const SGMDFTableModel&) = delete; // Copy Assignment Not Implemented
+  SGMDFTableModel& operator=(SGMDFTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h
@@ -178,7 +178,10 @@ private:
   QVector<float> m_Weights;
   QVector<float> m_Sigmas;
 
+public:
   SGODFTableModel(const SGODFTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGODFTableModel&) = delete;  // Move assignment Not Implemented
+  SGODFTableModel(SGODFTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGODFTableModel& operator=(const SGODFTableModel&) = delete; // Copy Assignment Not Implemented
+  SGODFTableModel& operator=(SGODFTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.h
@@ -152,7 +152,10 @@ private:
   QVector<float> m_Beta;
   QVector<SIMPL::Rgb> m_Colors;
 
+public:
   SGPowerLawTableModel(const SGPowerLawTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGPowerLawTableModel&) = delete;       // Move assignment Not Implemented
+  SGPowerLawTableModel(SGPowerLawTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGPowerLawTableModel& operator=(const SGPowerLawTableModel&) = delete; // Copy Assignment Not Implemented
+  SGPowerLawTableModel& operator=(SGPowerLawTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGRDFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGRDFTableModel.h
@@ -166,7 +166,10 @@ private:
 
   QVector<float> m_Frequencies;
 
+public:
   SGRDFTableModel(const SGRDFTableModel&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SGRDFTableModel&) = delete;  // Move assignment Not Implemented
+  SGRDFTableModel(SGRDFTableModel&&) = delete;      // Move Constructor Not Implemented
+  SGRDFTableModel& operator=(const SGRDFTableModel&) = delete; // Copy Assignment Not Implemented
+  SGRDFTableModel& operator=(SGRDFTableModel&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TextureDialog.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TextureDialog.h
@@ -76,7 +76,10 @@ protected:
 private:
   QVector<TexturePreset::Pointer> m_Presets;
 
+public:
   TextureDialog(const TextureDialog&) = delete;  // Copy Constructor Not Implemented
-  void operator=(const TextureDialog&) = delete; // Move assignment Not Implemented
+  TextureDialog(TextureDialog&&) = delete;       // Move Constructor Not Implemented
+  TextureDialog& operator=(const TextureDialog&) = delete; // Copy Assignment Not Implemented
+  TextureDialog& operator=(TextureDialog&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TransformationPhaseWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TransformationPhaseWidget.h
@@ -130,7 +130,10 @@ private:
   QwtPlotGrid* m_grid;
   AbstractMicrostructurePreset::Pointer m_MicroPreset;
 
+public:
   TransformationPhaseWidget(const TransformationPhaseWidget&) = delete; // Copy Constructor Not Implemented
-  void operator=(const TransformationPhaseWidget&) = delete;            // Move assignment Not Implemented
+  TransformationPhaseWidget(TransformationPhaseWidget&&) = delete;      // Move Constructor Not Implemented
+  TransformationPhaseWidget& operator=(const TransformationPhaseWidget&) = delete; // Copy Assignment Not Implemented
+  TransformationPhaseWidget& operator=(TransformationPhaseWidget&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddBadData.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddBadData.h
@@ -184,7 +184,9 @@ protected:
 private:
   DEFINE_DATAARRAY_VARIABLE(int32_t, GBEuclideanDistances)
 
-  AddBadData(const AddBadData&);     // Copy Constructor Not Implemented
+public:
+  AddBadData(const AddBadData&) = delete;            // Copy Constructor Not Implemented
+  AddBadData(AddBadData&&) = delete;                 // Move Constructor Not Implemented
   AddBadData& operator=(const AddBadData&) = delete; // Copy Assignment Not Implemented
   AddBadData& operator=(AddBadData&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.h
@@ -202,7 +202,9 @@ private:
 
   DEFINE_DATAARRAY_VARIABLE(int32_t, AtomFeatureLabels)
 
-  InsertAtoms(const InsertAtoms&);    // Copy Constructor Not Implemented
+public:
+  InsertAtoms(const InsertAtoms&) = delete;            // Copy Constructor Not Implemented
+  InsertAtoms(InsertAtoms&&) = delete;                 // Move Constructor Not Implemented
   InsertAtoms& operator=(const InsertAtoms&) = delete; // Copy Assignment Not Implemented
   InsertAtoms& operator=(InsertAtoms&&) = delete;      // Move Assignment Not Implemented
 };

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/AbstractMicrostructurePreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/AbstractMicrostructurePreset.h
@@ -145,8 +145,10 @@ public:
 protected:
   AbstractMicrostructurePreset();
 
-private:
+public:
   AbstractMicrostructurePreset(const AbstractMicrostructurePreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const AbstractMicrostructurePreset&) = delete;               // Move assignment Not Implemented
+  AbstractMicrostructurePreset(AbstractMicrostructurePreset&&) = delete;      // Move Constructor Not Implemented
+  AbstractMicrostructurePreset& operator=(const AbstractMicrostructurePreset&) = delete; // Copy Assignment Not Implemented
+  AbstractMicrostructurePreset& operator=(AbstractMicrostructurePreset&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/AbstractMicrostructurePresetFactory.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/AbstractMicrostructurePresetFactory.h
@@ -158,8 +158,10 @@ protected:
   {
   }
 
-private:
-  AbstractMicrostructurePresetFactory(const AbstractMicrostructurePresetFactory&); // Copy Constructor Not Implemented
-  void operator=(const AbstractMicrostructurePresetFactory&);                      // Move assignment Not Implemented
+public:
+  AbstractMicrostructurePresetFactory(const AbstractMicrostructurePresetFactory&) = delete;            // Copy Constructor Not Implemented
+  AbstractMicrostructurePresetFactory(AbstractMicrostructurePresetFactory&&) = delete;                 // Move Constructor Not Implemented
+  AbstractMicrostructurePresetFactory& operator=(const AbstractMicrostructurePresetFactory&) = delete; // Copy Assignment Not Implemented
+  AbstractMicrostructurePresetFactory& operator=(AbstractMicrostructurePresetFactory&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/MicrostructurePresetManager.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/MicrostructurePresetManager.h
@@ -132,7 +132,10 @@ protected:
 private:
   AbstractMicrostructurePresetFactory::Collection _factories;
 
+public:
   MicrostructurePresetManager(const MicrostructurePresetManager&) = delete; // Copy Constructor Not Implemented
-  void operator=(const MicrostructurePresetManager&) = delete;              // Move assignment Not Implemented
+  MicrostructurePresetManager(MicrostructurePresetManager&&) = delete;      // Move Constructor Not Implemented
+  MicrostructurePresetManager& operator=(const MicrostructurePresetManager&) = delete; // Copy Assignment Not Implemented
+  MicrostructurePresetManager& operator=(MicrostructurePresetManager&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrecipitateEquiaxedPreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrecipitateEquiaxedPreset.h
@@ -80,9 +80,11 @@ public:
 protected:
   PrecipitateEquiaxedPreset();
 
-private:
+public:
   PrecipitateEquiaxedPreset(const PrecipitateEquiaxedPreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrecipitateEquiaxedPreset&) = delete;            // Move assignment Not Implemented
+  PrecipitateEquiaxedPreset(PrecipitateEquiaxedPreset&&) = delete;      // Move Constructor Not Implemented
+  PrecipitateEquiaxedPreset& operator=(const PrecipitateEquiaxedPreset&) = delete; // Copy Assignment Not Implemented
+  PrecipitateEquiaxedPreset& operator=(PrecipitateEquiaxedPreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 DECLARE_FACTORY_CLASS(PrecipitateEquiaxedPresetFactory, PrecipitateEquiaxedPreset, "Precipitate Equiaxed")

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrecipitateRolledPreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrecipitateRolledPreset.h
@@ -80,9 +80,11 @@ public:
 protected:
   PrecipitateRolledPreset();
 
-private:
+public:
   PrecipitateRolledPreset(const PrecipitateRolledPreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrecipitateRolledPreset&) = delete;          // Move assignment Not Implemented
+  PrecipitateRolledPreset(PrecipitateRolledPreset&&) = delete;      // Move Constructor Not Implemented
+  PrecipitateRolledPreset& operator=(const PrecipitateRolledPreset&) = delete; // Copy Assignment Not Implemented
+  PrecipitateRolledPreset& operator=(PrecipitateRolledPreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 DECLARE_FACTORY_CLASS(PrecipitateRolledPresetFactory, PrecipitateRolledPreset, "Precipitate Rolled")

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryEquiaxedPreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryEquiaxedPreset.h
@@ -76,9 +76,11 @@ public:
 protected:
   PrimaryEquiaxedPreset();
 
-private:
+public:
   PrimaryEquiaxedPreset(const PrimaryEquiaxedPreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrimaryEquiaxedPreset&) = delete;        // Move assignment Not Implemented
+  PrimaryEquiaxedPreset(PrimaryEquiaxedPreset&&) = delete;      // Move Constructor Not Implemented
+  PrimaryEquiaxedPreset& operator=(const PrimaryEquiaxedPreset&) = delete; // Copy Assignment Not Implemented
+  PrimaryEquiaxedPreset& operator=(PrimaryEquiaxedPreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 DECLARE_FACTORY_CLASS(PrimaryEquiaxedPresetFactory, PrimaryEquiaxedPreset, "Primary Equiaxed")

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryRecrystallizedPreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryRecrystallizedPreset.h
@@ -78,9 +78,11 @@ public:
 protected:
   PrimaryRecrystallizedPreset();
 
-private:
+public:
   PrimaryRecrystallizedPreset(const PrimaryRecrystallizedPreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrimaryRecrystallizedPreset&) = delete;              // Move assignment Not Implemented
+  PrimaryRecrystallizedPreset(PrimaryRecrystallizedPreset&&) = delete;      // Move Constructor Not Implemented
+  PrimaryRecrystallizedPreset& operator=(const PrimaryRecrystallizedPreset&) = delete; // Copy Assignment Not Implemented
+  PrimaryRecrystallizedPreset& operator=(PrimaryRecrystallizedPreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 DECLARE_FACTORY_CLASS(PrimaryRecrystallizedPresetFactory, PrimaryRecrystallizedPreset, "Recrystallized")

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryRolledPreset.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/Presets/PrimaryRolledPreset.h
@@ -85,9 +85,11 @@ public:
 protected:
   PrimaryRolledPreset();
 
-private:
+public:
   PrimaryRolledPreset(const PrimaryRolledPreset&) = delete; // Copy Constructor Not Implemented
-  void operator=(const PrimaryRolledPreset&) = delete;      // Move assignment Not Implemented
+  PrimaryRolledPreset(PrimaryRolledPreset&&) = delete;      // Move Constructor Not Implemented
+  PrimaryRolledPreset& operator=(const PrimaryRolledPreset&) = delete; // Copy Assignment Not Implemented
+  PrimaryRolledPreset& operator=(PrimaryRolledPreset&&) = delete;      // Move Assignment Not Implemented
 };
 
 DECLARE_FACTORY_CLASS(PrimaryRolledPresetFactory, PrimaryRolledPreset, "Primary Rolled")

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.h
@@ -223,7 +223,6 @@ protected:
    */
   void readArray(const QJsonObject& jsonRoot, size_t numTuples);
 
-private:
 public:
   StatsGeneratorFilter(const StatsGeneratorFilter&) = delete;            // Copy Constructor Not Implemented
   StatsGeneratorFilter(StatsGeneratorFilter&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h
@@ -71,8 +71,10 @@ public:
 protected:
   StatsGeneratorUtilities();
 
-private:
+public:
   StatsGeneratorUtilities(const StatsGeneratorUtilities&) = delete; // Copy Constructor Not Implemented
-  void operator=(const StatsGeneratorUtilities&) = delete;          // Move assignment Not Implemented
+  StatsGeneratorUtilities(StatsGeneratorUtilities&&) = delete;      // Move Constructor Not Implemented
+  StatsGeneratorUtilities& operator=(const StatsGeneratorUtilities&) = delete; // Copy Assignment Not Implemented
+  StatsGeneratorUtilities& operator=(StatsGeneratorUtilities&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingPlugin.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingPlugin.h
@@ -187,8 +187,11 @@ class SyntheticBuilding_EXPORT SyntheticBuildingPlugin : public QObject, public 
     QList<QString>      m_Filters;
     bool                m_DidLoad;
 
+  public:
     SyntheticBuildingPlugin(const SyntheticBuildingPlugin&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SyntheticBuildingPlugin&) = delete;          // Move assignment Not Implemented
+    SyntheticBuildingPlugin(SyntheticBuildingPlugin&&) = delete;      // Move Constructor Not Implemented
+    SyntheticBuildingPlugin& operator=(const SyntheticBuildingPlugin&) = delete; // Copy Assignment Not Implemented
+    SyntheticBuildingPlugin& operator=(SyntheticBuildingPlugin&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Tools/SandboxTool.cpp
+++ b/Tools/SandboxTool.cpp
@@ -174,49 +174,46 @@ int main(int argc, char* argv[])
   qRegisterMetaType<PipelineMessage>();
 
   std::list<QDir> dirs;
-//  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/SIMPL/Source/SIMPLib"));
-  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/Source/Plugins"));
-//  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/SIMPL/Source"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/SIMPLView/Source"));
 
-//  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/Source/Plugins"));
+  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/Source/EbsdLib"));
+  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/Source/OrientationLib"));
 
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/Anisotropy/AnisotropyFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/CellularAutomata/CellularAutomataFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/DDDAnalysisToolbox/DDDAnalysisToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/DREAM3DReview/DREAM3DReviewFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/FiberToolbox/FiberToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/HEDMAnalysis/HEDMAnalysisFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ITKImageProcessing/ITKImageProcessingFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ImageProcessing/ImageProcessingFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/MASSIFUtilities/MASSIFUtilitiesFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ProgWorkshop/ProgWorkshopFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/TransformationPhase/TransformationPhaseFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/UCSBUtilities/UCSBUtilitiesFilters"));
 
-//dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins"));
-
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/Anisotropy/AnisotropyFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/CellularAutomata/CellularAutomataFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/DDDAnalysisToolbox/DDDAnalysisToolboxFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/DREAM3DReview/DREAM3DReviewFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/FiberToolbox/FiberToolboxFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/HEDMAnalysis/HEDMAnalysisFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ITKImageProcessing/ITKImageProcessingFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ImageProcessing/ImageProcessingFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/MASSIFUtilities/MASSIFUtilitiesFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/ProgWorkshop/ProgWorkshopFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/TransformationPhase/TransformationPhaseFilters"));
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/ExternalProjects/Plugins/UCSBUtilities/UCSBUtilitiesFilters"));
-
-#if 1
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/AMProcessMonitoring/AMProcessMonitoringFilters"));   
-dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DictionaryIndexing/DictionaryIndexingFilters"));    
-#endif
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/NETLIntegration/NETLIntegrationFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/AskNDEToolbox/AskNDEToolboxFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/EMsoftToolbox/EMsoftToolboxFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/ProcessModeling/ProcessModelingFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/BrukerIntegration/BrukerIntegrationFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/Fusion/FusionFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/SMTKPlugin/SMTKPluginFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/CAxisByPolarizedLight/CAxisByPolarizedLightFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/Leroy2/Leroy2Filters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/TomvizToolbox/TomvizToolboxFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DataFusion/DataFusionFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/MDIToolbox/MDIToolboxFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/VolumeMeshing/VolumeMeshingFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DatasetMerging/DatasetMergingFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/MultiscaleFusion/MultiscaleFusionFilters")); 
- dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/ZeissImport/ZeissImportFilters"));
- 
+  //#if 1
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/AMProcessMonitoring/AMProcessMonitoringFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DictionaryIndexing/DictionaryIndexingFilters"));
+  //#endif
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/NETLIntegration/NETLIntegrationFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/AskNDEToolbox/AskNDEToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/EMsoftToolbox/EMsoftToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/ProcessModeling/ProcessModelingFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/BrukerIntegration/BrukerIntegrationFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/Fusion/FusionFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/SMTKPlugin/SMTKPluginFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/CAxisByPolarizedLight/CAxisByPolarizedLightFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/Leroy2/Leroy2Filters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/TomvizToolbox/TomvizToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DataFusion/DataFusionFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/MDIToolbox/MDIToolboxFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/VolumeMeshing/VolumeMeshingFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/DatasetMerging/DatasetMergingFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/MultiscaleFusion/MultiscaleFusionFilters"));
+  //  dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/ZeissImport/ZeissImportFilters"));
 
   QStringList filters;
   // filters.append("*.cpp");
@@ -225,7 +222,7 @@ dirs.emplace_back(QDir(D3DTools::GetDREAM3DProjDir() + "/../DREAM3D_Plugins/Dict
 
   for(auto const& dir : dirs)
   {
-    RecursiveFileSearch<AddPybindMacros>(dir, filters);
+    RecursiveFileSearch<UpdateFilterHeaders>(dir, filters);
   }
 
 

--- a/Tools/SandboxTool/UpdateFilterHeaders.hpp
+++ b/Tools/SandboxTool/UpdateFilterHeaders.hpp
@@ -17,10 +17,10 @@ public:
     QString contents;
     QFileInfo fi(hFile);
 
-    //    if (fi.baseName().compare("FindNumFeatures") != 0)
-    //    {
-    //      return;
-    //    }
+    //     if (fi.baseName().compare("IObserver") != 0)
+    //     {
+    //       return;
+    //     }
 
     {
       // Read the Source File
@@ -34,157 +34,145 @@ public:
     bool isFilter = false;
     QString searchString = "virtual const QString getSubGroupName() override;";
 
-    QStringList outLines;
+    QVector<QString> outLines;
     QStringList list = contents.split(QRegExp("\\n"));
     QStringListIterator sourceLines(list);
 
     QString baseName = fi.baseName();
     QString cpyCtr = QString("%1(const %1&) = delete;").arg(baseName);
+    int32_t cpyCtrLine = 0;
+
     QString mvCtr = QString("%1(%1&&) = delete;").arg(baseName);
-    QString cpyAssign = QString("void operator=(const %1&) = delete;").arg(baseName);
+    int32_t mvCtrLine = 0;
+
+    QString cpyAssign = QString("%1& operator=(const %1&) = delete;").arg(baseName);
+    int32_t cpyAssignLine = 0;
+
+    QString mvAssign = QString("%1& operator=(%1&&) = delete;").arg(baseName);
+    int32_t mvAssignLine = 0;
+
+    QString cpyAssignOld = QString("void operator=(const %1&)").arg(baseName);
+    int32_t cpyAssignOldLine = 0;
+
     QString cpyAssignRepl = QString("    %1& operator=(const %1&) = delete; // Copy Assignment Not Implemented").arg(baseName);
-    QString mvAssign = QString("    %1& operator=(%1&&) = delete;      // Move Assignment Not Implemented").arg(baseName);
     QString mvAssign1 = QString("void operator=(const %1&);").arg(baseName);
 
+    size_t lineIndex = 0;
+
+    // First Pass is to analyze the header file
     while(sourceLines.hasNext())
     {
       QString line = sourceLines.next();
-      if(line.contains(cpyCtr) && isFilter)
+      if(line.contains(cpyCtr))
       {
-        // outLines.push_back("  public:");
-        outLines.push_back(line);
-        // outLines.push_back(mvCtr);
-        didReplace = true;
+        if(!outLines.last().contains("public:"))
+        {
+          outLines.push_back("  public:");
+          lineIndex++;
+          didReplace = true;
+        }
+        cpyCtrLine = lineIndex;
       }
-      else if(line.contains(cpyAssign) && isFilter)
+      else if(line.contains(mvCtr))
       {
-        outLines.push_back(cpyAssignRepl);
-        outLines.push_back(mvAssign);
-        didReplace = true;
+        mvCtrLine = lineIndex;
       }
-      else if(line.contains(mvAssign1) && isFilter)
+      else if(line.contains(cpyAssign))
       {
-        outLines.push_back(cpyAssignRepl);
-        outLines.push_back(mvAssign);
-        didReplace = true;
+        cpyAssignLine = lineIndex;
       }
-      else if(line.contains("virtual const QString getCompiledLibraryName() const override"))
+      else if(line.contains(mvAssign))
+      {
+        mvAssignLine = lineIndex;
+      }
+      else if(line.contains(cpyAssignOld))
+      {
+        cpyAssignOldLine = lineIndex;
+      }
+      else if(line.contains("virtual ~") && !isFilter)
       {
         QString replaceString = line;
         replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QString getBrandingString() const override"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QString getFilterVersion() const override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) const override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QString getGroupName() const override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QString getSubGroupName() const override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QUuid getUuid() override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual const QString getHumanLabel() const override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-
-      else if(line.contains("virtual void setupFilterParameters() override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual void execute() override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual void preflight() override;"))
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("virtual ~") && isFilter)
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("virtual ", "");
-        replaceString = replaceString.replace(";", " override;");
-        outLines.push_back(replaceString);
-        didReplace = true;
-      }
-      else if(line.contains("SIMPL_STATIC_NEW_MACRO") && isFilter)
-      {
-        QString replaceString = line;
-        replaceString = replaceString.replace("SIMPL_STATIC_NEW_MACRO", "SIMPL_FILTER_NEW_MACRO");
-        outLines.push_back(replaceString);
+        // replaceString = replaceString.replace(";", " override;");
+        // outLines.push_back(replaceString);
         didReplace = true;
       }
       else if(line.contains(": public AbstractFilter"))
       {
-        std::cout << "isFilter = True" << std::endl;
+        // std::cout << "isFilter = True" << std::endl;
         isFilter = true;
-        outLines.push_back(line);
+        // outLines.push_back(line);
       }
       else
       {
-        outLines.push_back(line);
+        // outLines.push_back(line);
       }
+      outLines.push_back(line);
+      lineIndex++;
     }
+
+    if(cpyCtrLine == 0)
+    {
+      std::cout << "#### " << hFile.toStdString() << std::endl;
+      return;
+    }
+
+    if(mvCtrLine == 0)
+    {
+      QString line = outLines[cpyCtrLine];
+      line = line + "\n" + "    " + mvCtr + " // Move Constructor Not Implemented";
+      outLines[cpyCtrLine] = line;
+      mvCtrLine = cpyCtrLine;
+      didReplace = true;
+    }
+    if(cpyAssignLine == 0)
+    {
+      QString line = outLines[mvCtrLine];
+      line = line + "\n" + "    " + cpyAssign + " // Copy Assignment Not Implemented";
+      outLines[mvCtrLine] = line;
+      cpyAssignLine = cpyCtrLine;
+      didReplace = true;
+    }
+    if(mvAssignLine == 0)
+    {
+      QString line = outLines[cpyAssignLine];
+      line = line + "\n" + "    " + mvAssign + " // Move Assignment Not Implemented";
+      outLines[cpyAssignLine] = line;
+      mvAssignLine = cpyCtrLine;
+      didReplace = true;
+    }
+    if(cpyAssignOldLine != 0)
+    {
+      outLines[cpyAssignOldLine] = "";
+      didReplace = true;
+    }
+
+    // didReplace = false;
+    writeOutput(didReplace, outLines, hFile);
 
     if(didReplace)
     {
-      std::cout << hFile.toStdString() << std::endl;
+      // std::cout << hFile.toStdString() << std::endl;
+      if(cpyCtrLine)
+      {
+        std::cout << "  cpyCtrLine: " << cpyCtrLine << std::endl;
+      }
+      if(mvCtrLine)
+      {
+        std::cout << "  mvCtrLine: " << mvCtrLine << std::endl;
+      }
+      if(cpyAssignLine)
+      {
+        std::cout << "  cpyAssignLine: " << cpyAssignLine << std::endl;
+      }
+      if(mvAssignLine)
+      {
+        std::cout << "  mvAssignLine: " << mvAssignLine << std::endl;
+      }
+      if(cpyAssignOldLine)
+      {
+        std::cout << "  cpyAssignOldLine: " << cpyAssignOldLine << std::endl;
+      }
     }
-
-    writeOutput(didReplace, outLines, hFile);
   }
 };


### PR DESCRIPTION
Classes are updated to use C++11 standard '=delete' or '=default' for each of
the copy and move constructors and copy and move assignments.

Other misc formatting updates to any affected classes.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>