### PR TITLE
Uses case-insensitive syntax for some gitignore folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 slnx.sqlite
 /DREAM3DProj.includes
 CMakeLists.txt.user
-/Build/
+/[Bb]uild/
+/[Bb]uilds/
 /Build-ninja/
 /Build-Xcode/
 /zRel/


### PR DESCRIPTION
Just a simple adjustment to the globbing pattern in the gitignore file to allow ignoring case-insensitive build folders.