### PR TITLE
Remove the notification at the end of the execute() method of filters.

### DIFF
--- a/Source/Plugins/EMMPM/EMMPMFilters/EMMPMFilter.cpp
+++ b/Source/Plugins/EMMPM/EMMPMFilters/EMMPMFilter.cpp
@@ -280,8 +280,7 @@ void EMMPMFilter::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/EMMPM/EMMPMFilters/MultiEmmpmFilter.cpp
+++ b/Source/Plugins/EMMPM/EMMPMFilters/MultiEmmpmFilter.cpp
@@ -325,8 +325,7 @@ void MultiEmmpmFilter::execute()
     return;
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindBoundaryCells.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindBoundaryCells.cpp
@@ -245,7 +245,6 @@ void FindBoundaryCells::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindBoundingBoxFeatures.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindBoundingBoxFeatures.cpp
@@ -465,7 +465,6 @@ void FindBoundingBoxFeatures::execute()
     find_boundingboxfeatures2D();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindFeatureCentroids.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindFeatureCentroids.cpp
@@ -211,7 +211,6 @@ void FindFeatureCentroids::execute()
 
   find_centroids();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindFeaturePhases.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindFeaturePhases.cpp
@@ -221,7 +221,6 @@ void FindFeaturePhases::execute()
     notifyWarningMessage(getHumanLabel(), warnings.join("\n"), getWarningCondition());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindFeaturePhasesBinary.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindFeaturePhasesBinary.cpp
@@ -209,7 +209,6 @@ void FindFeaturePhasesBinary::execute()
     // m_FeaturePhases[gnum] = m_CellPhases[i];
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/FindSurfaceFeatures.cpp
+++ b/Source/Plugins/Generic/GenericFilters/FindSurfaceFeatures.cpp
@@ -316,7 +316,6 @@ void FindSurfaceFeatures::execute()
     find_surfacefeatures2D();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Generic/GenericFilters/GenerateVectorColors.cpp
+++ b/Source/Plugins/Generic/GenericFilters/GenerateVectorColors.cpp
@@ -282,8 +282,7 @@ void GenerateVectorColors::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/AbaqusHexahedronWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/AbaqusHexahedronWriter.cpp
@@ -284,7 +284,6 @@ void AbaqusHexahedronWriter::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/AbaqusSurfaceMeshWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/AbaqusSurfaceMeshWriter.cpp
@@ -217,7 +217,6 @@ void AbaqusSurfaceMeshWriter::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/AvizoRectilinearCoordinateWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/AvizoRectilinearCoordinateWriter.cpp
@@ -194,8 +194,7 @@ void AvizoRectilinearCoordinateWriter::execute()
 
   fclose(avizoFile);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/AvizoUniformCoordinateWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/AvizoUniformCoordinateWriter.cpp
@@ -192,8 +192,7 @@ void AvizoUniformCoordinateWriter::execute()
 
   fclose(avizoFile);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/DxReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/DxReader.cpp
@@ -527,7 +527,6 @@ int32_t DxReader::readFile()
 
   m_InStream.close();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/DxWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/DxWriter.cpp
@@ -376,8 +376,7 @@ int32_t DxWriter::writeFile()
   out.close();
 #endif
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
   return err;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/FeatureInfoReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/FeatureInfoReader.cpp
@@ -489,7 +489,6 @@ int32_t FeatureInfoReader::readFile()
     cellFeatureAttrMat->removeInactiveObjects(activeObjects, m_FeatureIdsPtr.lock().get());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/GBCDTriangleDumper.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/GBCDTriangleDumper.cpp
@@ -264,8 +264,7 @@ void GBCDTriangleDumper::execute()
 
   fclose(f);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/GoldfeatherReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/GoldfeatherReader.cpp
@@ -407,8 +407,7 @@ void GoldfeatherReader::execute()
     m_SurfaceMeshFaceNormals[t * 3 + 2] = n2;
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/ImportAvxmMDSim.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/ImportAvxmMDSim.cpp
@@ -245,7 +245,6 @@ void ImportAvxmMDSim::execute()
     dc->setGeometry(vertex);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/LammpsFileWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/LammpsFileWriter.cpp
@@ -241,7 +241,6 @@ void LammpsFileWriter::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/LosAlamosFFTWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/LosAlamosFFTWriter.cpp
@@ -251,7 +251,6 @@ int32_t LosAlamosFFTWriter::writeFile()
 
   fclose(f);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return err;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/NodesTrianglesToStl.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/NodesTrianglesToStl.cpp
@@ -404,7 +404,6 @@ void NodesTrianglesToStl::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/NodesTrianglesToVtk.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/NodesTrianglesToVtk.cpp
@@ -368,7 +368,6 @@ void NodesTrianglesToVtk::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/PhReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/PhReader.cpp
@@ -399,7 +399,6 @@ int32_t PhReader::readFile()
   m->getGeometryAs<ImageGeom>()->setResolution(std::make_tuple(m_Resolution.x, m_Resolution.y, m_Resolution.z));
   m->getGeometryAs<ImageGeom>()->setOrigin(std::make_tuple(m_Origin.x, m_Origin.y, m_Origin.z));
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/ReadStlFile.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/ReadStlFile.cpp
@@ -252,7 +252,6 @@ void ReadStlFile::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/SPParksDumpReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/SPParksDumpReader.cpp
@@ -512,7 +512,6 @@ int32_t SPParksDumpReader::readFile()
   m->getGeometryAs<ImageGeom>()->setResolution(std::make_tuple(m_Resolution.x, m_Resolution.y, m_Resolution.z));
   m->getGeometryAs<ImageGeom>()->setOrigin(std::make_tuple(m_Origin.x, m_Origin.y, m_Origin.z));
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/SPParksSitesWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/SPParksSitesWriter.cpp
@@ -254,8 +254,7 @@ int32_t SPParksSitesWriter::writeFile()
   }
   outfile.close();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/SurfaceMeshToNonconformalVtk.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/SurfaceMeshToNonconformalVtk.cpp
@@ -415,7 +415,6 @@ void SurfaceMeshToNonconformalVtk::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/SurfaceMeshToVtk.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/SurfaceMeshToVtk.cpp
@@ -398,7 +398,6 @@ void SurfaceMeshToVtk::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VASPReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VASPReader.cpp
@@ -406,7 +406,6 @@ int VASPReader::readFile()
   tokens.clear();
   m_InStream.close();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.cpp
@@ -453,8 +453,7 @@ void VisualizeGBCDGMT::execute()
   }
   fclose(f);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.cpp
@@ -489,8 +489,7 @@ void VisualizeGBCDPoleFigure::execute()
   }
   fclose(f);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VtkRectilinearGridWriter.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VtkRectilinearGridWriter.cpp
@@ -444,7 +444,6 @@ void VtkRectilinearGridWriter::execute()
 
   // The scopedFileMonitor will fclose() the FILE pointer for us
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VtkStructuredPointsReader.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VtkStructuredPointsReader.cpp
@@ -251,7 +251,6 @@ void VtkStructuredPointsReader::execute()
   // is executing then the file data will be read into the data arrays
   dataCheck();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/WriteStlFile.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/WriteStlFile.cpp
@@ -369,7 +369,6 @@ void WriteStlFile::execute()
 
   setErrorCondition(0);
   setWarningCondition(0);
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
@@ -363,8 +363,7 @@ void BadDataNeighborOrientationCheck::execute()
     currentLevel = currentLevel - 1;
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ChangeAngleRepresentation.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ChangeAngleRepresentation.cpp
@@ -223,7 +223,6 @@ void ChangeAngleRepresentation::execute()
     serial.convert(0, totalPoints);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertHexGridToSquareGrid.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertHexGridToSquareGrid.cpp
@@ -482,7 +482,6 @@ void ConvertHexGridToSquareGrid::execute()
       return;
     }
   }
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.cpp
@@ -294,7 +294,6 @@ void ConvertOrientations::execute()
     generateRepresentation<double>(this, dArray, outData);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/CreateEnsembleInfo.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/CreateEnsembleInfo.cpp
@@ -248,8 +248,7 @@ void CreateEnsembleInfo::execute()
     m_PhaseNamesPtr.lock()->setValue(i + 1, phaseName);
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/CreateLambertSphere.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/CreateLambertSphere.cpp
@@ -375,7 +375,6 @@ void CreateLambertSphere::execute()
   createTriangleGeometry();
   createQuadGeometry();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EMsoftSO3Sampler.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EMsoftSO3Sampler.cpp
@@ -562,7 +562,6 @@ void EMsoftSO3Sampler::execute()
     m_EulerAngles[j * 3 + 2] = static_cast<float>(eu[2]);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EbsdToH5Ebsd.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EbsdToH5Ebsd.cpp
@@ -515,7 +515,6 @@ void EbsdToH5Ebsd::execute()
   }
   err = QH5Utilities::closeFile(fileId);
   fileId = -1;
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EnsembleInfoReader.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/EnsembleInfoReader.cpp
@@ -345,7 +345,6 @@ int32_t EnsembleInfoReader::readFile()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return 0;
 }
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.cpp
@@ -241,7 +241,6 @@ void FindAvgCAxes::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.cpp
@@ -269,7 +269,6 @@ void FindAvgOrientations::execute()
     FOrientArrayType eu(m_FeatureEulerAngles + (3 * i), 3);
     FOrientTransformsType::qu2eu(FOrientArrayType(avgQuats[i]), eu);
   }
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.cpp
@@ -341,7 +341,6 @@ void FindBoundaryStrengths::execute()
     m_SurfaceMeshF7s[2 * i + 1] = F7_2;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.cpp
@@ -181,7 +181,6 @@ void FindCAxisLocations::execute()
     m_CAxisLocations[index + 2] = c1[2];
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindDistsToCharactGBs.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindDistsToCharactGBs.cpp
@@ -517,7 +517,6 @@ void FindDistsToCharactGBs::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
@@ -336,7 +336,6 @@ void FindFeatureNeighborCAxisMisalignments::execute()
     m_CAxisMisalignmentList.lock()->setList(static_cast<int32_t>(i), misaL);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.cpp
@@ -347,7 +347,6 @@ void FindFeatureReferenceCAxisMisorientations::execute()
     m_FeatureStdevCAxisMisorientations[i] = sqrtf((1 / avgmiso[index]) * avgmiso[index + 2]);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
@@ -379,7 +379,6 @@ void FindFeatureReferenceMisorientations::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCD.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCD.cpp
@@ -709,8 +709,7 @@ void FindGBCD::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
@@ -1054,7 +1054,6 @@ void FindGBCDMetricBased::execute()
   fclose(fDist);
   fclose(fErr);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBPDMetricBased.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBPDMetricBased.cpp
@@ -1156,7 +1156,6 @@ void FindGBPDMetricBased::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
@@ -316,7 +316,6 @@ void FindKernelAvgMisorientations::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.cpp
@@ -325,8 +325,7 @@ void FindLocalAverageCAxisMisalignments::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
@@ -297,7 +297,6 @@ void FindMisorientations::execute()
     misoL->assign(misorientationlists[i].begin(), misorientationlists[i].end());
     m_MisorientationList.lock()->setList(static_cast<int32_t>(i), misoL);
   }
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.cpp
@@ -353,7 +353,6 @@ void FindSchmids::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.cpp
@@ -309,7 +309,6 @@ void FindSlipTransmissionMetrics::execute()
     m_mPrimeList.lock()->setList(static_cast<int32_t>(i), mPrimeL);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
@@ -458,7 +458,6 @@ void FindTwinBoundaries::execute()
     serial.generate(0, numTriangles);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.cpp
@@ -499,7 +499,6 @@ void FindTwinBoundarySchmidFactors::execute()
     outFile.close();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateEulerColors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateEulerColors.cpp
@@ -241,8 +241,7 @@ void GenerateEulerColors::execute()
       m_CellEulerColors[index + 2] = static_cast<unsigned char>(m_CellEulerAngles[index + 2] / twoThirdPi * 255.0f);
     }
   }
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.cpp
@@ -304,7 +304,6 @@ This indicates a problem with the input cell phase data. DREAM.3D will give INCO
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceIPFColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceIPFColoring.cpp
@@ -425,8 +425,7 @@ void GenerateFaceIPFColoring::execute()
     serial.generate(0, numTriangles);
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
@@ -367,8 +367,7 @@ void GenerateFaceMisorientationColoring::execute()
     serial.generate(0, numTriangles);
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceSchuhMisorientationColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceSchuhMisorientationColoring.cpp
@@ -340,8 +340,7 @@ void GenerateFaceSchuhMisorientationColoring::execute()
     serial.generate(0, numTriangles);
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateIPFColors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateIPFColors.cpp
@@ -351,8 +351,7 @@ This indicates a problem with the input cell phase data. DREAM.3D will give INCO
     notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateRodriguesColors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateRodriguesColors.cpp
@@ -266,8 +266,7 @@ void GenerateRodriguesColors::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/INLWriter.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/INLWriter.cpp
@@ -441,7 +441,6 @@ int32_t INLWriter::writeFile()
 
   fclose(f);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
   return err;
 }
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportEbsdMontage.cpp
@@ -288,7 +288,6 @@ void ImportEbsdMontage::execute()
   // The entire Reading of the data, whether that is in prefligth (so just read the header) or in execute is performed
   // in the dataCheck() method so we essentially do nothing here.
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5EspritData.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5EspritData.cpp
@@ -161,8 +161,7 @@ void ImportH5EspritData::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5OimData.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5OimData.cpp
@@ -601,8 +601,7 @@ void ImportH5OimData::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
@@ -545,8 +545,7 @@ void NeighborOrientationCorrelation::execute()
     return;
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/OrientationUtility.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/OrientationUtility.cpp
@@ -76,7 +76,6 @@ void OrientationUtility::preflight()
 // -----------------------------------------------------------------------------
 void OrientationUtility::execute()
 {
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.cpp
@@ -623,8 +623,7 @@ void ReadAngData::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadCtfData.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadCtfData.cpp
@@ -625,8 +625,7 @@ void ReadCtfData::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadH5Ebsd.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadH5Ebsd.cpp
@@ -724,8 +724,7 @@ void ReadH5Ebsd::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReplaceElementAttributesWithNeighborValues.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReplaceElementAttributesWithNeighborValues.cpp
@@ -383,8 +383,7 @@ void ReplaceElementAttributesWithNeighborValues::execute()
   // redundant code
   EXECUTE_FUNCTION_TEMPLATE(this, Detail::ExecuteTemplate, m_InArrayPtr.lock(), this, m_InArrayPtr.lock());
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/RotateEulerRefFrame.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/RotateEulerRefFrame.cpp
@@ -229,7 +229,6 @@ void RotateEulerRefFrame::execute()
     serial.convert(0, totalPoints);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/Stereographic3D.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/Stereographic3D.cpp
@@ -249,7 +249,6 @@ void Stereographic3D::execute()
     serial.convert(0, totalPoints);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteIPFStandardTriangle.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteIPFStandardTriangle.cpp
@@ -236,8 +236,7 @@ void WriteIPFStandardTriangle::execute()
     writeImage(image);
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.cpp
@@ -1016,8 +1016,7 @@ void WritePoleFigure::execute()
     }
   }
   
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteStatsGenOdfAngleFile.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WriteStatsGenOdfAngleFile.cpp
@@ -318,8 +318,7 @@ void WriteStatsGenOdfAngleFile::execute()
     file.close(); // Close the file
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/ConvertColorToGrayScale.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/ConvertColorToGrayScale.cpp
@@ -577,7 +577,6 @@ void ConvertColorToGrayScale::execute()
     }
 
 #endif
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/DetectEllipsoids.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/DetectEllipsoids.cpp
@@ -470,7 +470,6 @@ void DetectEllipsoids::execute()
       std::cout << i.key() << ": " << i.value() << std::endl;
   }
 #endif
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/ErodeDilateBadData.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/ErodeDilateBadData.cpp
@@ -351,8 +351,7 @@ void ErodeDilateBadData::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/ErodeDilateCoordinationNumber.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/ErodeDilateCoordinationNumber.cpp
@@ -343,8 +343,7 @@ void ErodeDilateCoordinationNumber::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/ErodeDilateMask.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/ErodeDilateMask.cpp
@@ -270,8 +270,7 @@ void ErodeDilateMask::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/FillBadData.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/FillBadData.cpp
@@ -438,8 +438,7 @@ void FillBadData::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/FindProjectedImageStatistics.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/FindProjectedImageStatistics.cpp
@@ -590,7 +590,6 @@ void FindProjectedImageStatistics::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/FindRelativeMotionBetweenSlices.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/FindRelativeMotionBetweenSlices.cpp
@@ -679,7 +679,6 @@ void FindRelativeMotionBetweenSlices::execute()
     m_MotionDirection[3 * i + 2] = v[2];
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/FixNonmanifoldVoxels.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/FixNonmanifoldVoxels.cpp
@@ -197,7 +197,6 @@ void FixNonmanifoldVoxels::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/IdentifySample.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/IdentifySample.cpp
@@ -311,8 +311,7 @@ void IdentifySample::execute()
   }
   checked.clear();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/InitializeData.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/InitializeData.cpp
@@ -433,7 +433,6 @@ void InitializeData::execute()
     delay(1); // Delay the execution by 1 second to avoid the exact same seedings for each array
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/MinNeighbors.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/MinNeighbors.cpp
@@ -268,8 +268,7 @@ void MinNeighbors::execute()
   AttributeMatrix::Pointer cellFeatureAttrMat = m->getAttributeMatrix(m_NumNeighborsArrayPath.getAttributeMatrixName());
   cellFeatureAttrMat->removeInactiveObjects(activeObjects, m_FeatureIdsPtr.lock().get());
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Processing/ProcessingFilters/MinSize.cpp
+++ b/Source/Plugins/Processing/ProcessingFilters/MinSize.cpp
@@ -264,8 +264,7 @@ void MinSize::execute()
   AttributeMatrix::Pointer cellFeatureAttrMat = getDataContainerArray()->getAttributeMatrix(m_NumCellsArrayPath);
   cellFeatureAttrMat->removeInactiveObjects(activeObjects, m_FeatureIdsPtr.lock().get());
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSections.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSections.cpp
@@ -386,8 +386,7 @@ void AlignSections::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeature.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeature.cpp
@@ -260,8 +260,7 @@ void AlignSectionsFeature::execute()
 
   AlignSections::execute();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeatureCentroid.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsFeatureCentroid.cpp
@@ -303,8 +303,7 @@ void AlignSectionsFeatureCentroid::execute()
 
   AlignSections::execute();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsList.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsList.cpp
@@ -217,8 +217,7 @@ void AlignSectionsList::execute()
 
   AlignSections::execute();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
@@ -392,8 +392,7 @@ void AlignSectionsMisorientation::execute()
 
   AlignSections::execute();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
@@ -604,8 +604,7 @@ void AlignSectionsMutualInformation::execute()
 
   AlignSections::execute();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.cpp
@@ -462,8 +462,7 @@ void CAxisSegmentFeatures::execute()
     randomizeFeatureIds(totalPoints, totalFeatures);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/ComputeFeatureRect.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/ComputeFeatureRect.cpp
@@ -203,7 +203,6 @@ void ComputeFeatureRect::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
@@ -439,8 +439,7 @@ void EBSDSegmentFeatures::execute()
     randomizeFeatureIds(totalPoints, totalFeatures);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/GroupFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/GroupFeatures.cpp
@@ -266,8 +266,7 @@ void GroupFeatures::execute()
     grouplist.clear();
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/GroupMicroTextureRegions.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/GroupMicroTextureRegions.cpp
@@ -536,8 +536,7 @@ void GroupMicroTextureRegions::execute()
     randomizeFeatureIds(totalPoints, totalFeatures);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/IdentifyMicroTextureRegions.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/IdentifyMicroTextureRegions.cpp
@@ -739,8 +739,7 @@ void IdentifyMicroTextureRegions::execute()
     randomizeFeatureIds(totalPoints, totalFeatures);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
@@ -686,7 +686,6 @@ void MergeColonies::execute()
     identify_globAlpha();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
@@ -439,7 +439,6 @@ void MergeTwins::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/ScalarSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/ScalarSegmentFeatures.cpp
@@ -546,8 +546,7 @@ void ScalarSegmentFeatures::execute()
   }
   
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/SegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/SegmentFeatures.cpp
@@ -232,8 +232,7 @@ void SegmentFeatures::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/AppendImageGeometryZSlice.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/AppendImageGeometryZSlice.cpp
@@ -294,7 +294,6 @@ void AppendImageGeometryZSlice::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/Sampling/SamplingFilters/ChangeResolution.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/ChangeResolution.cpp
@@ -444,7 +444,6 @@ void ChangeResolution::execute()
     cellFeatureAttrMat->removeInactiveObjects(activeObjects, featureIds.get());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/CropImageGeometry.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/CropImageGeometry.cpp
@@ -607,7 +607,6 @@ void CropImageGeometry::execute()
     destCellDataContainer->getGeometryAs<ImageGeom>()->setOrigin(origin);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/ExtractFlaggedFeatures.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/ExtractFlaggedFeatures.cpp
@@ -246,8 +246,7 @@ void ExtractFlaggedFeatures::execute()
     }
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/NearestPointFuseRegularGrids.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/NearestPointFuseRegularGrids.cpp
@@ -332,7 +332,6 @@ void NearestPointFuseRegularGrids::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/RegularGridSampleSurfaceMesh.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/RegularGridSampleSurfaceMesh.cpp
@@ -241,7 +241,6 @@ void RegularGridSampleSurfaceMesh::execute()
 
   SampleSurfaceMesh::execute();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/RegularizeZSpacing.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/RegularizeZSpacing.cpp
@@ -273,7 +273,6 @@ void RegularizeZSpacing::execute()
   m->removeAttributeMatrix(getCellAttributeMatrixPath().getAttributeMatrixName());
   m->addAttributeMatrix(getCellAttributeMatrixPath().getAttributeMatrixName(), newCellAttrMat);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/RotateSampleRefFrame.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/RotateSampleRefFrame.cpp
@@ -655,7 +655,6 @@ void RotateSampleRefFrame::execute()
   m->getGeometryAs<ImageGeom>()->setDimensions(params.xpNew, params.ypNew, params.zpNew);
   m->getGeometryAs<ImageGeom>()->setOrigin(xMin, yMin, zMin);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMeshSpecifiedPoints.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/SampleSurfaceMeshSpecifiedPoints.cpp
@@ -239,8 +239,7 @@ void SampleSurfaceMeshSpecifiedPoints::execute()
     outFile << m_FeatureIds[i] << std::endl;
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/UncertainRegularGridSampleSurfaceMesh.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/UncertainRegularGridSampleSurfaceMesh.cpp
@@ -251,7 +251,6 @@ void UncertainRegularGridSampleSurfaceMesh::execute()
 
   SampleSurfaceMesh::execute();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Sampling/SamplingFilters/WarpRegularGrid.cpp
+++ b/Source/Plugins/Sampling/SamplingFilters/WarpRegularGrid.cpp
@@ -318,7 +318,6 @@ void WarpRegularGrid::execute()
   m->removeAttributeMatrix(getCellAttributeMatrixPath().getAttributeMatrixName());
   m->addAttributeMatrix(getCellAttributeMatrixPath().getAttributeMatrixName(), newCellAttrMat);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/CalculateArrayHistogram.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/CalculateArrayHistogram.cpp
@@ -319,7 +319,6 @@ void CalculateArrayHistogram::execute()
     notifyWarningMessage(getHumanLabel(), ss, getWarningCondition());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/ComputeMomentInvariants2D.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/ComputeMomentInvariants2D.cpp
@@ -290,7 +290,6 @@ void ComputeMomentInvariants2D::execute()
     notifyStatusMessage(getMessagePrefix(), getHumanLabel(), ss);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindAvgScalarValueForFeatures.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindAvgScalarValueForFeatures.cpp
@@ -207,7 +207,6 @@ void FindAvgScalarValueForFeatures::execute()
 
   EXECUTE_FUNCTION_TEMPLATE(this, findAverage, m_InDataArrayPtr.lock(), m_InDataArrayPtr.lock(), m_NewFeatureArrayPtr.lock(), m_FeatureIds)
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindBoundaryElementFractions.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindBoundaryElementFractions.cpp
@@ -200,7 +200,6 @@ void FindBoundaryElementFractions::execute()
 
   find_surface_voxel_fractions();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindDifferenceMap.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindDifferenceMap.cpp
@@ -308,7 +308,6 @@ void FindDifferenceMap::execute()
 
   EXECUTE_TEMPLATE(this, ExecuteFindDifferenceMap, m_FirstInputArrayPtr.lock(), m_FirstInputArrayPtr.lock(), m_SecondInputArrayPtr.lock(), m_DifferenceMapPtr.lock())
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindEuclideanDistMap.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindEuclideanDistMap.cpp
@@ -754,7 +754,6 @@ void FindEuclideanDistMap::execute()
     attrMat->removeAttributeArray(getNearestNeighborsArrayName());
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindFeatureClustering.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindFeatureClustering.cpp
@@ -449,7 +449,6 @@ void FindFeatureClustering::execute()
 
   find_clustering();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindFeatureHistogram.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindFeatureHistogram.cpp
@@ -304,7 +304,6 @@ void FindFeatureHistogram::execute()
     findHistogram<bool>(inputData, m_NewEnsembleArray, m_FeaturePhases, m_NumberOfBins, m_RemoveBiasedFeatures, m_BiasedFeatures);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindLargestCrossSections.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindLargestCrossSections.cpp
@@ -265,7 +265,6 @@ void FindLargestCrossSections::execute()
 
   find_crosssections();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindNeighborhoods.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindNeighborhoods.cpp
@@ -385,7 +385,6 @@ void FindNeighborhoods::execute()
     m_NeighborhoodList.lock()->setList(static_cast<int32_t>(i), sharedNeiLst);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindNeighbors.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindNeighbors.cpp
@@ -426,7 +426,6 @@ void FindNeighbors::execute()
     m_SharedSurfaceAreaList.lock()->setList(static_cast<int32_t>(i), sharedSAL);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindNumFeatures.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindNumFeatures.cpp
@@ -159,7 +159,6 @@ void FindNumFeatures::execute()
     m_NumFeatures[m_FeaturePhases[i]]++;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindShapes.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindShapes.cpp
@@ -916,7 +916,6 @@ void FindShapes::execute()
   }
 
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindSizes.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindSizes.cpp
@@ -378,7 +378,6 @@ void FindSizes::execute()
 
   findSizes(igeom);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindSurfaceAreaToVolume.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindSurfaceAreaToVolume.cpp
@@ -322,7 +322,6 @@ void FindSurfaceAreaToVolume::execute()
     m_Sphericity[i] = (thirdRootPi * std::pow((6.0f * featureVolume), 0.66666f)) / featureSurfaceArea[i];
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FindVolFractions.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindVolFractions.cpp
@@ -166,7 +166,6 @@ void FindVolFractions::execute()
     m_VolFractions[i] /= totalPoints;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FitCorrelatedFeatureData.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FitCorrelatedFeatureData.cpp
@@ -470,7 +470,6 @@ void FitCorrelatedFeatureData::execute()
     fitData<bool>(inputData, m_NewEnsembleArray, m_FeaturePhases, numEnsembles, m_DistributionType, binArray, m_NumberOfCorrelatedBins, m_RemoveBiasedFeatures, m_BiasedFeatures);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/FitFeatureData.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FitFeatureData.cpp
@@ -286,7 +286,6 @@ void FitFeatureData::execute()
   EXECUTE_FUNCTION_TEMPLATE(this, fitData, m_InDataArrayPtr.lock(), m_InDataArrayPtr.lock(), m_NewEnsembleArray, m_FeaturePhases, numEnsembles, m_DistributionType, m_RemoveBiasedFeatures,
                             m_BiasedFeatures)
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
@@ -1460,7 +1460,6 @@ void GenerateEnsembleStatistics::execute()
 
   calculatePPTBoundaryFrac();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/Statistics/StatisticsFilters/QuiltCellData.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/QuiltCellData.cpp
@@ -431,7 +431,6 @@ void QuiltCellData::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/BinaryNodesTrianglesReader.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/BinaryNodesTrianglesReader.cpp
@@ -220,8 +220,7 @@ void BinaryNodesTrianglesReader::execute()
   err = read();
   setErrorCondition(err);
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FeatureFaceCurvatureFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FeatureFaceCurvatureFilter.cpp
@@ -447,8 +447,7 @@ void FeatureFaceCurvatureFilter::execute()
   
 #endif
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomCentroids.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomCentroids.cpp
@@ -215,7 +215,6 @@ void FindTriangleGeomCentroids::execute()
     vertexSets[i].clear();
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomNeighbors.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomNeighbors.cpp
@@ -286,7 +286,6 @@ void FindTriangleGeomNeighbors::execute()
     m_NeighborList.lock()->setList(static_cast<int32_t>(i), sharedNeiLst);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomShapes.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomShapes.cpp
@@ -694,7 +694,6 @@ void FindTriangleGeomShapes::execute()
   find_axes();
   find_axiseulers();
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomSizes.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/FindTriangleGeomSizes.cpp
@@ -213,7 +213,6 @@ void FindTriangleGeomSizes::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/GenerateGeometryConnectivity.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/GenerateGeometryConnectivity.cpp
@@ -153,8 +153,7 @@ void GenerateGeometryConnectivity::execute()
     }
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/LaplacianSmoothing.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/LaplacianSmoothing.cpp
@@ -216,7 +216,6 @@ void LaplacianSmoothing::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/MovingFiniteElementSmoothing.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/MovingFiniteElementSmoothing.cpp
@@ -1081,8 +1081,7 @@ void MovingFiniteElementSmoothing::execute()
     nodesF[n].pos[2] = nodes[n].pos[2];
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.cpp
@@ -1547,7 +1547,6 @@ void QuickSurfaceMesh::createNodesAndTriangles(std::vector<int64_t> m_NodeIds, i
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------
@@ -1666,7 +1665,6 @@ void QuickSurfaceMesh::execute()
       edgeCount++;
     }
   }
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/ReverseTriangleWinding.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/ReverseTriangleWinding.cpp
@@ -190,8 +190,7 @@ void ReverseTriangleWinding::execute()
     serial.generate(0, triangleGeom->getNumberOfTris());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/SharedFeatureFaceFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/SharedFeatureFaceFilter.cpp
@@ -260,8 +260,7 @@ void SharedFeatureFaceFilter::execute()
     m_SurfaceMeshFeatureFaceNumTriangles[i] = faceSizeMap[*faceId_64];
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleAreaFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleAreaFilter.cpp
@@ -229,8 +229,7 @@ void TriangleAreaFilter::execute()
     serial.generate(0, triangleGeom->getNumberOfTris());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleCentroidFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleCentroidFilter.cpp
@@ -216,8 +216,7 @@ void TriangleCentroidFilter::execute()
     serial.generate(0, triangleGeom->getNumberOfTris());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleDihedralAngleFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleDihedralAngleFilter.cpp
@@ -250,8 +250,7 @@ void TriangleDihedralAngleFilter::execute()
     serial.generate(0, triangleGeom->getNumberOfTris());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleNormalFilter.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/TriangleNormalFilter.cpp
@@ -227,8 +227,7 @@ void TriangleNormalFilter::execute()
     serial.generate(0, triangleGeom->getNumberOfTris());
   }
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/Unsupported/GenerateNodeTriangleConnectivity.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/Unsupported/GenerateNodeTriangleConnectivity.cpp
@@ -172,8 +172,7 @@ void GenerateNodeTriangleConnectivity::execute()
   // Generate the connectivity data
   generateConnectivity();
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 #if 0

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/Unsupported/M3CEntireVolume.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/Unsupported/M3CEntireVolume.cpp
@@ -207,7 +207,6 @@ void M3CEntireVolume::execute()
     return;
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/VerifyTriangleWinding.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/VerifyTriangleWinding.cpp
@@ -398,8 +398,7 @@ void VerifyTriangleWinding::execute()
   notifyStatusMessage(getHumanLabel(), "Generating Connectivity Complete. Starting Analysis");
   verifyTriangleWinding();
 
-  /* Let the GUI know we are done with this filter */
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddBadData.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddBadData.cpp
@@ -160,8 +160,7 @@ void AddBadData::execute()
 
   add_noise();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddOrientationNoise.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/AddOrientationNoise.cpp
@@ -143,8 +143,7 @@ void AddOrientationNoise::execute()
 
   add_orientation_noise();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/EstablishMatrixPhase.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/EstablishMatrixPhase.cpp
@@ -332,8 +332,7 @@ void EstablishMatrixPhase::execute()
     cellEnsembleAttrMat->addAttributeArray(outputPhaseNames->getName(), outputPhaseNames);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/EstablishShapeTypes.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/EstablishShapeTypes.cpp
@@ -181,8 +181,7 @@ void EstablishShapeTypes::execute()
     m_ShapeTypesPtr.lock()->setValue(i, static_cast<ShapeType::EnumType>(m_ShapeTypeData[i]));
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrecipitateStatsData.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrecipitateStatsData.cpp
@@ -623,7 +623,6 @@ void GeneratePrecipitateStatsData::execute()
     QVector<float> qFreq = QVector<float>::fromStdVector(rdfFrequencies);
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrimaryStatsData.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrimaryStatsData.cpp
@@ -571,7 +571,6 @@ void GeneratePrimaryStatsData::execute()
     }
     StatsGeneratorUtilities::GenerateAxisODFBinData(m_PrimaryStatsData, PhaseType::Type::Primary, e1s, e2s, e3s, weights, sigmas, true);
   }
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InitializeSyntheticVolume.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InitializeSyntheticVolume.cpp
@@ -271,8 +271,7 @@ void InitializeSyntheticVolume::execute()
   tDims[2] = m->getGeometryAs<ImageGeom>()->getZPoints();
   cellAttrMat->resizeAttributeArrays(tDims);
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.cpp
@@ -643,7 +643,6 @@ void InsertAtoms::execute()
 
   assign_points(points, inFeature);
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertPrecipitatePhases.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertPrecipitatePhases.cpp
@@ -694,8 +694,7 @@ void InsertPrecipitatePhases::execute()
 
   moveShapeDescriptions();
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/JumbleOrientations.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/JumbleOrientations.cpp
@@ -255,8 +255,7 @@ void JumbleOrientations::execute()
     QuaternionMathF::Copy(quat.toQuaternion(), avgQuats[i]);
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.cpp
@@ -427,8 +427,7 @@ void MatchCrystallography::execute()
     m_SyntheticCrystalStructures[i] = m_CrystalStructures[i]; // Copy over the crystal structures from the statsfile into the synthetic file
   }
 
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/PackPrimaryPhases.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/PackPrimaryPhases.cpp
@@ -918,8 +918,7 @@ void PackPrimaryPhases::execute()
     IDataArray::Pointer outputPhaseNames = inputPhaseNames->deepCopy();
     cellEnsembleAttrMat->addAttributeArray(outputPhaseNames->getName(), outputPhaseNames);
   }
-  // If there is an error set this to something negative and also set a message
-  notifyStatusMessage(getHumanLabel(), "Complete");
+
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.cpp
@@ -441,7 +441,6 @@ void StatsGeneratorFilter::execute()
     }
   }
 
-  notifyStatusMessage(getHumanLabel(), "Complete");
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The FilterPipeline class now sends a PipelineMessage object at the completion of
each filter in a consistent form.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>