### PR TITLE
Create a filter that will import a montage of EBSD Data

### DIFF
--- a/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/ImportEbsdMontage.md
+++ b/Source/Plugins/OrientationAnalysis/Documentation/OrientationAnalysisFilters/ImportEbsdMontage.md
@@ -1,0 +1,53 @@
+# Import Ebsd Montage #
+
+## Group (Subgroup) ##
+
+Import/Export (Montage Import)
+
+## Description ##
+
+This **Filter** will import a collection of EBSD data files (Edax .ang or Oxford .ctf) and roughly calculate the proper coordiates for each tile within the global reference frame. Each data file will be placed into it's own DataContainer. This filter uses the _ReadAngData_ or _ReadCtfData_ filters to import the data. The filenames need to be named with the following pattern.
+
+	[File Prefix]r[RowIndex]c[ColIndex][FileSuffix].ang
+
+The user can set the name of the Cell and Ensemble Attribute Matrix that will be created in each DataContainer. The name of each DataContainer is based off the file used to populate the input data for that DataContainer.
+
+## Parameters ##
+
+| Name | Type | Description |
+|------|------|------|
+| Parameter Name | Parameter Type | Description of parameter... |
+
+## Required Geometry ##
+
+Required Geometry Type -or- Not Applicable
+
+## Required Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|-------------|---------|-----|
+| **Data Container** | Data Container Name | N/A | N/A | Description of object... |
+| **Attribute Matrix** | Attribute Matrix Name | Element/Feature/Ensemble/etc. | N/A | Description of object... |
+| **Element/Feature/Ensemble/etc. Attribute Array** | AttributeArray Name | int32_t/float/etc. | (1)/(3)/etc. | Description of object... |
+
+## Created Objects ##
+
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|-------------|---------|-----|
+| **Data Container** | Data Container Name | N/A | N/A | Description of object... |
+| **Attribute Matrix** | Attribute Matrix Name | Element/Feature/Ensemble/etc. | N/A | Description of object... |
+| **Element/Feature/Ensemble/etc. Attribute Array** | AttributeArray Name | int32_t/float/etc. | (1)/(3)/etc. | Description of object... |
+
+
+## Example Pipelines ##
+
+List the names of the example pipelines where this filter is used.
+
+## License & Copyright ##
+
+Please see the description file distributed with this plugin.
+
+## DREAM3D Mailing Lists ##
+
+If you need more help with a filter, please consider asking your question on the DREAM3D Users mailing list:
+https://groups.google.com/forum/?hl=en#!forum/dream3d-users

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.cpp
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.cpp
@@ -1,0 +1,106 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "EbsdMontageImportFilterParameter.h"
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonValue>
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+EbsdMontageImportFilterParameter::EbsdMontageImportFilterParameter() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+EbsdMontageImportFilterParameter::~EbsdMontageImportFilterParameter() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+EbsdMontageImportFilterParameter::Pointer EbsdMontageImportFilterParameter::New(const QString& humanLabel, const QString& propertyName, const EbsdMontageListInfo_t& defaultValue,
+                                                                                FilterParameter::Category category, SetterCallbackType setterCallback, GetterCallbackType getterCallback)
+{
+
+  EbsdMontageImportFilterParameter::Pointer ptr = EbsdMontageImportFilterParameter::New();
+  ptr->setHumanLabel(humanLabel);
+  ptr->setPropertyName(propertyName);
+  QVariant v;
+  v.setValue(defaultValue);
+  ptr->setDefaultValue(v);
+  ptr->setCategory(category);
+  ptr->setSetterCallback(setterCallback);
+  ptr->setGetterCallback(getterCallback);
+
+  return ptr;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString EbsdMontageImportFilterParameter::getWidgetType() const
+{
+  return QString("EbsdMontageImportWidget");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportFilterParameter::readJson(const QJsonObject& json)
+{
+  QJsonValue jsonValue = json[getPropertyName()];
+  if(!jsonValue.isUndefined() && m_SetterCallback)
+  {
+    QJsonObject jsonObj = jsonValue.toObject();
+    EbsdMontageListInfo_t fileListInfo;
+    fileListInfo.readJson(jsonObj);
+    m_SetterCallback(fileListInfo);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportFilterParameter::writeJson(QJsonObject& json)
+{
+  if(m_GetterCallback)
+  {
+    EbsdMontageListInfo_t fileListInfo = m_GetterCallback();
+    QJsonObject jsonObj;
+    fileListInfo.writeJson(jsonObj);
+    json[getPropertyName()] = jsonObj;
+  }
+}

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h
@@ -1,0 +1,193 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QMetaType>
+#include <QtCore/QString>
+
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/FilterParameters/FilterParameter.h"
+#include "SIMPLib/SIMPLib.h"
+
+using EbsdMontageListInfo_t = struct
+{
+  qint32 PaddingDigits = 3;
+  quint32 Ordering = 0; /* Ordering=0 = RowColumn, Ordering=1 = ColumnRow */
+  qint32 RowStart = 0;
+  qint32 RowEnd = 2;
+  qint32 ColStart = 0;
+  qint32 ColEnd = 2;
+  qint32 IncrementIndex = 1;
+  QString InputPath;
+  QString FilePrefix;
+  QString FileSuffix;
+  QString FileExtension;
+
+  void writeJson(QJsonObject& json)
+  {
+    json["PaddingDigits"] = static_cast<double>(PaddingDigits);
+    json["Ordering"] = static_cast<double>(Ordering);
+    json["RowStart"] = static_cast<double>(RowStart);
+    json["ColStart"] = static_cast<double>(ColStart);
+    json["RowEnd"] = static_cast<double>(RowEnd);
+    json["ColEnd"] = static_cast<double>(ColEnd);
+    json["IncrementIndex"] = static_cast<double>(IncrementIndex);
+    json["InputPath"] = InputPath;
+    json["FilePrefix"] = FilePrefix;
+    json["FileSuffix"] = FileSuffix;
+    json["FileExtension"] = FileExtension;
+  }
+
+  bool readJson(QJsonObject& json)
+  {
+    if(json["PaddingDigits"].isDouble() && json["Ordering"].isDouble() && json["RowStart"].isDouble() && json["ColStart"].isDouble() && json["IncrementIndex"].isDouble() &&
+       json["InputPath"].isString() && json["FilePrefix"].isString() && json["FileSuffix"].isString() && json["FileExtension"].isString())
+    {
+      PaddingDigits = static_cast<qint32>(json["PaddingDigits"].toDouble());
+      Ordering = static_cast<quint32>(json["Ordering"].toDouble());
+      RowStart = static_cast<qint32>(json["RowStart"].toDouble());
+      ColStart = static_cast<qint32>(json["ColStart"].toDouble());
+      RowEnd = static_cast<qint32>(json["RowEnd"].toDouble());
+      ColEnd = static_cast<qint32>(json["ColEnd"].toDouble());
+      IncrementIndex = static_cast<qint32>(json["IncrementIndex"].toDouble());
+      InputPath = json["InputPath"].toString();
+      FilePrefix = json["FilePrefix"].toString();
+      FileSuffix = json["FileSuffix"].toString();
+      FileExtension = json["FileExtension"].toString();
+      return true;
+    }
+    return false;
+  }
+};
+
+Q_DECLARE_METATYPE(EbsdMontageListInfo_t)
+
+/**
+ * @brief SIMPL_NEW_EbsdMontageListInfo_FP This macro is a short-form way of instantiating an instance of
+ * EbsdMontageImportFilterParameter. There are 4 required parameters that are always passed to this macro
+ * in the following order: HumanLabel, PropertyName, Category, FilterName (class name).
+ *
+ * Therefore, the macro should be written like this (this is a concrete example):
+ * SIMPL_NEW_EbsdMontageListInfo_FP("HumanLabel", PropertyName, Category, FilterName)
+ *
+ * Example 1 (instantiated within a filter called [GenericExample](@ref genericexample)):
+ * SIMPL_NEW_EbsdMontageListInfo_FP("Input File List", InputEbsdMontageListInfo, FilterParameter::Parameter, GenericExample);
+ */
+#define SIMPL_NEW_EbsdMontageListInfo_FP(...)                                                                                                                                                          \
+  SIMPL_EXPAND(_FP_GET_OVERRIDE(__VA_ARGS__, SIMPL_NEW_FP_9, SIMPL_NEW_FP_8, SIMPL_NEW_FP_7, SIMPL_NEW_FP_6, SIMPL_NEW_FP_5, SIMPL_NEW_FP_4)(EbsdMontageImportFilterParameter, __VA_ARGS__))
+
+/**
+ * @brief The EbsdMontageImportFilterParameter class is used by filters to instantiate an EbsdMontageListInfoWidget.  By instantiating an instance of
+ * this class in a filter's setupFilterParameters() method, a EbsdMontageListInfoWidget will appear in the filter's "filter input" section in the DREAM3D GUI.
+ */
+class EbsdMontageImportFilterParameter : public FilterParameter
+{
+public:
+  SIMPL_SHARED_POINTERS(EbsdMontageImportFilterParameter)
+  SIMPL_STATIC_NEW_MACRO(EbsdMontageImportFilterParameter)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(EbsdMontageImportFilterParameter, FilterParameter)
+
+  typedef std::function<void(EbsdMontageListInfo_t)> SetterCallbackType;
+  typedef std::function<EbsdMontageListInfo_t(void)> GetterCallbackType;
+
+  /**
+   * @brief New This function instantiates an instance of the EbsdMontageImportFilterParameter. Although this
+   * function is available to be used, the preferable way to instantiate an instance of this class is to use the
+   * SIMPL_NEW_EbsdMontageListInfo_FP(...) macro at the top of this file.
+
+   * @param humanLabel The name that the users of DREAM.3D see for this filter parameter
+   * @param propertyName The internal property name for this filter parameter.
+   * @param defaultValue The value that this filter parameter will be initialized to by default.
+   * @param category The category for the filter parameter in the DREAM.3D user interface.  There
+   * are three categories: Parameter, Required Arrays, and Created Arrays.
+   * @param setterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+  * that this FilterParameter subclass represents.
+   * @param getterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+  * that this FilterParameter subclass represents.
+   * @return
+   */
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const EbsdMontageListInfo_t& defaultValue, Category category, SetterCallbackType setterCallback,
+                     GetterCallbackType getterCallback);
+
+  ~EbsdMontageImportFilterParameter() override;
+
+  /**
+   * @brief getWidgetType Returns the type of widget that displays and controls
+   * this FilterParameter subclass
+   * @return
+   */
+  QString getWidgetType() const override;
+
+  /**
+   * @brief readJson Reads this filter parameter's corresponding property out of a QJsonObject.
+   * @param json The QJsonObject that the filter parameter reads from.
+   */
+  void readJson(const QJsonObject& json) override;
+
+  /**
+   * @brief writeJson Writes this filter parameter's corresponding property to a QJsonObject.
+   * @param json The QJsonObject that the filter parameter writes to.
+   */
+  void writeJson(QJsonObject& json) override;
+
+  /**
+   * @param SetterCallback The method in the AbstractFilter subclass that <i>sets</i> the value of the property
+   * that this FilterParameter subclass represents.
+   * from the filter parameter.
+   */
+  SIMPL_INSTANCE_PROPERTY(SetterCallbackType, SetterCallback)
+
+  /**
+   * @param GetterCallback The method in the AbstractFilter subclass that <i>gets</i> the value of the property
+   * that this FilterParameter subclass represents.
+   * @return The GetterCallback
+   */
+  SIMPL_INSTANCE_PROPERTY(GetterCallbackType, GetterCallback)
+
+protected:
+  /**
+   * @brief EbsdMontageImportFilterParameter The default constructor.  It is protected because this
+   * filter parameter should only be instantiated using its New(...) function or short-form macro.
+   */
+  EbsdMontageImportFilterParameter();
+
+public:
+  EbsdMontageImportFilterParameter(const EbsdMontageImportFilterParameter&) = delete;            // Copy Constructor Not Implemented
+  EbsdMontageImportFilterParameter(EbsdMontageImportFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+  EbsdMontageImportFilterParameter& operator=(const EbsdMontageImportFilterParameter&) = delete; // Copy Assignment Not Implemented
+  EbsdMontageImportFilterParameter& operator=(EbsdMontageImportFilterParameter&&) = delete;      // Move Assignment Not Implemented
+};

--- a/Source/Plugins/OrientationAnalysis/FilterParameters/SourceList.cmake
+++ b/Source/Plugins/OrientationAnalysis/FilterParameters/SourceList.cmake
@@ -11,6 +11,7 @@ set (${PLUGIN_NAME}_FilterParameters_SRCS
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/ReadEdaxH5DataFilterParameter.cpp
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/ReadH5EbsdFilterParameter.cpp
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/OrientationUtilityFilterParameter.cpp
+    ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/EbsdMontageImportFilterParameter.cpp
 )
 
 set (${PLUGIN_NAME}_FilterParameters_HDRS
@@ -20,5 +21,6 @@ set (${PLUGIN_NAME}_FilterParameters_HDRS
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/ReadEdaxH5DataFilterParameter.h
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/ReadH5EbsdFilterParameter.h
     ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/OrientationUtilityFilterParameter.h
+    ${${PLUGIN_NAME}_SOURCE_DIR}/FilterParameters/EbsdMontageImportFilterParameter.h
 )
 cmp_IDE_SOURCE_PROPERTIES( "FilterParameters" "${${PLUGIN_NAME}_FilterParameters_HDRS}" "${${PLUGIN_NAME}_FilterParameters_SRCS}" "${PROJECT_INSTALL_HEADERS}")

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.cpp
@@ -1,0 +1,489 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "EbsdMontageImportWidget.h"
+
+//-- Qt Includes
+#include <QtCore/QDir>
+#include <QtGui/QKeyEvent>
+#include <QtGui/QPainter>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMenu>
+
+#include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
+#include "SIMPLib/Utilities/FilePathGenerator.h"
+#include "SIMPLib/Utilities/SIMPLDataPathValidator.h"
+#include "SIMPLib/Utilities/StringOperations.h"
+
+#include "SVWidgetsLib/Core/SVWidgetsLibConstants.h"
+#include "SVWidgetsLib/QtSupport/QtSFileCompleter.h"
+#include "SVWidgetsLib/QtSupport/QtSFileUtils.h"
+
+#include "FilterParameterWidgetsDialogs.h"
+
+#include "OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h"
+
+#include "ui_EbsdMontageImportWidget.h"
+
+// Initialize private static member variable
+QString EbsdMontageImportWidget::m_OpenDialogLastFilePath = "";
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+EbsdMontageImportWidget::EbsdMontageImportWidget(FilterParameter* parameter, AbstractFilter* filter, QWidget* parent)
+: FilterParameterWidget(parameter, filter, parent)
+, m_Ui(new Ui::EbsdMontageImportWidget)
+{
+  auto fli = dynamic_cast<EbsdMontageImportFilterParameter*>(parameter);
+  if(nullptr == fli)
+  {
+    QString msg;
+    QTextStream ss(&msg);
+    ss << "EbsdMontageImportWidget can ONLY be used with EbsdMontageImportFilterParameter objects. The programmer of the filter has a bug.";
+    ss << " The name of the filter was " << filter->getHumanLabel() << " and the name of the Filter Parameter was " << parameter->getHumanLabel();
+    ss << " and is trying to get the propery " << parameter->getPropertyName() << " in the filter";
+    Q_ASSERT_X(nullptr != fli, msg.toLatin1().constData(), __FILE__);
+  }
+  m_Ui->setupUi(this);
+  setupGui();
+  if(m_Ui->inputDir->text().isEmpty())
+  {
+    setInputDirectory(QDir::homePath());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+EbsdMontageImportWidget::~EbsdMontageImportWidget() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::setIcon(const QPixmap& path)
+{
+  m_Icon = path;
+  setupMenuField();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QPixmap EbsdMontageImportWidget::getIcon()
+{
+  return m_Icon;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::SetOpenDialogLastFilePath(const QString& val)
+{
+  m_OpenDialogLastFilePath = val;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString EbsdMontageImportWidget::GetOpenDialogLastFilePath()
+{
+  return m_OpenDialogLastFilePath;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::setWidgetListEnabled(bool b)
+{
+  foreach(QWidget* w, m_WidgetList)
+  {
+    w->setEnabled(b);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::setupGui()
+{
+  connectSignalsSlots();
+
+  setupMenuField();
+
+  m_Ui->absPathLabel->hide();
+
+  m_WidgetList << m_Ui->inputDir << m_Ui->inputDirBtn;
+  m_WidgetList << m_Ui->fileExt << m_Ui->errorMessage << m_Ui->totalDigits << m_Ui->fileSuffix;
+  m_WidgetList << m_Ui->filePrefix << m_Ui->totalSlices << m_Ui->rowStart << m_Ui->rowEnd << m_Ui->colStart << m_Ui->colEnd;
+
+  m_Ui->errorMessage->setVisible(false);
+
+  // Update the widget when the data directory changes
+//  SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
+//  connect(validator, &SIMPLDataPathValidator::dataDirectoryChanged, [=] {
+//    blockSignals(true);
+//    inputDir_textChanged(m_Ui->inputDir->text());
+//    blockSignals(false);
+
+//    emit parametersChanged();
+//  });
+
+  getGuiParametersFromFilter();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::connectSignalsSlots()
+{
+  // Catch when the filter is about to execute the preflight
+  connect(getFilter(), SIGNAL(preflightAboutToExecute()), this, SLOT(beforePreflight()));
+
+  // Catch when the filter is finished running the preflight
+  connect(getFilter(), SIGNAL(preflightExecuted()), this, SLOT(afterPreflight()));
+
+  // Catch when the filter wants its values updated
+  connect(getFilter(), SIGNAL(updateFilterParameters(AbstractFilter*)), this, SLOT(filterNeedsInputParameters(AbstractFilter*)));
+
+  // Connections for the various ui widgets
+  connect(m_Ui->inputDirBtn, &QPushButton::clicked, this, &EbsdMontageImportWidget::inputDirBtn_clicked);
+
+  QtSFileCompleter* com = new QtSFileCompleter(this, true);
+  m_Ui->inputDir->setCompleter(com);
+  connect(com, static_cast<void (QtSFileCompleter::*)(const QString&)>(&QtSFileCompleter::activated), this, &EbsdMontageImportWidget::inputDir_textChanged);
+
+  connect(m_Ui->inputDir, &QtSLineEdit::textChanged, this, &EbsdMontageImportWidget::inputDir_textChanged);
+
+  connect(m_Ui->filePrefix, &QtSLineEdit::textChanged, this, &EbsdMontageImportWidget::widgetChanged);
+  connect(m_Ui->fileSuffix, &QtSLineEdit::textChanged, this, &EbsdMontageImportWidget::widgetChanged);
+  connect(m_Ui->fileExt, &QtSLineEdit::textChanged, this, &EbsdMontageImportWidget::widgetChanged);
+
+  connect(m_Ui->totalDigits, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+  connect(m_Ui->rowStart, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+  connect(m_Ui->rowEnd, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+  connect(m_Ui->colStart, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+  connect(m_Ui->colEnd, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+  connect(m_Ui->increment, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &EbsdMontageImportWidget::spinnerChanged);
+
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::spinnerChanged(int value)
+{
+  updateFileListView();
+  emit parametersChanged();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::keyPressEvent(QKeyEvent* event)
+{
+  if(event->key() == Qt::Key_Escape)
+  {
+    m_Ui->inputDir->setText(m_CurrentText);
+    m_Ui->inputDir->setStyleSheet("");
+    m_Ui->inputDir->setToolTip("");
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::setupMenuField()
+{
+  SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
+  QString inputPath = validator->convertToAbsolutePath(m_Ui->inputDir->text());
+
+  QFileInfo fi(inputPath);
+
+  QMenu* lineEditMenu = new QMenu(m_Ui->inputDir);
+  m_Ui->inputDir->setButtonMenu(QtSLineEdit::Left, lineEditMenu);
+  m_Ui->inputDir->setButtonVisible(QtSLineEdit::Left, true);
+
+  QPixmap pixmap(8, 8);
+  pixmap.fill(Qt::transparent);
+  QPainter painter(&pixmap);
+  painter.drawPixmap(0, (pixmap.height() - m_Icon.height()) / 2, m_Icon);
+  m_Ui->inputDir->setButtonPixmap(QtSLineEdit::Left, pixmap);
+
+  {
+    m_ShowFileAction = new QAction(lineEditMenu);
+    m_ShowFileAction->setObjectName(QString::fromUtf8("showFileAction"));
+#if defined(Q_OS_WIN)
+    m_ShowFileAction->setText("Show in Windows Explorer");
+#elif defined(Q_OS_MAC)
+    m_ShowFileAction->setText("Show in Finder");
+#else
+    m_ShowFileAction->setText("Show in File System");
+#endif
+    lineEditMenu->addAction(m_ShowFileAction);
+    connect(m_ShowFileAction, SIGNAL(triggered()), this, SLOT(showFileInFileSystem()));
+  }
+
+  if(!inputPath.isEmpty() && fi.exists())
+  {
+    m_ShowFileAction->setEnabled(true);
+  }
+  else
+  {
+    m_ShowFileAction->setDisabled(true);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::getGuiParametersFromFilter()
+{
+  blockSignals(true);
+
+  EbsdMontageListInfo_t data = getFilter()->property(PROPERTY_NAME_AS_CHAR).value<EbsdMontageListInfo_t>();
+
+  m_Ui->inputDir->setText(data.InputPath);
+
+  m_Ui->rowStart->setValue(data.RowStart);
+  m_Ui->rowEnd->setValue(data.RowEnd);
+  m_Ui->colStart->setValue(data.ColStart);
+  m_Ui->colEnd->setValue(data.ColEnd);
+  m_Ui->increment->setValue(data.IncrementIndex);
+
+  m_Ui->filePrefix->setText(data.FilePrefix);
+  m_Ui->fileSuffix->setText(data.FileSuffix);
+
+  m_Ui->fileExt->setText(data.FileExtension);
+  m_Ui->totalDigits->setValue(data.PaddingDigits);
+
+  blockSignals(false);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::inputDirBtn_clicked()
+{
+  QString outputFile = QFileDialog::getExistingDirectory(this, tr("Select Input Directory"), getInputDirectory());
+
+  if(!outputFile.isNull())
+  {
+    m_Ui->inputDir->blockSignals(true);
+    m_Ui->inputDir->setText(QDir::toNativeSeparators(outputFile));
+    inputDir_textChanged(m_Ui->inputDir->text());
+    SetOpenDialogLastFilePath(outputFile);
+    m_Ui->inputDir->blockSignals(false);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::inputDir_textChanged(const QString& text)
+{
+  SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
+  QString inputPath = validator->convertToAbsolutePath(text);
+
+  QFileInfo fi(text);
+  if(fi.isRelative())
+  {
+    m_Ui->absPathLabel->setText(inputPath);
+    m_Ui->absPathLabel->show();
+  }
+  else
+  {
+    m_Ui->absPathLabel->hide();
+  }
+
+  m_Ui->inputDir->setToolTip("Absolute File Path: " + inputPath);
+
+  if(verifyPathExists(inputPath, m_Ui->inputDir))
+  {
+    m_ShowFileAction->setEnabled(true);
+    QDir dir(inputPath);
+    dir.cdUp();
+
+    updateFileListView();
+    m_Ui->inputDir->blockSignals(true);
+    m_Ui->inputDir->setText(QDir::toNativeSeparators(m_Ui->inputDir->text()));
+    m_Ui->inputDir->blockSignals(false);
+  }
+  else
+  {
+    m_ShowFileAction->setEnabled(false);
+    m_Ui->fileListView->clear();
+  }
+
+  emit parametersChanged();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::updateFileListView()
+{
+  int rowStart = m_Ui->rowStart->value();
+  int rowEnd = m_Ui->rowEnd->value() + 1;
+  int colStart = m_Ui->colStart->value();
+  int colEnd = m_Ui->colEnd->value() + 1;
+
+  // int increment = m_Ui->increment->value();
+  bool hasMissingFiles = false;
+  const bool k_RowColOrdering = true;
+  SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
+  QString inputPath = validator->convertToAbsolutePath(m_Ui->inputDir->text());
+
+  // Now generate all the file names the user is asking for and populate the table
+  FilePathGenerator::TileRCIncexLayout2D tileLayout2d = FilePathGenerator::GenerateRCIndexMontageFileList(rowStart, rowEnd, colStart, colEnd, hasMissingFiles, k_RowColOrdering, inputPath, m_Ui->filePrefix->text(),
+                                                                                            m_Ui->fileSuffix->text(), m_Ui->fileExt->text(), m_Ui->totalDigits->value());
+
+  m_Ui->fileListView->clear();
+  QIcon greenDot = QIcon(QString(":/SIMPL/icons/images/bullet_ball_green.png"));
+  QIcon redDot = QIcon(QString(":/SIMPL/icons/images/bullet_ball_red.png"));
+  for(const FilePathGenerator::TileRCIndexRow2D& tileRow2D : tileLayout2d)
+  {
+    for(const FilePathGenerator::TileRCIndex2D& tile2D : tileRow2D)
+    {
+      QFileInfo fi(tile2D.FileName);
+      QListWidgetItem* item = new QListWidgetItem(tile2D.FileName, m_Ui->fileListView);
+      if(fi.exists())
+      {
+        item->setIcon(greenDot);
+        m_Ui->generatedFileNameExample->setText(tile2D.FileName);
+      }
+      else
+      {
+        hasMissingFiles = true;
+        item->setIcon(redDot);
+      }
+    }
+  }
+  if(hasMissingFiles)
+  {
+    m_Ui->errorMessage->setVisible(true);
+    m_Ui->errorMessage->setText("Alert: Red Dot File(s) on the list do NOT exist on the filesystem. Please make sure all files exist");
+  }
+  else
+  {
+    m_Ui->errorMessage->setVisible(true);
+    m_Ui->errorMessage->setText("All files exist.");
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::widgetChanged(const QString& text)
+{
+  updateFileListView();
+  emit parametersChanged();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::filterNeedsInputParameters(AbstractFilter* filter)
+{
+  if(nullptr == filter)
+  {
+    QString ss = QObject::tr("Error Setting FileListStack Gui values to Filter instance. Filter instance was nullptr.").arg(getFilterParameter()->getPropertyName());
+    emit errorSettingFilterParameter(ss);
+    return;
+  }
+  bool ok = false;
+
+  SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
+  QString inputPath = validator->convertToAbsolutePath(m_Ui->inputDir->text());
+
+  EbsdMontageListInfo_t data;
+  data.IncrementIndex = m_Ui->increment->value();
+  data.RowStart = m_Ui->rowStart->value();
+  data.RowEnd = m_Ui->rowEnd->value() + 1;
+  data.ColStart = m_Ui->colStart->value();
+  data.ColEnd = m_Ui->colEnd->value() + 1;
+  data.FileExtension = m_Ui->fileExt->text();
+  data.FilePrefix = m_Ui->filePrefix->text();
+  data.FileSuffix = m_Ui->fileSuffix->text();
+  data.InputPath = inputPath;
+  data.Ordering = 0; // By Default we use RowColumn ordering
+  data.PaddingDigits = m_Ui->totalDigits->value();
+
+  QVariant v;
+  v.setValue(data);
+  ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
+  if(!ok)
+  {
+    getFilter()->notifyMissingProperty(getFilterParameter());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::beforePreflight()
+{
+  if(!m_DidCausePreflight)
+  {
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::afterPreflight()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void EbsdMontageImportWidget::setInputDirectory(const QString& val)
+{
+  m_Ui->inputDir->setText(val);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString EbsdMontageImportWidget::getInputDirectory()
+{
+  if(m_Ui->inputDir->text().isEmpty())
+  {
+    return QDir::homePath();
+  }
+  return m_Ui->inputDir->text();
+}

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.h
@@ -1,0 +1,162 @@
+/* ============================================================================
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <QtCore/QSettings>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QUrl>
+#include <QtCore/QVector>
+
+#include <QtWidgets/QButtonGroup>
+
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+
+#include "SVWidgetsLib/FilterParameterWidgets/FilterParameterWidget.h"
+#include "SVWidgetsLib/QtSupport/QtSPluginFrame.h"
+
+#include "OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h"
+
+namespace Ui
+{
+class EbsdMontageImportWidget;
+}
+
+/**
+ * @class EbsdMontageImportWidget EbsdMontageImportWidget.h Plugins/EbsdImport/UI/EbsdMontageImportWidget.h
+ * @brief This class represents the User Interface for the EBSD file import module
+ * of the SIMPLView program. The user interface subclasses QFrame which
+ * should make it able to be embedded in most Qt applications. This module controls
+ * the import of EBSD data files into an HDF5 file
+ * for better data management and archiving.
+ *
+ * @date Jan 30, 2011
+ * @version 1.0
+ */
+class EbsdMontageImportWidget : public FilterParameterWidget
+{
+  Q_OBJECT
+
+public:
+  /**
+   * @brief Constructor
+   * @param parameter The FilterParameter object that this widget represents
+   * @param filter The instance of the filter that this parameter is a part of
+   * @param parent The parent QWidget for this Widget
+   */
+  EbsdMontageImportWidget(FilterParameter* parameter, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
+
+  ~EbsdMontageImportWidget() override;
+
+  Q_PROPERTY(QPixmap Icon READ getIcon WRITE setIcon)
+  void setIcon(const QPixmap& path);
+  QPixmap getIcon();
+
+  /**
+   * @brief Initializes some of the GUI elements with selections or other GUI related items
+   */
+  void setupGui() override;
+
+public slots:
+  void widgetChanged(const QString& msg);
+  void beforePreflight();
+  void afterPreflight();
+  void filterNeedsInputParameters(AbstractFilter* filter);
+  void spinnerChanged(int value);
+
+protected slots:
+
+  // Slots to catch signals emitted by the various ui widgets
+  void inputDirBtn_clicked();
+  void inputDir_textChanged(const QString& text);
+
+protected:
+  void setInputDirectory(const QString& val);
+  QString getInputDirectory();
+
+  static void SetOpenDialogLastFilePath(const QString& val);
+
+  static QString GetOpenDialogLastFilePath();
+
+  /**
+   * @brief setWidgetListEnabled
+   */
+  void setWidgetListEnabled(bool v);
+
+  /**
+   * @brief generateExampleInputFile
+   */
+  void updateFileListView();
+
+  /**
+   * @brief getGuiParametersFromFilter
+   */
+  void getGuiParametersFromFilter();
+
+  /**
+   * @brief
+   * @param event
+   */
+  void keyPressEvent(QKeyEvent* event) override;
+
+  /**
+   * @brief setupMenuField
+   */
+  void setupMenuField();
+
+private:
+  QSharedPointer<Ui::EbsdMontageImportWidget> m_Ui;
+
+  QList<QWidget*> m_WidgetList;
+  static QString m_OpenDialogLastFilePath;
+
+  QAction* m_ShowFileAction = nullptr;
+  QString m_CurrentlyValidPath = "";
+  QString m_CurrentText = "";
+  bool m_DidCausePreflight = false;
+  QPixmap m_Icon = QPixmap(QLatin1String(":/SIMPL/icons/images/caret-bottom.png"));
+
+  /**
+   * @brief connectSignalsSlots
+   */
+  void connectSignalsSlots();
+
+public:
+  EbsdMontageImportWidget(const EbsdMontageImportWidget&) = delete;            // Copy Constructor Not Implemented
+  EbsdMontageImportWidget(EbsdMontageImportWidget&&) = delete;                 // Move Constructor Not Implemented
+  EbsdMontageImportWidget& operator=(const EbsdMontageImportWidget&) = delete; // Copy Assignment Not Implemented
+  EbsdMontageImportWidget& operator=(EbsdMontageImportWidget&&) = delete;      // Move Assignment Not Implemented
+};

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/SourceList.cmake
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/SourceList.cmake
@@ -5,12 +5,13 @@ set(${PLUGIN_NAME}_ParameterWidgets_UIS "")
 
 
 set(${PLUGIN_NAME}_PARAMETER_WIDGETS
-      EbsdToH5EbsdWidget
-      EnsembleInfoCreationWidget
-      ReadH5EbsdWidget
-      ReadEdaxH5DataWidget
-      OrientationUtilityWidget
-      ConvertHexGridToSquareGridWidget
+  ConvertHexGridToSquareGridWidget  
+  EbsdMontageImportWidget      
+  EbsdToH5EbsdWidget
+  EnsembleInfoCreationWidget
+  OrientationUtilityWidget
+  ReadH5EbsdWidget
+  ReadEdaxH5DataWidget    
 )
 
 # --------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/UI_Files/EbsdMontageImportWidget.ui
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/UI_Files/EbsdMontageImportWidget.ui
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EbsdMontageImportWidget</class>
+ <widget class="QFrame" name="EbsdMontageImportWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>758</width>
+    <height>525</height>
+   </rect>
+  </property>
+  <property name="title" stdset="0">
+   <string>Image Stack Import</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <item row="6" column="0">
+    <layout class="QHBoxLayout" name="_6">
+     <item>
+      <widget class="QLabel" name="label_17">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Generated Input File Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_24">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>12</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="generatedFileNameExample">
+       <property name="font">
+        <font>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="text">
+        <string>[Prefix][Zero Padding]r[Row]c[Col][Suffix].[extension]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_25">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="8" column="0">
+    <widget class="QListWidget" name="fileListView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>The list of files that will be imported in the order they will be imported into the HDF5 Ebsd File</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_57">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <italic>false</italic>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>File List (Green=File Exists  Red=File Does NOT Exist)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="errorMessage">
+     <property name="text">
+      <string>Error Messages</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="widgetLayout">
+     <property name="topMargin">
+      <number>6</number>
+     </property>
+     <property name="bottomMargin">
+      <number>6</number>
+     </property>
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item row="3" column="1">
+      <widget class="QLabel" name="totalSlices">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_29">
+       <property name="toolTip">
+        <string>The directory that contains the .ang or .ctf files</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Input Directory:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" colspan="3">
+      <widget class="QLabel" name="label_5">
+       <property name="styleSheet">
+        <string notr="true">QLabel 
+{
+	font-style: italic;font-weight: bold;
+font-size: 12px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Files Source Directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QtSLineEdit" name="inputDir"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="SVSmallLabel" name="absPathLabel">
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <italic>false</italic>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="inputDirBtn">
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_47">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Total Files Found:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="Line" name="line_9">
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_58">
+     <property name="styleSheet">
+      <string notr="true">QLabel 
+{
+	font-style: italic;font-weight: bold;
+font-size: 12px;
+}</string>
+     </property>
+     <property name="text">
+      <string>File Name Generation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QGridLayout" name="gridLayout_20">
+     <item row="1" column="3">
+      <widget class="SVSpinBox" name="rowEnd">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>The file index to stop the import at. (Inclusive)</string>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_50">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Row Start</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="SVSpinBox" name="rowStart">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Which file index to start the import at.</string>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="label_51">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Row End</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="QLabel" name="label_56">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>File Extension:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="SVLineEdit" name="fileSuffix">
+       <property name="toolTip">
+        <string>The part of the filename that comes AFTER the slice index</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="SVLineEdit" name="fileExt">
+       <property name="toolTip">
+        <string>The file extension of the input files</string>
+       </property>
+       <property name="text">
+        <string>ang</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_32">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>File Prefix:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="SVLineEdit" name="filePrefix">
+       <property name="toolTip">
+        <string>The front part of the input file name</string>
+       </property>
+       <property name="text">
+        <string>Slice_</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_13">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>File Suffix:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QLabel" name="label_52">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Increment Index:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="SVSpinBox" name="increment">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Which file index to start the import at.</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_53">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Col Start</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="SVSpinBox" name="colStart">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Which file index to start the import at.</string>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="label_54">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Col End</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="SVSpinBox" name="colEnd">
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>The file index to stop the import at. (Inclusive)</string>
+       </property>
+       <property name="maximum">
+        <number>1000000</number>
+       </property>
+       <property name="value">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="QLabel" name="label_21">
+       <property name="styleSheet">
+        <string notr="true">QLabel {
+font-weight: bold;
+font-size: 11px;
+}</string>
+       </property>
+       <property name="text">
+        <string>Num. Index Digits:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="SVSpinBox" name="totalDigits">
+       <property name="toolTip">
+        <string>The number of digits to allow for the slice index.</string>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SVLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">SVControlWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QtSLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">QtSLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SVSmallLabel</class>
+   <extends>QLabel</extends>
+   <header location="global">SVControlWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SVSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header location="global">SVControlWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>inputDir</tabstop>
+  <tabstop>inputDirBtn</tabstop>
+  <tabstop>filePrefix</tabstop>
+  <tabstop>fileSuffix</tabstop>
+  <tabstop>fileExt</tabstop>
+  <tabstop>rowStart</tabstop>
+  <tabstop>rowEnd</tabstop>
+  <tabstop>fileListView</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.cpp
@@ -1,0 +1,364 @@
+/* ============================================================================
+ * Copyright (c) 2018 BlueQuartz Software, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the names of any of the BlueQuartz Software contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "ImportEbsdMontage.h"
+
+#include <QtCore/QDateTime>
+#include <QtCore/QFileInfo>
+
+#include "EbsdLib/HKL/CtfFields.h"
+#include "EbsdLib/HKL/CtfReader.h"
+#include "EbsdLib/TSL/AngFields.h"
+#include "EbsdLib/TSL/AngReader.h"
+
+#include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/DataArrays/StringDataArray.h"
+#include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
+#include "SIMPLib/FilterParameters/StringFilterParameter.h"
+#include "SIMPLib/Geometry/ImageGeom.h"
+#include "SIMPLib/Utilities/FilePathGenerator.h"
+
+#include "OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h"
+
+#include "OrientationAnalysis/OrientationAnalysisConstants.h"
+#include "OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.h"
+#include "OrientationAnalysis/OrientationAnalysisFilters/ReadCtfData.h"
+#include "OrientationAnalysis/OrientationAnalysisVersion.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ImportEbsdMontage::ImportEbsdMontage()
+: m_DataContainerName("OIM Data Container")
+, m_CellEnsembleAttributeMatrixName("Phase Data")
+, m_CellAttributeMatrixName("Scan Data")
+{
+  initialize();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ImportEbsdMontage::~ImportEbsdMontage() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportEbsdMontage::initialize()
+{
+  setErrorCondition(0);
+  setWarningCondition(0);
+  setCancel(false);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportEbsdMontage::setupFilterParameters()
+{
+  FilterParameterVector parameters;
+
+  parameters.push_back(SIMPL_NEW_EbsdMontageListInfo_FP("Input File List", InputFileListInfo, FilterParameter::Parameter, ImportEbsdMontage));
+  // parameters.push_back(SIMPL_NEW_STRING_FP("Data Container", DataContainerName, FilterParameter::CreatedArray, ImportEbsdMontage));
+  parameters.push_back(SeparatorFilterParameter::New("Cell Data", FilterParameter::CreatedArray));
+  parameters.push_back(SIMPL_NEW_STRING_FP("Cell Attribute Matrix", CellAttributeMatrixName, FilterParameter::CreatedArray, ImportEbsdMontage));
+  parameters.push_back(SIMPL_NEW_STRING_FP("Cell Ensemble Attribute Matrix", CellEnsembleAttributeMatrixName, FilterParameter::CreatedArray, ImportEbsdMontage));
+
+  setFilterParameters(parameters);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+template <class EbsdReaderClass>
+void readEbsdFile(ImportEbsdMontage* filter, const QString& fileName, std::map<QString, AbstractFilter::Pointer>& prevFilterCache, std::map<QString, AbstractFilter::Pointer>& newFilterCache)
+{
+  QFileInfo fi(fileName);
+  QString fname = fi.completeBaseName();
+  if(filter->getDataContainerArray()->doesDataContainerExist(fname))
+  {
+    filter->setErrorCondition(-74000);
+    QString msg = QString("Error: DataContainer '%1' already exists in the DataContainerArray.").arg(fname);
+    filter->notifyErrorMessage(filter->getHumanLabel(), msg, filter->getErrorCondition());
+    return;
+  }
+
+  DataContainerArray::Pointer dca = DataContainerArray::New();
+
+  typename EbsdReaderClass::Pointer reader = EbsdReaderClass::NullPointer();
+  if(prevFilterCache.find(fileName) != prevFilterCache.end())
+  {
+    reader = std::dynamic_pointer_cast<EbsdReaderClass>(prevFilterCache[fileName]);
+  }
+  else
+  {
+    reader = EbsdReaderClass::New();
+    reader->setInputFile(fileName);
+    reader->setDataContainerName(fname);
+  }
+  newFilterCache[fileName] = reader;
+  reader->setDataContainerArray(dca);
+  reader->setCellEnsembleAttributeMatrixName(filter->getCellEnsembleAttributeMatrixName());
+  reader->setCellAttributeMatrixName(filter->getCellAttributeMatrixName());
+  if(filter->getInPreflight())
+  {
+    reader->preflight();
+  }
+  else
+  {
+    reader->execute();
+  }
+  if(reader->getErrorCondition() < 0)
+  {
+    filter->setErrorCondition(reader->getErrorCondition());
+    QString msg = QString("Sub filter (%1) caused an error during preflight.").arg(reader->getHumanLabel());
+    filter->notifyErrorMessage(filter->getHumanLabel(), msg, filter->getErrorCondition());
+    return;
+  }
+
+  DataContainer::Pointer dc = dca->getDataContainer(fname);
+  filter->getDataContainerArray()->addDataContainer(dc);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportEbsdMontage::dataCheck()
+{
+  setErrorCondition(0);
+  setWarningCondition(0);
+  setWarningCondition(0);
+
+  DataArrayPath tempPath;
+  QString ss;
+
+  if(m_InputFileListInfo.InputPath.isEmpty())
+  {
+    ss = QObject::tr("The input directory must be set");
+    setErrorCondition(-13);
+    notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+    m_FilterCache.clear();
+  }
+  bool hasMissingFiles = false;
+  // Now generate all the file names the user is asking for and populate the table
+  FilePathGenerator::TileRCIncexLayout2D tileLayout2d = FilePathGenerator::GenerateRCIndexMontageFileList(
+      m_InputFileListInfo.RowStart, m_InputFileListInfo.RowEnd, m_InputFileListInfo.ColStart, m_InputFileListInfo.ColEnd, hasMissingFiles, (m_InputFileListInfo.Ordering == 0),
+      m_InputFileListInfo.InputPath, m_InputFileListInfo.FilePrefix, m_InputFileListInfo.FileSuffix, m_InputFileListInfo.FileExtension, m_InputFileListInfo.PaddingDigits);
+  if(tileLayout2d.empty())
+  {
+    ss.clear();
+    QTextStream out(&ss);
+    out << " No files have been selected for import. Have you set the input directory and other values so that input files will be generated?\n";
+    out << "InputPath: " << m_InputFileListInfo.InputPath << "\n";
+    out << "FilePrefix: " << m_InputFileListInfo.FilePrefix << "\n";
+    out << "FileSuffix: " << m_InputFileListInfo.FileSuffix << "\n";
+    out << "FileExtension: " << m_InputFileListInfo.FileExtension << "\n";
+    out << "PaddingDigits: " << m_InputFileListInfo.PaddingDigits << "\n";
+    out << "RowStart: " << m_InputFileListInfo.RowStart << "\n";
+    out << "RowEnd: " << m_InputFileListInfo.RowEnd << "\n";
+    out << "ColStart: " << m_InputFileListInfo.ColStart << "\n";
+    out << "ColEnd: " << m_InputFileListInfo.ColEnd << "\n";
+
+    m_FilterCache.clear();
+
+    setErrorCondition(-11);
+    notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+    return;
+  }
+
+  int32_t numRows = tileLayout2d.size();
+  int32_t numCols = tileLayout2d[0].size();
+  int32_t totalTiles = numRows * numCols;
+  int32_t tilesRead = 0;
+
+  std::array<double, 2> globalTileOrigin = {{0.0, 0.0}};
+
+  std::map<QString, AbstractFilter::Pointer> oldCache = m_FilterCache;
+
+  std::map<QString, AbstractFilter::Pointer> newFilterCache;
+
+  for(const FilePathGenerator::TileRCIndexRow2D& tileRow2D : tileLayout2d)
+  {
+    globalTileOrigin[0] = 0.0; // Reset the X Coord back to Zero for each row.
+    double tileHeight = 0.0;
+    for(const FilePathGenerator::TileRCIndex2D& tile2D : tileRow2D)
+    {
+      QFileInfo fi(tile2D.FileName);
+      QString fname = fi.completeBaseName();
+
+      if(m_InputFileListInfo.FileExtension == Ebsd::Ang::FileExt)
+      {
+        readEbsdFile<ReadAngData>(this, tile2D.FileName, m_FilterCache, newFilterCache);
+      }
+      if(m_InputFileListInfo.FileExtension == Ebsd::Ctf::FileExt)
+      {
+        readEbsdFile<ReadCtfData>(this, tile2D.FileName, m_FilterCache, newFilterCache);
+      }
+      if(getErrorCondition() >= 0)
+      {
+        DataContainer::Pointer dc = getDataContainerArray()->getDataContainer(fname);
+        ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
+
+        std::array<size_t, 3> dims = {{0, 0, 0}};
+        std::tie(dims[0], dims[1], dims[2]) = imageGeom->getDimensions();
+        std::array<float, 3> res = {{0.0f, 0.0f, 0.0f}};
+        std::tie(res[0], res[1], res[2]) = imageGeom->getResolution();
+        std::array<float, 3> origin = {{0.0f, 0.0f, 0.0f}};
+        std::tie(origin[0], origin[1], origin[2]) = imageGeom->getOrigin();
+
+        //
+        origin[0] = globalTileOrigin[0];
+        origin[1] = globalTileOrigin[1];
+        imageGeom->setOrigin(origin.data());
+
+        // Now update the globalTileOrigin values
+        globalTileOrigin[0] += origin[0] + (dims[0] * res[0]);
+        tileHeight = (dims[1] * res[1]);
+
+        if(getCancel())
+        {
+          return;
+        }
+        tilesRead++;
+        if(!getInPreflight())
+        {
+          QString msg = QString("==> [%1/%2] %3").arg(tilesRead).arg(totalTiles).arg(tile2D.FileName);
+          notifyStatusMessage(getHumanLabel(), msg);
+        }
+      }
+    }
+    globalTileOrigin[1] += tileHeight;
+  }
+
+  m_FilterCache = newFilterCache; // Swap our maps. This dumps any previous instantiations of the reader filter that are not used any more.
+  setWarningCondition(0);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportEbsdMontage::preflight()
+{
+  // These are the REQUIRED lines of CODE to make sure the filter behaves correctly
+  setInPreflight(true);              // Set the fact that we are preflighting.
+  emit preflightAboutToExecute();    // Emit this signal so that other widgets can do one file update
+  emit updateFilterParameters(this); // Emit this signal to have the widgets push their values down to the filter
+  dataCheck();                       // Run our DataCheck to make sure everthing is setup correctly
+  emit preflightExecuted();          // We are done preflighting this filter
+  setInPreflight(false);             // Inform the system this filter is NOT in preflight mode anymore.
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ImportEbsdMontage::execute()
+{
+  initialize();
+  dataCheck();
+
+  // The entire Reading of the data, whether that is in prefligth (so just read the header) or in execute is performed
+  // in the dataCheck() method so we essentially do nothing here.
+
+  notifyStatusMessage(getHumanLabel(), "Complete");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+AbstractFilter::Pointer ImportEbsdMontage::newFilterInstance(bool copyFilterParameters) const
+{
+  ImportEbsdMontage::Pointer filter = ImportEbsdMontage::New();
+  if(copyFilterParameters)
+  {
+    copyFilterParameterInstanceVariables(filter.get());
+  }
+  return filter;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getCompiledLibraryName() const
+{
+  return OrientationAnalysisConstants::OrientationAnalysisBaseName;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getBrandingString() const
+{
+  return "OrientationAnalysis";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getFilterVersion() const
+{
+  QString version;
+  QTextStream vStream(&version);
+  vStream << OrientationAnalysis::Version::Major() << "." << OrientationAnalysis::Version::Minor() << "." << OrientationAnalysis::Version::Patch();
+  return version;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getGroupName() const
+{
+  return SIMPL::FilterGroups::Unsupported;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getSubGroupName() const
+{
+  return SIMPL::FilterSubGroups::InputFilters;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ImportEbsdMontage::getHumanLabel() const
+{
+  return "Import EBSD Montage";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QUuid ImportEbsdMontage::getUuid()
+{
+  return QUuid("{179b0c7a-4e62-5070-ba49-ae58d5ccbfe8}");
+}

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.h
@@ -1,0 +1,182 @@
+/* ============================================================================
+ * Copyright (c) 2018 BlueQuartz Software, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the names of any of the BlueQuartz Software contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <map>
+
+#include <QtCore/QString>
+
+#include "EbsdLib/TSL/AngPhase.h"
+
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/Filtering/AbstractFilter.h"
+#include "SIMPLib/SIMPLib.h"
+
+#include "OrientationAnalysis/FilterParameters/EbsdMontageImportFilterParameter.h"
+
+#include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+/**
+ * @brief The ImportEbsdMontage class. See [Filter documentation](@ref importebsdmontage) for details.
+ */
+class OrientationAnalysis_EXPORT ImportEbsdMontage : public AbstractFilter
+{
+  Q_OBJECT
+
+public:
+  SIMPL_SHARED_POINTERS(ImportEbsdMontage)
+  SIMPL_FILTER_NEW_MACRO(ImportEbsdMontage)
+  SIMPL_TYPE_MACRO_SUPER_OVERRIDE(ImportEbsdMontage, AbstractFilter)
+
+  ~ImportEbsdMontage() override;
+
+  SIMPL_FILTER_PARAMETER(QString, DataContainerName)
+  Q_PROPERTY(QString DataContainerName READ getDataContainerName WRITE setDataContainerName)
+
+  SIMPL_FILTER_PARAMETER(QString, CellEnsembleAttributeMatrixName)
+  Q_PROPERTY(QString CellEnsembleAttributeMatrixName READ getCellEnsembleAttributeMatrixName WRITE setCellEnsembleAttributeMatrixName)
+
+  SIMPL_FILTER_PARAMETER(QString, CellAttributeMatrixName)
+  Q_PROPERTY(QString CellAttributeMatrixName READ getCellAttributeMatrixName WRITE setCellAttributeMatrixName)
+
+  SIMPL_FILTER_PARAMETER(EbsdMontageListInfo_t, InputFileListInfo)
+  Q_PROPERTY(EbsdMontageListInfo_t InputFileListInfo READ getInputFileListInfo WRITE setInputFileListInfo)
+
+  /**
+   * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
+   */
+  const QString getCompiledLibraryName() const override;
+
+  /**
+   * @brief getBrandingString Returns the branding string for the filter, which is a tag
+   * used to denote the filter's association with specific plugins
+   * @return Branding string
+   */
+  const QString getBrandingString() const override;
+
+  /**
+   * @brief getFilterVersion Returns a version string for this filter. Default
+   * value is an empty string.
+   * @return
+   */
+  const QString getFilterVersion() const override;
+
+  /**
+   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+   */
+  AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) const override;
+
+  /**
+   * @brief getGroupName Reimplemented from @see AbstractFilter class
+   */
+  const QString getGroupName() const override;
+
+  /**
+   * @brief getSubGroupName Reimplemented from @see AbstractFilter class
+   */
+  const QString getSubGroupName() const override;
+
+  /**
+   * @brief getUuid Return the unique identifier for this filter.
+   * @return A QUuid object.
+   */
+  const QUuid getUuid() override;
+
+  /**
+   * @brief getHumanLabel Reimplemented from @see AbstractFilter class
+   */
+  const QString getHumanLabel() const override;
+
+  /**
+   * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
+   */
+  void setupFilterParameters() override;
+
+  /**
+   * @brief execute Reimplemented from @see AbstractFilter class
+   */
+  void execute() override;
+
+  /**
+   * @brief preflight Reimplemented from @see AbstractFilter class
+   */
+  void preflight() override;
+
+signals:
+  /**
+   * @brief updateFilterParameters Emitted when the Filter requests all the latest Filter parameters
+   * be pushed from a user-facing control (such as a widget)
+   * @param filter Filter instance pointer
+   */
+  void updateFilterParameters(AbstractFilter* filter);
+
+  /**
+   * @brief parametersChanged Emitted when any Filter parameter is changed internally
+   */
+  void parametersChanged();
+
+  /**
+   * @brief preflightAboutToExecute Emitted just before calling dataCheck()
+   */
+  void preflightAboutToExecute();
+
+  /**
+   * @brief preflightExecuted Emitted just after calling dataCheck()
+   */
+  void preflightExecuted();
+
+protected:
+  ImportEbsdMontage();
+
+  /**
+   * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
+   */
+  void dataCheck();
+
+  /**
+   * @brief Initializes all the private instance variables.
+   */
+  void initialize();
+
+private:
+  std::map<QString, AbstractFilter::Pointer> m_FilterCache;
+
+public:
+  /* Rule of 5: All special member functions should be defined if any are defined.
+   * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all
+   */
+  ImportEbsdMontage(const ImportEbsdMontage&) = delete;            // Copy Constructor Not Implemented
+  ImportEbsdMontage& operator=(const ImportEbsdMontage&) = delete; // Copy Assignment Not Implemented
+  ImportEbsdMontage(ImportEbsdMontage&&) = delete;                 // Move Constructor Not Implemented
+  ImportEbsdMontage& operator=(ImportEbsdMontage&&) = delete;      // Move Assignment Not Implemented
+};

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/SourceList.cmake
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/SourceList.cmake
@@ -31,38 +31,39 @@ set(_PublicFilters
   FindAvgOrientations
   FindBoundaryStrengths
   FindCAxisLocations
+  FindDistsToCharactGBs
   FindFeatureNeighborCAxisMisalignments
   FindFeatureReferenceCAxisMisorientations
   FindFeatureReferenceMisorientations
+  FindGBCD
+  FindGBCDMetricBased
+  FindGBPDMetricBased
   FindKernelAvgMisorientations
   FindMisorientations
   FindSchmids
   FindSlipTransmissionMetrics
   FindTwinBoundaries
   FindTwinBoundarySchmidFactors
-  INLWriter
+  GenerateFaceIPFColoring
+  GenerateFaceMisorientationColoring
+  GenerateFZQuaternions
   GenerateIPFColors
+  GenerateOrientationMatrixTranspose
+  GenerateQuaternionConjugate
+  ImportEbsdMontage
+  INLWriter
   NeighborOrientationCorrelation
+  OrientationUtility
   ReadAngData
   ReadCtfData
   ReadEdaxH5Data
   ReadH5Ebsd
   ReplaceElementAttributesWithNeighborValues
+  RodriguesConvertor
   RotateEulerRefFrame
+  Stereographic3D
   WritePoleFigure
   WriteStatsGenOdfAngleFile
-  OrientationUtility
-  Stereographic3D
-  GenerateFZQuaternions
-  FindGBCD
-  FindGBCDMetricBased
-  FindGBPDMetricBased
-  FindDistsToCharactGBs
-  GenerateFaceIPFColoring
-  GenerateFaceMisorientationColoring
-  RodriguesConvertor
-  GenerateQuaternionConjugate
-  GenerateOrientationMatrixTranspose
 )
 
 

--- a/Source/Plugins/OrientationAnalysis/Test/ImportEbsdMontageTest.cpp
+++ b/Source/Plugins/OrientationAnalysis/Test/ImportEbsdMontageTest.cpp
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------------
+// Insert your license & copyright information here
+// -----------------------------------------------------------------------------
+#pragma once
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QFile>
+
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+#include "SIMPLib/DataArrays/DataArray.hpp"
+#include "SIMPLib/Filtering/FilterFactory.hpp"
+#include "SIMPLib/Filtering/FilterManager.h"
+#include "SIMPLib/Filtering/FilterPipeline.h"
+#include "SIMPLib/Plugin/ISIMPLibPlugin.h"
+#include "SIMPLib/Plugin/SIMPLibPluginLoader.h"
+#include "SIMPLib/SIMPLib.h"
+
+#include "SIMPLib/Filtering/QMetaObjectUtilities.h"
+
+#include "UnitTestSupport.hpp"
+
+#include "EbsdMontageTestFileLocations.h"
+
+class ImportEbsdMontageTest
+{
+
+public:
+  ImportEbsdMontageTest() = default;
+  ~ImportEbsdMontageTest() = default;
+  ImportEbsdMontageTest(const ImportEbsdMontageTest&) = delete;            // Copy Constructor
+  ImportEbsdMontageTest(ImportEbsdMontageTest&&) = delete;                 // Move Constructor
+  ImportEbsdMontageTest& operator=(const ImportEbsdMontageTest&) = delete; // Copy Assignment
+  ImportEbsdMontageTest& operator=(ImportEbsdMontageTest&&) = delete;      // Move Assignment
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void RemoveTestFiles()
+  {
+#if REMOVE_TEST_FILES
+    QFile::remove(UnitTest::ImportEbsdMontageTest::TestFile1);
+    QFile::remove(UnitTest::ImportEbsdMontageTest::TestFile2);
+#endif
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  int TestFilterAvailability()
+  {
+    // Now instantiate the ImportEbsdMontageTest Filter from the FilterManager
+    QString filtName = "ImportEbsdMontage";
+    FilterManager* fm = FilterManager::Instance();
+    IFilterFactory::Pointer filterFactory = fm->getFactoryFromClassName(filtName);
+    if(nullptr == filterFactory.get())
+    {
+      std::stringstream ss;
+      ss << "The ImportEbsdMontageTest Requires the use of the " << filtName.toStdString() << " filter which is found in the EbsdMontage Plugin";
+      DREAM3D_TEST_THROW_EXCEPTION(ss.str())
+    }
+    return 0;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  int TestImportEbsdMontageTest()
+  {
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    /* Please write ImportEbsdMontageTest test code here.
+     *
+     * Your IO test files are:
+     * UnitTest::ImportEbsdMontageTest::TestFile1
+     * UnitTest::ImportEbsdMontageTest::TestFile2
+     *
+     * SIMPLib provides some macros that will throw exceptions when a test fails
+     * and thus report that during testing. These macros are located in the
+     * SIMPLib/Utilities/UnitTestSupport.hpp file. Some examples are:
+     *
+     * SIMPLib_REQUIRE_EQUAL(foo, 0)
+     * This means that if the variable foo is NOT equal to Zero then test will fail
+     * and the current test will exit immediately. If there are more tests registered
+     * with the SIMPLib_REGISTER_TEST() macro, the next test will execute. There are
+     * lots of examples in the SIMPLib/Test folder to look at.
+     */
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    int foo = -1;
+    DREAM3D_REQUIRE_EQUAL(foo, 0)
+
+    return EXIT_SUCCESS;
+  }
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()()
+  {
+    int err = EXIT_SUCCESS;
+
+    DREAM3D_REGISTER_TEST(TestFilterAvailability());
+
+    DREAM3D_REGISTER_TEST(TestImportEbsdMontageTest())
+
+    DREAM3D_REGISTER_TEST(RemoveTestFiles())
+  }
+
+private:
+};


### PR DESCRIPTION
This filter allows the user to import a montage or mosaic of EBSD data files
either (.ang or .ctf) and will place each EBSD file into its own DataContainer
for later processing by the EBSD montaging filters.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>