### PR TITLE
Remove calls to styling API that does not return any CSS. 

### DIFF
--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoCreationWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EnsembleInfoCreationWidget.cpp
@@ -126,10 +126,7 @@ void EnsembleInfoCreationWidget::setupGui()
   EnsembleInfo info = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<EnsembleInfo>();
   m_EnsembleInfoTableModel->setTableData(info);
 
-//  addBtn->setStyleSheet(SVStyle::StyleSheetForButton(addBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::AddImagePath));
-//  deleteBtn->setStyleSheet(SVStyle::StyleSheetForButton(deleteBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::DeleteImagePath));
- 
- 
+
 #if 0
   // is the filter parameter tied to a boolean property of the Filter Instance, if it is then we need to make the check box visible
   if(getFilterParameter()->isConditional())

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.cpp
@@ -192,16 +192,6 @@ void StatsGeneratorWidget::setupGui()
   // Catch when the filter wants its values updated
   connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
   
-  editPhase->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(editPhase->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::CogImagePath));
-  addPhase->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(addPhase->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::AddImagePath));
-  deletePhase->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(deletePhase->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::DeleteImagePath));
-
-  updatePipelineBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(updatePipelineBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::ReloadImagePath));
-  openStatsFile->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(openStatsFile->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::LoadImagePath));
-  saveJsonBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(saveJsonBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::ReloadImagePath));
-  saveH5Btn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(saveH5Btn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::HDFImagePath));
-
-
   // Hide the debugging buttons
   updatePipelineBtn->hide();
   saveJsonBtn->hide();

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/UI_Files/StatsGeneratorWidget.ui
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/UI_Files/StatsGeneratorWidget.ui
@@ -78,7 +78,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/cog.png</normaloff>:/cog.png</iconset>
+       <normaloff>:/SIMPL/icons/images/cog.png</normaloff>:/SIMPL/icons/images/cog.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -122,7 +122,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/data-transfer-download.png</normaloff>:/data-transfer-download.png</iconset>
+       <normaloff>:/SIMPL/icons/images/data-transfer-download.png</normaloff>:/SIMPL/icons/images/data-transfer-download.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -169,7 +169,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/delete.png</normaloff>:/delete.png</iconset>
+       <normaloff>:/SIMPL/icons/images/delete.png</normaloff>:/SIMPL/icons/images/delete.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -210,7 +210,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/reload.png</normaloff>:/reload.png</iconset>
+       <normaloff>:/SIMPL/icons/images/reload.png</normaloff>:/SIMPL/icons/images/reload.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -257,7 +257,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/add.png</normaloff>:/add.png</iconset>
+       <normaloff>:/SIMPL/icons/images/add.png</normaloff>:/SIMPL/icons/images/add.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -298,7 +298,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/data-transfer-hdf.png</normaloff>:/data-transfer-hdf.png</iconset>
+       <normaloff>:/SIMPL/icons/images/data-transfer-hdf.png</normaloff>:/SIMPL/icons/images/data-transfer-hdf.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -372,7 +372,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../../../../ExternalProjects/SIMPL/Resources/SIMPL.qrc">
-       <normaloff>:/SIMPL/icons/images/data-transfer-upload.png</normaloff>:/data-transfer-upload.png</iconset>
+       <normaloff>:/SIMPL/icons/images/data-transfer-upload.png</normaloff>:/SIMPL/icons/images/data-transfer-upload.png</iconset>
      </property>
      <property name="iconSize">
       <size>

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
@@ -331,12 +331,6 @@ void StatsGenAxisODFWidget::setupGui()
   m_MDFParametersBtn->setVisible(false);
   horizontalLine->setVisible(false);
 
-  // Style the buttons
-  addODFTextureBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(addODFTextureBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::AddImagePath));  
-  deleteODFTextureBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(deleteODFTextureBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::DeleteImagePath));
-  m_CalculateODFBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(m_CalculateODFBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::ReloadImagePath));
-  savePoleFigureImage->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(savePoleFigureImage->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::SaveImagePath));
-  
   on_m_ODFParametersBtn_clicked(true);
 }
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
@@ -131,12 +131,6 @@ void StatsGenMDFWidget::setupGui()
   QAbstractItemDelegate* aid = m_MDFTableModel->getItemDelegate();
   m_MDFTableView->setItemDelegate(aid);
   m_PlotCurve = new QwtPlotCurve;
-  
-  // Apple the Style to the buttons
-  addMDFRowBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(addMDFRowBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::AddImagePath));  
-  deleteMDFRowBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(deleteMDFRowBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::DeleteImagePath));
-  loadMDFBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(loadMDFBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::LoadImagePath));
-  m_MDFUpdateBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(m_MDFUpdateBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::ReloadImagePath));
 
 }
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
@@ -430,13 +430,6 @@ void StatsGenODFWidget::setupGui()
   m_ODFGroup.addButton(m_ODFParametersBtn);
   m_ODFGroup.addButton(m_MDFParametersBtn);
 
-  // Style the buttons
-  addODFTextureBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(addODFTextureBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::AddImagePath));  
-  deleteODFTextureBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(deleteODFTextureBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::DeleteImagePath));
-  m_CalculateODFBtn->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(m_CalculateODFBtn->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::ReloadImagePath));
-  savePoleFigureImage->setStyleSheet(SVStyle::Instance()->StyleSheetForButton(savePoleFigureImage->objectName(), SVWidgets::Styles::PushButtonStyleSheet, SVWidgets::Styles::SaveImagePath));
-  
-  
   on_m_ODFParametersBtn_clicked(true);
 }
 


### PR DESCRIPTION
API has been removed from SIMPL in another pull request but we can make the change now.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>