### PR TITLE
Fix failing test due to different results from the FindFeatureCentroids change.

### DIFF
--- a/Source/Plugins/Generic/GenericFilters/FindFeatureCentroids.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindFeatureCentroids.cpp
@@ -157,9 +157,9 @@ void FindFeatureCentroids::find_centroids()
   size_t yPoints = imageGeom->getYPoints();
   size_t zPoints = imageGeom->getZPoints();
 
-  std::array<float, 3> resolution = {0.0f, 0.0f, 0.0f};
+  std::array<float, 3> resolution = {{0.0f, 0.0f, 0.0f}};
   imageGeom->getResolution(resolution.data());
-  std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
+  std::array<float, 3> origin = {{0.0f, 0.0f, 0.0f}};
   imageGeom->getOrigin(origin.data());
 
   size_t zStride = 0;
@@ -174,7 +174,7 @@ void FindFeatureCentroids::find_centroids()
       {
         int32_t gnum = m_FeatureIds[zStride + yStride + k];
         featurecenters[gnum * 4 + 0]++;
-        std::array<float, 3> coords = {0.0f, 0.0f, 0.0f};
+        std::array<float, 3> coords = {{0.0f, 0.0f, 0.0f}};
         imageGeom->getCoords(k, j, i, coords.data());
         featurecenters[gnum * 4 + 1] = featurecenters[gnum * 4 + 1] + coords[0];
         featurecenters[gnum * 4 + 2] = featurecenters[gnum * 4 + 2] + coords[1];

--- a/Source/Plugins/Statistics/Test/FindShapesTest.cpp
+++ b/Source/Plugins/Statistics/Test/FindShapesTest.cpp
@@ -55,12 +55,8 @@ class FindShapesTest
 {
 
 public:
-  FindShapesTest()
-  {
-  }
-  virtual ~FindShapesTest()
-  {
-  }
+  FindShapesTest() = default;
+  virtual ~FindShapesTest() = default;
 
 #define DREAM3D_CLOSE_ENOUGH(L, R, eps)                                                                                                                                                                \
   if(false == SIMPLibMath::closeEnough<>(L, R, eps))                                                                                                                                                   \
@@ -288,7 +284,7 @@ public:
     DREAM3D_REQUIRE_EQUAL(axisEulerAngles->getNumberOfTuples(), 2);
     DREAM3D_REQUIRE_EQUAL(aspectRatios->getNumberOfTuples(), 2);
 
-    DREAM3D_CLOSE_ENOUGH(omega3s->getValue(1), 0.7879f, 0.0001f);
+    DREAM3D_CLOSE_ENOUGH(omega3s->getValue(1), 0.78715f, 0.0001f);
 
     DREAM3D_CLOSE_ENOUGH(axisLengths->getValue(3), 120.0f, 1.5f);
     DREAM3D_CLOSE_ENOUGH(axisLengths->getValue(4), 40.0f, 1.5f);
@@ -353,7 +349,11 @@ public:
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
 
-private:
-  FindShapesTest(const FindShapesTest&); // Copy Constructor Not Implemented
-  void operator=(const FindShapesTest&); // Move assignment Not Implemented
+  public:
+  FindShapesTest(const FindShapesTest&) = delete; // Copy Constructor Not Implemented
+  FindShapesTest(FindShapesTest&&) = delete;      // Move Constructor Not Implemented
+  FindShapesTest& operator=(const FindShapesTest&) = delete; // Copy Assignment Not Implemented
+  FindShapesTest& operator=(FindShapesTest&&) = delete;      // Move Assignment Not Implemented
+
+
 };


### PR DESCRIPTION
The newer computed value is now used as the exemplar for the test.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>