### PR TITLE
Additional fixes to QuickSurfaceMesh to address triangle winding issues.

### DIFF
--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
@@ -72,6 +72,9 @@ public:
   SIMPL_FILTER_PARAMETER(QString, SurfaceDataContainerName)
   Q_PROPERTY(QString SurfaceDataContainerName READ getSurfaceDataContainerName WRITE setSurfaceDataContainerName)
 
+  SIMPL_FILTER_PARAMETER(QString, TripleLineDataContainerName)
+  Q_PROPERTY(QString TripleLineDataContainerName READ getTripleLineDataContainerName WRITE setTripleLineDataContainerName)
+
   SIMPL_FILTER_PARAMETER(QString, VertexAttributeMatrixName)
   Q_PROPERTY(QString VertexAttributeMatrixName READ getVertexAttributeMatrixName WRITE setVertexAttributeMatrixName)
 

--- a/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomCentroidsTest.cpp
+++ b/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomCentroidsTest.cpp
@@ -54,12 +54,14 @@ class FindTriangleGeomCentroidsTest
 {
 
 public:
-  FindTriangleGeomCentroidsTest()
-  {
-  }
-  virtual ~FindTriangleGeomCentroidsTest()
-  {
-  }
+  FindTriangleGeomCentroidsTest() = default;
+  ~FindTriangleGeomCentroidsTest() = default;
+
+  SIMPL_TYPE_MACRO(FindTriangleGeomCentroidsTest)
+  FindTriangleGeomCentroidsTest(const FindTriangleGeomCentroidsTest&) = delete;            // Copy Constructor Not Implemented
+  FindTriangleGeomCentroidsTest(FindTriangleGeomCentroidsTest&&) = delete;                 // Move Constructor Not Implemented
+  FindTriangleGeomCentroidsTest& operator=(const FindTriangleGeomCentroidsTest&) = delete; // Copy Assignment Not Implemented
+  FindTriangleGeomCentroidsTest& operator=(FindTriangleGeomCentroidsTest&&) = delete;      // Move Assignment Not Implemented
 
   // -----------------------------------------------------------------------------
   //
@@ -286,6 +288,7 @@ public:
   void operator()()
   {
     int err = EXIT_SUCCESS;
+    std::cout << "---- " << getNameOfClass().toStdString() << " ----" << std::endl;
 
     DREAM3D_REGISTER_TEST(TestFilterAvailability());
 
@@ -293,8 +296,4 @@ public:
 
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
-
-private:
-  FindTriangleGeomCentroidsTest(const FindTriangleGeomCentroidsTest&); // Copy Constructor Not Implemented
-  void operator=(const FindTriangleGeomCentroidsTest&);                // Move assignment Not Implemented
 };

--- a/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomNeighborsTest.cpp
+++ b/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomNeighborsTest.cpp
@@ -55,12 +55,13 @@ class FindTriangleGeomNeighborsTest
 {
 
 public:
-  FindTriangleGeomNeighborsTest()
-  {
-  }
-  virtual ~FindTriangleGeomNeighborsTest()
-  {
-  }
+  FindTriangleGeomNeighborsTest() = default;
+  ~FindTriangleGeomNeighborsTest() = default;
+  SIMPL_TYPE_MACRO(FindTriangleGeomNeighborsTest)
+  FindTriangleGeomNeighborsTest(const FindTriangleGeomNeighborsTest&) = delete;            // Copy Constructor Not Implemented
+  FindTriangleGeomNeighborsTest(FindTriangleGeomNeighborsTest&&) = delete;                 // Move Constructor Not Implemented
+  FindTriangleGeomNeighborsTest& operator=(const FindTriangleGeomNeighborsTest&) = delete; // Copy Assignment Not Implemented
+  FindTriangleGeomNeighborsTest& operator=(FindTriangleGeomNeighborsTest&&) = delete;      // Move Assignment Not Implemented
 
   // -----------------------------------------------------------------------------
   //
@@ -474,6 +475,7 @@ public:
   void operator()()
   {
     int err = EXIT_SUCCESS;
+    std::cout << "---- " << getNameOfClass().toStdString() << " ----" << std::endl;
 
     DREAM3D_REGISTER_TEST(TestFilterAvailability());
 
@@ -482,7 +484,4 @@ public:
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
 
-private:
-  FindTriangleGeomNeighborsTest(const FindTriangleGeomNeighborsTest&); // Copy Constructor Not Implemented
-  void operator=(const FindTriangleGeomNeighborsTest&);                // Move assignment Not Implemented
 };

--- a/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomShapesTest.cpp
+++ b/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomShapesTest.cpp
@@ -1,37 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
@@ -56,12 +56,15 @@ class FindTriangleGeomShapesTest
 {
 
 public:
-  FindTriangleGeomShapesTest()
-  {
-  }
-  virtual ~FindTriangleGeomShapesTest()
-  {
-  }
+  FindTriangleGeomShapesTest() = default;
+  ~FindTriangleGeomShapesTest() = default;
+
+  SIMPL_TYPE_MACRO(FindTriangleGeomShapesTest)
+
+  FindTriangleGeomShapesTest(const FindTriangleGeomShapesTest&) = delete;            // Copy Constructor Not Implemented
+  FindTriangleGeomShapesTest(FindTriangleGeomShapesTest&&) = delete;                 // Move Constructor Not Implemented
+  FindTriangleGeomShapesTest& operator=(const FindTriangleGeomShapesTest&) = delete; // Copy Assignment Not Implemented
+  FindTriangleGeomShapesTest& operator=(FindTriangleGeomShapesTest&&) = delete;      // Move Assignment Not Implemented
 
 #define DREAM3D_CLOSE_ENOUGH(L, R, eps)                                                                                                                                                                \
   if(false == SIMPLibMath::closeEnough<>(L, R, eps))                                                                                                                                                   \
@@ -80,8 +83,8 @@ public:
   void RemoveTestFiles()
   {
 #if REMOVE_TEST_FILES
-    QFile::remove(UnitTest::FindTriangleGeomShapesTest::TestFile1);
-    QFile::remove(UnitTest::FindTriangleGeomShapesTest::TestFile2);
+    QFile::remove(UnitTest::FindTriangleGeomShapesTest::TestFile);
+    QFile::remove(UnitTest::FindTriangleGeomShapesTest::TestFileXdmf);
 #endif
   }
 
@@ -159,6 +162,7 @@ public:
     bool propWasSet = true;
     QVariant var;
 
+    //##################################################################################################################
     QString filtName = "QuickSurfaceMesh";
     IFilterFactory::Pointer factory = fm->getFactoryFromClassName(filtName);
     DREAM3D_REQUIRE(factory.get() != nullptr);
@@ -177,6 +181,7 @@ public:
     int32_t err = meshFilter->getErrorCondition();
     DREAM3D_REQUIRE_EQUAL(err, 0);
 
+    //##################################################################################################################
     filtName = "FindTriangleGeomCentroids";
     factory = fm->getFactoryFromClassName(filtName);
     DREAM3D_REQUIRE(factory.get() != nullptr);
@@ -202,6 +207,7 @@ public:
     err = centroidsFilter->getErrorCondition();
     DREAM3D_REQUIRE_EQUAL(err, 0);
 
+    //##################################################################################################################
     filtName = "FindTriangleGeomSizes";
     factory = fm->getFactoryFromClassName(filtName);
     DREAM3D_REQUIRE(factory.get() != nullptr);
@@ -227,6 +233,7 @@ public:
     err = sizesFilter->getErrorCondition();
     DREAM3D_REQUIRE_EQUAL(err, 0);
 
+    //##################################################################################################################
     filtName = "FindTriangleGeomShapes";
     factory = fm->getFactoryFromClassName(filtName);
     DREAM3D_REQUIRE(factory.get() != nullptr);
@@ -266,29 +273,51 @@ public:
     err = shapesFilter->getErrorCondition();
     DREAM3D_REQUIRE_EQUAL(err, 0);
 
+    //##################################################################################################################
+    filtName = "DataContainerWriter";
+    factory = fm->getFactoryFromClassName(filtName);
+    DREAM3D_REQUIRE(factory.get() != nullptr);
+    AbstractFilter::Pointer writer = factory->create();
+    DREAM3D_REQUIRE(writer.get() != nullptr);
+    writer->setDataContainerArray(dca);
+    var.setValue(UnitTest::FindTriangleGeomShapesTest::TestFile);
+    propWasSet = writer->setProperty("OutputFile", var);
+    if(!propWasSet)
+    {
+      qDebug() << "Unable to set property OutputFile";
+    }
+    writer->execute();
+    err = writer->getErrorCondition();
+    DREAM3D_REQUIRED(err, >=, 0)
+
     AttributeMatrix::Pointer faceFeatAttrMat = dca->getDataContainer(SIMPL::Defaults::TriangleDataContainerName)->getAttributeMatrix(SIMPL::Defaults::FaceFeatureAttributeMatrixName);
-    FloatArrayType::Pointer omega3s = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::Omega3s);
+
+    FloatArrayType::Pointer centroids = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::Centroids);
+    DREAM3D_REQUIRE_EQUAL(centroids->getNumberOfTuples(), 2);
+    DREAM3D_CLOSE_ENOUGH(centroids->getValue(3), 128.0f, 0.0001f);
+    DREAM3D_CLOSE_ENOUGH(centroids->getValue(4), 64.0f, 0.0001f);
+    DREAM3D_CLOSE_ENOUGH(centroids->getValue(5), 32.0f, 0.0001f);
+
     FloatArrayType::Pointer axisLengths = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::AxisLengths);
-    FloatArrayType::Pointer axisEulerAngles = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::AxisEulerAngles);
-    FloatArrayType::Pointer aspectRatios = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::AspectRatios);
-
-    DREAM3D_REQUIRE_EQUAL(omega3s->getNumberOfTuples(), 2);
     DREAM3D_REQUIRE_EQUAL(axisLengths->getNumberOfTuples(), 2);
-    DREAM3D_REQUIRE_EQUAL(axisEulerAngles->getNumberOfTuples(), 2);
-    DREAM3D_REQUIRE_EQUAL(aspectRatios->getNumberOfTuples(), 2);
-
-    DREAM3D_CLOSE_ENOUGH(omega3s->getValue(1), 0.824f, 0.0001f);
-
     DREAM3D_CLOSE_ENOUGH(axisLengths->getValue(3), 160.0f, 1.0f);
     DREAM3D_CLOSE_ENOUGH(axisLengths->getValue(4), 80.0f, 1.0f);
     DREAM3D_CLOSE_ENOUGH(axisLengths->getValue(5), 40.0f, 1.0f);
 
+    FloatArrayType::Pointer axisEulerAngles = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::AxisEulerAngles);
+    DREAM3D_REQUIRE_EQUAL(axisEulerAngles->getNumberOfTuples(), 2);
     DREAM3D_CLOSE_ENOUGH(axisEulerAngles->getValue(3), 3.141f, 0.001f);
     DREAM3D_CLOSE_ENOUGH(axisEulerAngles->getValue(4), 0.0f, 0.001f);
     DREAM3D_CLOSE_ENOUGH(axisEulerAngles->getValue(5), 0.0f, 0.001f);
 
+    FloatArrayType::Pointer aspectRatios = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::AspectRatios);
+    DREAM3D_REQUIRE_EQUAL(aspectRatios->getNumberOfTuples(), 2);
     DREAM3D_CLOSE_ENOUGH(aspectRatios->getValue(2), 0.5f, 0.0001f);
     DREAM3D_CLOSE_ENOUGH(aspectRatios->getValue(3), 0.25f, 0.0001f);
+
+    FloatArrayType::Pointer omega3s = faceFeatAttrMat->getAttributeArrayAs<FloatArrayType>(SIMPL::FeatureData::Omega3s);
+    DREAM3D_REQUIRE_EQUAL(omega3s->getNumberOfTuples(), 2);
+    DREAM3D_CLOSE_ENOUGH(omega3s->getValue(1), 0.824f, 0.0001f);
 
     return EXIT_SUCCESS;
   }
@@ -299,6 +328,7 @@ public:
   void operator()()
   {
     int err = EXIT_SUCCESS;
+    std::cout << "---- " << getNameOfClass().toStdString() << " ----" << std::endl;
 
     DREAM3D_REGISTER_TEST(TestFilterAvailability());
 
@@ -306,8 +336,4 @@ public:
 
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
-
-private:
-  FindTriangleGeomShapesTest(const FindTriangleGeomShapesTest&); // Copy Constructor Not Implemented
-  void operator=(const FindTriangleGeomShapesTest&);             // Move assignment Not Implemented
 };

--- a/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomSizesTest.cpp
+++ b/Source/Plugins/SurfaceMeshing/Test/FindTriangleGeomSizesTest.cpp
@@ -54,12 +54,15 @@ class FindTriangleGeomSizesTest
 {
 
 public:
-  FindTriangleGeomSizesTest()
-  {
-  }
-  virtual ~FindTriangleGeomSizesTest()
-  {
-  }
+  FindTriangleGeomSizesTest() = default;
+  virtual ~FindTriangleGeomSizesTest() = default;
+
+  SIMPL_TYPE_MACRO(FindTriangleGeomSizesTest)
+
+  FindTriangleGeomSizesTest(const FindTriangleGeomSizesTest&) = delete;            // Copy Constructor Not Implemented
+  FindTriangleGeomSizesTest(FindTriangleGeomSizesTest&&) = delete;                 // Move Constructor Not Implemented
+  FindTriangleGeomSizesTest& operator=(const FindTriangleGeomSizesTest&) = delete; // Copy Assignment Not Implemented
+  FindTriangleGeomSizesTest& operator=(FindTriangleGeomSizesTest&&) = delete;      // Move Assignment Not Implemented
 
   // -----------------------------------------------------------------------------
   //
@@ -285,6 +288,7 @@ public:
   void operator()()
   {
     int err = EXIT_SUCCESS;
+    std::cout << "---- " << getNameOfClass().toStdString() << " ----" << std::endl;
 
     DREAM3D_REGISTER_TEST(TestFilterAvailability());
 
@@ -293,7 +297,4 @@ public:
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
 
-private:
-  FindTriangleGeomSizesTest(const FindTriangleGeomSizesTest&); // Copy Constructor Not Implemented
-  void operator=(const FindTriangleGeomSizesTest&);            // Move assignment Not Implemented
 };

--- a/Source/Plugins/SurfaceMeshing/Test/QuickSurfaceMeshTest.cpp
+++ b/Source/Plugins/SurfaceMeshing/Test/QuickSurfaceMeshTest.cpp
@@ -1,37 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
@@ -52,33 +52,30 @@
 
 #include "SurfaceMeshingTestFileLocations.h"
 
-#define SET_PROPERTIES_AND_CHECK(filter, featureIdsPath, surfMeshName, errVal)                                                                                                                         \
-  var.setValue(featureIdsPath);                                                                                                                                                                        \
-  propWasSet = filter->setProperty("FeatureIdsArrayPath", var);                                                                                                                                        \
-  if(false == propWasSet)                                                                                                                                                                              \
+#define SET_FILTER_PROPERTY_WITH_CHECK(filter, key, value, errVal)                                                                                                                                     \
+  var.setValue(value);                                                                                                                                                                                 \
+  propWasSet = filter->setProperty(key, var);                                                                                                                                                          \
+  if(!propWasSet)                                                                                                                                                                                      \
   {                                                                                                                                                                                                    \
-    qDebug() << "Unable to set property FeatureIdsArrayPath";                                                                                                                                          \
+    qDebug() << "Unable to set property " << key;                                                                                                                                                      \
   }                                                                                                                                                                                                    \
-  var.setValue(surfMeshName);                                                                                                                                                                          \
-  propWasSet = filter->setProperty("SurfaceDataContainerName", var);                                                                                                                                   \
-  if(false == propWasSet)                                                                                                                                                                              \
-  {                                                                                                                                                                                                    \
-    qDebug() << "Unable to set property SurfaceDataContainerName";                                                                                                                                     \
-  }                                                                                                                                                                                                    \
-  filter->execute();                                                                                                                                                                                   \
-  err = filter->getErrorCondition();                                                                                                                                                                   \
-  DREAM3D_REQUIRE_EQUAL(err, 0);
+  DREAM3D_REQUIRE_EQUAL(propWasSet, true)
 
+/**
+ * @brief The QuickSurfaceMeshTest class
+ */
 class QuickSurfaceMeshTest
 {
 public:
-  QuickSurfaceMeshTest()
-  {
-  }
-  virtual ~QuickSurfaceMeshTest()
-  {
-  }
+  QuickSurfaceMeshTest() = default;
+  ~QuickSurfaceMeshTest() = default;
+
   SIMPL_TYPE_MACRO(QuickSurfaceMeshTest)
+
+  QuickSurfaceMeshTest(const QuickSurfaceMeshTest&) = delete;            // Copy Constructor Not Implemented
+  QuickSurfaceMeshTest(QuickSurfaceMeshTest&&) = delete;                 // Move Constructor Not Implemented
+  QuickSurfaceMeshTest& operator=(const QuickSurfaceMeshTest&) = delete; // Copy Assignment Not Implemented
+  QuickSurfaceMeshTest& operator=(QuickSurfaceMeshTest&&) = delete;      // Move Assignment Not Implemented
 
   // -----------------------------------------------------------------------------
   //
@@ -87,7 +84,7 @@ public:
   {
 #if REMOVE_TEST_FILES
     QFile::remove(UnitTest::QuickSurfaceMeshTest::TestFile1);
-    QFile::remove(UnitTest::QuickSurfaceMeshTest::TestFile2);
+    QFile::remove(UnitTest::QuickSurfaceMeshTest::TestFile1Xdmf);
 #endif
   }
 
@@ -125,7 +122,7 @@ public:
 
     // Create an instance of each geometry for testing
     ImageGeom::Pointer image3D = ImageGeom::CreateGeometry(SIMPL::Geometry::ImageGeometry);
-    size_t dims[3] = { 2, 2, 1 };
+    size_t dims[3] = {2, 2, 1};
     image3D->setDimensions(dims);
     image3D_DC->setGeometry(image3D);
 
@@ -179,23 +176,56 @@ public:
   }
 
   // -----------------------------------------------------------------------------
-  //
-  // -----------------------------------------------------------------------------
-  void validateQuickSurfaceMesh(AbstractFilter::Pointer filter, DataContainerArray::Pointer dca)
+  void validateQuickSurfaceMesh(const AbstractFilter::Pointer& filter, const DataContainerArray::Pointer& dca)
   {
     QVariant var;
     bool propWasSet;
     int err = 0;
 
     DataArrayPath imageGeom3D_featureIds("ImageGeom3D", "Image3DData", "FeatureIds");
-    DataArrayPath rectGrid_featureIds("RectGrid", "RectGridData", "FeatureIds");
-
     QString imageSurfMesh = "ImageSurfMesh";
+    QString imageSurfMeshTripleLineDCName = "SurfaceMesh TripleLines";
+
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "FeatureIdsArrayPath", imageGeom3D_featureIds, err)
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "SurfaceDataContainerName", imageSurfMesh, err)
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "TripleLineDataContainerName", imageSurfMeshTripleLineDCName, err)
+    // Run the filter NOW to create the ImageGeom based surface mesh
+    filter->execute();
+    err = filter->getErrorCondition();
+    DREAM3D_REQUIRE_EQUAL(err, 0);
+
+    // Now setup to create a surface mesh from a RectilinearGrid Geometry
+    DataArrayPath rectGrid_featureIds("RectGrid", "RectGridData", "FeatureIds");
     QString rectGridSurfMesh = "RectGridSurfMesh";
+    QString rectGridSurfMeshTripleLineDCName = "RectGrid TripleLines";
 
-    SET_PROPERTIES_AND_CHECK(filter, imageGeom3D_featureIds, imageSurfMesh, err);
-    SET_PROPERTIES_AND_CHECK(filter, rectGrid_featureIds, rectGridSurfMesh, err);
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "FeatureIdsArrayPath", rectGrid_featureIds, err)
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "SurfaceDataContainerName", rectGridSurfMesh, err)
+    SET_FILTER_PROPERTY_WITH_CHECK(filter, "TripleLineDataContainerName", rectGridSurfMeshTripleLineDCName, err)
 
+    filter->execute();
+    err = filter->getErrorCondition();
+    DREAM3D_REQUIRE_EQUAL(err, 0);
+
+    //##################################################################################################################
+    FilterManager* fm = FilterManager::Instance();
+    QString filtName = "DataContainerWriter";
+    IFilterFactory::Pointer factory = fm->getFactoryFromClassName(filtName);
+    DREAM3D_REQUIRE(factory.get() != nullptr);
+    AbstractFilter::Pointer writer = factory->create();
+    DREAM3D_REQUIRE(writer.get() != nullptr);
+    writer->setDataContainerArray(dca);
+    var.setValue(UnitTest::QuickSurfaceMeshTest::TestFile1);
+    propWasSet = writer->setProperty("OutputFile", var);
+    if(!propWasSet)
+    {
+      qDebug() << "Unable to set property OutputFile";
+    }
+    writer->execute();
+    err = writer->getErrorCondition();
+    DREAM3D_REQUIRED(err, >=, 0)
+
+    //##################################################################################################################
     TriangleGeom::Pointer imageSurfMeshGeom = dca->getDataContainer(imageSurfMesh)->getGeometryAs<TriangleGeom>();
     TriangleGeom::Pointer rectGridSurfMeshGeom = dca->getDataContainer(rectGridSurfMesh)->getGeometryAs<TriangleGeom>();
 
@@ -211,192 +241,77 @@ public:
 
     DREAM3D_REQUIRE_EQUAL(imageMeshTris->getNumberOfTuples(), rectGridMeshTris->getNumberOfTuples());
 
+    int64_t tri[3] = {0, 0, 0};
+
+    /**
+     * This next bit of code uses a fixed array based that was manually verified by using ParaView to look at the mesh
+     * and then verifiy that the winding is correct. The bit of code that _should_ be used is the constant 2D array. If
+     * the QuickSurfaceMesh is changed so that this test starts failing the developer will need to go back through the
+     * generated mesh manually and verify the output is correct. Then they can flip the #define from 1 to 0 (look a bit
+     * farther down for another one), run the test, and then copy the proper output from the test which will generate the
+     * proper 2D array again. Once you paste that code in here, flip the #define back to 1 from 0 and run the test. The
+     * UnitTest should now pass.
+     */
+#if 1
+    float k_TriangleIndices[36][3] = {
+        /* 0 */ {0, 2, 1},
+        /* 1 */ {1, 2, 3},
+        /* 2 */ {0, 4, 2},
+        /* 3 */ {4, 5, 2},
+        /* 4 */ {0, 1, 4},
+        /* 5 */ {4, 1, 6},
+        /* 6 */ {6, 1, 7},
+        /* 7 */ {1, 3, 7},
+        /* 8 */ {5, 7, 2},
+        /* 9 */ {2, 7, 3},
+        /* 10 */ {4, 8, 5},
+        /* 11 */ {8, 9, 5},
+        /* 12 */ {4, 6, 8},
+        /* 13 */ {8, 6, 10},
+        /* 14 */ {8, 10, 9},
+        /* 15 */ {10, 11, 9},
+        /* 16 */ {10, 6, 11},
+        /* 17 */ {6, 7, 11},
+        /* 18 */ {9, 11, 5},
+        /* 19 */ {5, 11, 7},
+        /* 20 */ {1, 3, 12},
+        /* 21 */ {12, 3, 13},
+        /* 22 */ {1, 12, 6},
+        /* 23 */ {6, 12, 14},
+        /* 24 */ {14, 12, 15},
+        /* 25 */ {12, 13, 15},
+        /* 26 */ {7, 15, 3},
+        /* 27 */ {3, 15, 13},
+        /* 28 */ {6, 14, 10},
+        /* 29 */ {10, 14, 16},
+        /* 30 */ {10, 16, 11},
+        /* 31 */ {16, 17, 11},
+        /* 32 */ {16, 14, 17},
+        /* 33 */ {14, 15, 17},
+        /* 34 */ {11, 17, 7},
+        /* 35 */ {7, 17, 15},
+    };
+#else
+    std::cout << "float k_TriangleIndices[" << imageSurfMeshGeom->getNumberOfTris() << "][3] = {" << std::endl;
+    for(size_t t = 0; t < imageSurfMeshGeom->getNumberOfTris(); t++)
+    {
+      imageSurfMeshGeom->getVertsAtTri(t, tri);
+      std::cout << "  /* " << t << "*/  {" << tri[0] << ", " << tri[1] << ", " << tri[2] << "}, " << std::endl;
+    }
+    std::cout << "};" << std::endl;
+#endif
     for(size_t i = 0; i < imageMeshTris->getSize(); i++)
     {
       DREAM3D_REQUIRE_EQUAL(imageTriPtr[i], rectGridTriPtr[i]);
     }
 
-    int64_t tri[3] = {0, 0, 0};
-
-    imageSurfMeshGeom->getVertsAtTri(0, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 0);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 2);
-
-    imageSurfMeshGeom->getVertsAtTri(1, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 3);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 2);
-
-    imageSurfMeshGeom->getVertsAtTri(2, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 0);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 2);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 4);
-
-    imageSurfMeshGeom->getVertsAtTri(3, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 4);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 2);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 5);
-
-    imageSurfMeshGeom->getVertsAtTri(4, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 0);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 4);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 1);
-
-    imageSurfMeshGeom->getVertsAtTri(5, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 4);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 1);
-
-    imageSurfMeshGeom->getVertsAtTri(6, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 7);
-
-    imageSurfMeshGeom->getVertsAtTri(7, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 3);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 7);
-
-    imageSurfMeshGeom->getVertsAtTri(8, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 2);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 7);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 5);
-
-    imageSurfMeshGeom->getVertsAtTri(9, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 3);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 7);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 2);
-
-    imageSurfMeshGeom->getVertsAtTri(10, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 4);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 5);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 8);
-
-    imageSurfMeshGeom->getVertsAtTri(11, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 8);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 5);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 9);
-
-    imageSurfMeshGeom->getVertsAtTri(12, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 4);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 8);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 6);
-
-    imageSurfMeshGeom->getVertsAtTri(13, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 8);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 10);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 6);
-
-    imageSurfMeshGeom->getVertsAtTri(14, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 9);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 10);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 8);
-
-    imageSurfMeshGeom->getVertsAtTri(15, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 9);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 11);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 10);
-
-    imageSurfMeshGeom->getVertsAtTri(16, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 10);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 11);
-
-    imageSurfMeshGeom->getVertsAtTri(17, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 7);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 11);
-
-    imageSurfMeshGeom->getVertsAtTri(18, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 5);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 11);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 9);
-
-    imageSurfMeshGeom->getVertsAtTri(19, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 7);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 11);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 5);
-
-    imageSurfMeshGeom->getVertsAtTri(20, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 12);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 3);
-
-    imageSurfMeshGeom->getVertsAtTri(21, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 12);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 13);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 3);
-
-    imageSurfMeshGeom->getVertsAtTri(22, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 1);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 12);
-
-    imageSurfMeshGeom->getVertsAtTri(23, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 14);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 12);
-
-    imageSurfMeshGeom->getVertsAtTri(24, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 12);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 14);
-
-    imageSurfMeshGeom->getVertsAtTri(25, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 13);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 12);
-
-    imageSurfMeshGeom->getVertsAtTri(26, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 3);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 7);
-
-    imageSurfMeshGeom->getVertsAtTri(27, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 13);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 3);
-
-    imageSurfMeshGeom->getVertsAtTri(28, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 6);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 10);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 14);
-
-    imageSurfMeshGeom->getVertsAtTri(29, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 10);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 16);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 14);
-
-    imageSurfMeshGeom->getVertsAtTri(30, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 11);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 16);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 10);
-
-    imageSurfMeshGeom->getVertsAtTri(31, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 11);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 17);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 16);
-
-    imageSurfMeshGeom->getVertsAtTri(32, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 17);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 14);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 16);
-
-    imageSurfMeshGeom->getVertsAtTri(33, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 17);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 14);
-
-    imageSurfMeshGeom->getVertsAtTri(34, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 7);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 17);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 11);
-
-    imageSurfMeshGeom->getVertsAtTri(35, tri);
-    DREAM3D_REQUIRE_EQUAL(tri[0], 15);
-    DREAM3D_REQUIRE_EQUAL(tri[1], 17);
-    DREAM3D_REQUIRE_EQUAL(tri[2], 7);
+    for(size_t t = 0; t < imageSurfMeshGeom->getNumberOfTris(); t++)
+    {
+      imageSurfMeshGeom->getVertsAtTri(t, tri);
+      DREAM3D_REQUIRE_EQUAL(tri[0], k_TriangleIndices[t][0]);
+      DREAM3D_REQUIRE_EQUAL(tri[1], k_TriangleIndices[t][1]);
+      DREAM3D_REQUIRE_EQUAL(tri[2], k_TriangleIndices[t][2]);
+    }
 
     SharedVertexList::Pointer imageMeshVerts = imageSurfMeshGeom->getVertices();
     SharedVertexList::Pointer rectGridMeshVerts = rectGridSurfMeshGeom->getVertices();
@@ -413,96 +328,46 @@ public:
     }
 
     float coords[3] = {0, 0, 0};
+#if 1
+    float k_VertexCoords[18][3] = {
+        /* 0 */ {0.00000f, 0.00000f, 0.00000f},
+        /* 1 */ {0.00000f, 1.00000f, 0.00000f},
+        /* 2 */ {0.00000f, 0.00000f, 1.00000f},
+        /* 3 */ {0.00000f, 1.00000f, 1.00000f},
+        /* 4 */ {1.00000f, 0.00000f, 0.00000f},
+        /* 5 */ {1.00000f, 0.00000f, 1.00000f},
+        /* 6 */ {1.00000f, 1.00000f, 0.00000f},
+        /* 7 */ {1.00000f, 1.00000f, 1.00000f},
+        /* 8 */ {2.00000f, 0.00000f, 0.00000f},
+        /* 9 */ {2.00000f, 0.00000f, 1.00000f},
+        /* 10 */ {2.00000f, 1.00000f, 0.00000f},
+        /* 11 */ {2.00000f, 1.00000f, 1.00000f},
+        /* 12 */ {0.00000f, 2.00000f, 0.00000f},
+        /* 13 */ {0.00000f, 2.00000f, 1.00000f},
+        /* 14 */ {1.00000f, 2.00000f, 0.00000f},
+        /* 15 */ {1.00000f, 2.00000f, 1.00000f},
+        /* 16 */ {2.00000f, 2.00000f, 0.00000f},
+        /* 17 */ {2.00000f, 2.00000f, 1.00000f},
+    };
+#else
+    std::cout.precision(5);
+    std::cout << "float k_VertexCoords[" << imageSurfMeshGeom->getNumberOfVertices() << "][3] = {" << std::endl;
+    std::cout << std::fixed;
+    for(size_t v = 0; v < imageSurfMeshGeom->getNumberOfVertices(); v++)
+    {
+      imageSurfMeshGeom->getCoords(v, coords);
+      std::cout << "  /* " << v << "*/  {" << coords[0] << ", " << coords[1] << ", " << coords[2] << "}, " << std::endl;
+    }
+    std::cout << "};" << std::endl;
+#endif
 
-    imageSurfMeshGeom->getCoords(0, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(1, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(2, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(3, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(4, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(5, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(6, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(7, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(8, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(9, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(10, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(11, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(12, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(13, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 0.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(14, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(15, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 1.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
-
-    imageSurfMeshGeom->getCoords(16, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 0.0f);
-
-    imageSurfMeshGeom->getCoords(17, coords);
-    DREAM3D_REQUIRE_EQUAL(coords[0], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[1], 2.0f);
-    DREAM3D_REQUIRE_EQUAL(coords[2], 1.0f);
+    for(size_t v = 0; v < imageSurfMeshGeom->getNumberOfVertices(); v++)
+    {
+      imageSurfMeshGeom->getCoords(v, coords);
+      DREAM3D_REQUIRE_EQUAL(coords[0], k_VertexCoords[v][0]);
+      DREAM3D_REQUIRE_EQUAL(coords[1], k_VertexCoords[v][1]);
+      DREAM3D_REQUIRE_EQUAL(coords[2], k_VertexCoords[v][2]);
+    }
   }
 
   // -----------------------------------------------------------------------------
@@ -527,19 +392,17 @@ public:
     return EXIT_SUCCESS;
   }
   /**
-* @brief
-*/
+   * @brief
+   */
   void operator()()
   {
     int err = EXIT_SUCCESS;
+    std::cout << "---- " << getNameOfClass().toStdString() << " ----" << std::endl;
+
     DREAM3D_REGISTER_TEST(TestFilterAvailability());
 
     DREAM3D_REGISTER_TEST(RunTest())
 
     DREAM3D_REGISTER_TEST(RemoveTestFiles())
   }
-
-private:
-  QuickSurfaceMeshTest(const QuickSurfaceMeshTest&); // Copy Constructor Not Implemented
-  void operator=(const QuickSurfaceMeshTest&);       // Move assignment Not Implemented
 };

--- a/Source/Plugins/SurfaceMeshing/Test/TestFileLocations.h.in
+++ b/Source/Plugins/SurfaceMeshing/Test/TestFileLocations.h.in
@@ -26,55 +26,43 @@ namespace UnitTest
     static const size_t Offset = 200;
   }
 
+  const QString TestTempDir("@TEST_TEMP_DIR@");
+
   namespace CropVolumeTest
   {
     const QString CropVolumeTest_3("@TEST_TEMP_DIR@/CropVolumeTest_3.dream3d");
     const QString CropVolumeTest_4("@TEST_TEMP_DIR@/CropVolumeTest_4.dream3d");
   }
-}
 
-namespace UnitTest
-{
   namespace QuickSurfaceMeshTest
   {
-   const QString TestFile1("@TEST_TEMP_DIR@/TestFile1.txt");
-   const QString TestFile2("@TEST_TEMP_DIR@/TestFile2.txt");
+   const QString TestFile1("@TEST_TEMP_DIR@/QuickSurfaceMeshTest.dream3d");
+   const QString TestFile1Xdmf("@TEST_TEMP_DIR@/QuickSurfaceMeshTest.xdmf");
   }
-}
 
-namespace UnitTest
-{
   namespace FindTriangleGeomSizesTest
   {
    const QString TestFile1("@TEST_TEMP_DIR@/TestFile1.txt");
    const QString TestFile2("@TEST_TEMP_DIR@/TestFile2.txt");
   }
-}
 
-namespace UnitTest
-{
   namespace FindTriangleGeomCentroidsTest
   {
    const QString TestFile1("@TEST_TEMP_DIR@/TestFile1.txt");
    const QString TestFile2("@TEST_TEMP_DIR@/TestFile2.txt");
   }
-}
 
-namespace UnitTest
-{
   namespace FindTriangleGeomNeighborsTest
   {
    const QString TestFile1("@TEST_TEMP_DIR@/TestFile1.txt");
    const QString TestFile2("@TEST_TEMP_DIR@/TestFile2.txt");
   }
-}
 
-namespace UnitTest
-{
   namespace FindTriangleGeomShapesTest
   {
-   const QString TestFile1("@TEST_TEMP_DIR@/TestFile1.txt");
-   const QString TestFile2("@TEST_TEMP_DIR@/TestFile2.txt");
+   const QString TestFile("@TEST_TEMP_DIR@/FindTriangleGeomShapesTest.dream3d");
+   const QString TestFileXdmf("@TEST_TEMP_DIR@/FindTriangleGeomShapesTest.xdmf");
+
   }
 }
 


### PR DESCRIPTION
This fix addresses an issue where for specific cases of a voxel the triangle
winding was incorrect.

In addition to the filter fixes, all of the SurfaceMeshPlugin UnitTests have been
updated to better conform to modern C++ standards, compacted codes, add additional
test coverage and clang-formatted the file.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>