### PR TITLE
Bruker Esprit Import: Do not read specific arrays until it is understood how they are calculated.

### DIFF
--- a/Source/EbsdLib/BrukerNano/EspritConstants.h
+++ b/Source/EbsdLib/BrukerNano/EspritConstants.h
@@ -92,12 +92,12 @@ const QString Setting("Setting");
 const QString SpaceGroup("SpaceGroup");
 
 // Data Section for EBSD Data
-const QString DD("DD");
+// const QString DD("DD");
 const QString MAD("MAD");
-const QString MADPhase("MADPhase");
+// const QString MADPhase("MADPhase");
 const QString NIndexedBands("NIndexedBands");
-const QString PCX("PCX");
-const QString PCY("PCY");
+// const QString PCX("PCX");
+// const QString PCY("PCY");
 const QString PHI("PHI");
 const QString Phase("Phase");
 const QString RadonBandCount("RadonBandCount");
@@ -105,8 +105,8 @@ const QString RadonQuality("RadonQuality");
 const QString RawPatterns("RawPatterns");
 const QString XBEAM("X BEAM");
 const QString YBEAM("Y BEAM");
-const QString XSAMPLE("X SAMPLE");
-const QString YSAMPLE("Y SAMPLE");
+// const QString XSAMPLE("X SAMPLE");
+// const QString YSAMPLE("Y SAMPLE");
 const QString phi1("phi1");
 const QString phi2("phi2");
 

--- a/Source/EbsdLib/BrukerNano/H5EspritFields.cpp
+++ b/Source/EbsdLib/BrukerNano/H5EspritFields.cpp
@@ -50,12 +50,12 @@ H5EspritFields::~H5EspritFields() = default;
 QVector<QString> H5EspritFields::getFieldNames()
 {
   QVector<QString> features;
-  features.push_back(Ebsd::H5Esprit::DD);
+  // features.push_back(Ebsd::H5Esprit::DD);
   features.push_back(Ebsd::H5Esprit::MAD);
-  features.push_back(Ebsd::H5Esprit::MADPhase);
+  // features.push_back(Ebsd::H5Esprit::MADPhase);
   features.push_back(Ebsd::H5Esprit::NIndexedBands);
-  features.push_back(Ebsd::H5Esprit::PCX);
-  features.push_back(Ebsd::H5Esprit::PCY);
+  // features.push_back(Ebsd::H5Esprit::PCX);
+  // features.push_back(Ebsd::H5Esprit::PCY);
   features.push_back(Ebsd::H5Esprit::PHI);
   features.push_back(Ebsd::H5Esprit::Phase);
   features.push_back(Ebsd::H5Esprit::RadonBandCount);
@@ -63,8 +63,8 @@ QVector<QString> H5EspritFields::getFieldNames()
   features.push_back(Ebsd::H5Esprit::RawPatterns);
   features.push_back(Ebsd::H5Esprit::XBEAM);
   features.push_back(Ebsd::H5Esprit::YBEAM);
-  features.push_back(Ebsd::H5Esprit::XSAMPLE);
-  features.push_back(Ebsd::H5Esprit::YSAMPLE);
+  // features.push_back(Ebsd::H5Esprit::XSAMPLE);
+  // features.push_back(Ebsd::H5Esprit::YSAMPLE);
   features.push_back(Ebsd::H5Esprit::phi1);
   features.push_back(Ebsd::H5Esprit::phi2);
   return features;

--- a/Source/EbsdLib/BrukerNano/H5EspritFields.h
+++ b/Source/EbsdLib/BrukerNano/H5EspritFields.h
@@ -62,12 +62,12 @@ public:
   template <typename T> T getFilterFeatures()
   {
     T features;
-    features.push_back(Ebsd::H5Esprit::DD);
+    // features.push_back(Ebsd::H5Esprit::DD);
     features.push_back(Ebsd::H5Esprit::MAD);
-    features.push_back(Ebsd::H5Esprit::MADPhase);
+    // features.push_back(Ebsd::H5Esprit::MADPhase);
     features.push_back(Ebsd::H5Esprit::NIndexedBands);
-    features.push_back(Ebsd::H5Esprit::PCX);
-    features.push_back(Ebsd::H5Esprit::PCY);
+    //    features.push_back(Ebsd::H5Esprit::PCX);
+    //    features.push_back(Ebsd::H5Esprit::PCY);
     features.push_back(Ebsd::H5Esprit::PHI);
     features.push_back(Ebsd::H5Esprit::Phase);
     features.push_back(Ebsd::H5Esprit::RadonBandCount);
@@ -75,8 +75,8 @@ public:
     features.push_back(Ebsd::H5Esprit::RawPatterns);
     features.push_back(Ebsd::H5Esprit::XBEAM);
     features.push_back(Ebsd::H5Esprit::YBEAM);
-    features.push_back(Ebsd::H5Esprit::XSAMPLE);
-    features.push_back(Ebsd::H5Esprit::YSAMPLE);
+    //    features.push_back(Ebsd::H5Esprit::XSAMPLE);
+    //    features.push_back(Ebsd::H5Esprit::YSAMPLE);
     features.push_back(Ebsd::H5Esprit::phi1);
     features.push_back(Ebsd::H5Esprit::phi2);
     return features;

--- a/Source/EbsdLib/BrukerNano/H5EspritReader.cpp
+++ b/Source/EbsdLib/BrukerNano/H5EspritReader.cpp
@@ -90,36 +90,36 @@ H5EspritReader::H5EspritReader()
 // -----------------------------------------------------------------------------
 H5EspritReader::~H5EspritReader()
 {
-  if(m_DDCleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::DD_t>(m_DD);
-    m_DD = nullptr;
-  }
+  //  if(m_DDCleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::DD_t>(m_DD);
+  //    m_DD = nullptr;
+  //  }
   if(m_MADCleanup)
   {
     deallocateArrayData<Ebsd::H5Esprit::MAD_t>(m_MAD);
     m_MAD = nullptr;
   }
-  if(m_MADPhaseCleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::MADPhase_t>(m_MADPhase);
-    m_MADPhase = nullptr;
-  }
+  //  if(m_MADPhaseCleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::MADPhase_t>(m_MADPhase);
+  //    m_MADPhase = nullptr;
+  //  }
   if(m_NIndexedBandsCleanup)
   {
     deallocateArrayData<Ebsd::H5Esprit::NIndexedBands_t>(m_NIndexedBands);
     m_NIndexedBands = nullptr;
   }
-  if(m_PCXCleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::PCX_t>(m_PCX);
-    m_PCX = nullptr;
-  }
-  if(m_PCYCleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::PCY_t>(m_PCY);
-    m_PCY = nullptr;
-  }
+  //  if(m_PCXCleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::PCX_t>(m_PCX);
+  //    m_PCX = nullptr;
+  //  }
+  //  if(m_PCYCleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::PCY_t>(m_PCY);
+  //    m_PCY = nullptr;
+  //  }
   if(m_PHICleanup)
   {
     deallocateArrayData<Ebsd::H5Esprit::PHI_t>(m_PHI);
@@ -150,16 +150,16 @@ H5EspritReader::~H5EspritReader()
     deallocateArrayData<Ebsd::H5Esprit::YBEAM_t>(m_YBEAM);
     m_YBEAM = nullptr;
   }
-  if(m_XSAMPLECleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::XSAMPLE_t>(m_XSAMPLE);
-    m_XSAMPLE = nullptr;
-  }
-  if(m_YSAMPLECleanup)
-  {
-    deallocateArrayData<Ebsd::H5Esprit::YSAMPLE_t>(m_YSAMPLE);
-    m_YSAMPLE = nullptr;
-  }
+  //  if(m_XSAMPLECleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::XSAMPLE_t>(m_XSAMPLE);
+  //    m_XSAMPLE = nullptr;
+  //  }
+  //  if(m_YSAMPLECleanup)
+  //  {
+  //    deallocateArrayData<Ebsd::H5Esprit::YSAMPLE_t>(m_YSAMPLE);
+  //    m_YSAMPLE = nullptr;
+  //  }
   if(m_phi1Cleanup)
   {
     deallocateArrayData<Ebsd::H5Esprit::phi1_t>(m_phi1);
@@ -433,25 +433,25 @@ int H5EspritReader::readHeader(hid_t parId)
   }
   H5ScopedGroupSentinel sentinel(&gid, false);
 
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::CameraTilt, gid, m_HeaderMap);
+  // ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::CameraTilt, gid, m_HeaderMap);
   ReadH5EbsdHeaderStringData<H5EspritReader, QString, AngStringHeaderEntry>(this, Ebsd::H5Esprit::GridType, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::KV, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::MADMax, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::Magnification, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::MapStepFactor, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::MaxRadonBandCount, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::MinIndexedBands, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::KV, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::MADMax, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::Magnification, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::MapStepFactor, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::MaxRadonBandCount, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::MinIndexedBands, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::NCOLS, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::NPoints, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::NROWS, gid, m_HeaderMap);
   ReadH5EbsdHeaderStringData<H5EspritReader, QString, AngStringHeaderEntry>(this, Ebsd::H5Esprit::OriginalFile, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::PixelByteCount, gid, m_HeaderMap);
+  // ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::PixelByteCount, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::SEPixelSizeX, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::SEPixelSizeY, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::SampleTilt, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::TopClip, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::UnClippedPatternHeight, gid, m_HeaderMap);
-  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::WD, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::SampleTilt, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::TopClip, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, int32_t, AngHeaderIntType>(this, Ebsd::H5Esprit::UnClippedPatternHeight, gid, m_HeaderMap);
+  //  ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::WD, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::XSTEP, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::YSTEP, gid, m_HeaderMap);
   ReadH5EbsdHeaderData<H5EspritReader, double, AngHeaderDoubleType>(this, Ebsd::H5Esprit::ZOffset, gid, m_HeaderMap);
@@ -624,20 +624,20 @@ int H5EspritReader::readData(hid_t parId)
     return err;
   }
 
-  ANG_READER_ALLOCATE_AND_READ(DD, Ebsd::H5Esprit::DD, Ebsd::H5Esprit::DD_t);
+  //  ANG_READER_ALLOCATE_AND_READ(DD, Ebsd::H5Esprit::DD, Ebsd::H5Esprit::DD_t);
   ANG_READER_ALLOCATE_AND_READ(MAD, Ebsd::H5Esprit::MAD, Ebsd::H5Esprit::MAD_t);
-  ANG_READER_ALLOCATE_AND_READ(MADPhase, Ebsd::H5Esprit::MADPhase, Ebsd::H5Esprit::MADPhase_t);
+  // ANG_READER_ALLOCATE_AND_READ(MADPhase, Ebsd::H5Esprit::MADPhase, Ebsd::H5Esprit::MADPhase_t);
   ANG_READER_ALLOCATE_AND_READ(NIndexedBands, Ebsd::H5Esprit::NIndexedBands, Ebsd::H5Esprit::NIndexedBands_t);
-  ANG_READER_ALLOCATE_AND_READ(PCX, Ebsd::H5Esprit::PCX, Ebsd::H5Esprit::PCX_t);
-  ANG_READER_ALLOCATE_AND_READ(PCY, Ebsd::H5Esprit::PCY, Ebsd::H5Esprit::PCY_t);
+  // ANG_READER_ALLOCATE_AND_READ(PCX, Ebsd::H5Esprit::PCX, Ebsd::H5Esprit::PCX_t);
+  // ANG_READER_ALLOCATE_AND_READ(PCY, Ebsd::H5Esprit::PCY, Ebsd::H5Esprit::PCY_t);
   ANG_READER_ALLOCATE_AND_READ(PHI, Ebsd::H5Esprit::PHI, Ebsd::H5Esprit::PHI_t);
   ANG_READER_ALLOCATE_AND_READ(Phase, Ebsd::H5Esprit::Phase, Ebsd::H5Esprit::Phase_t);
   ANG_READER_ALLOCATE_AND_READ(RadonBandCount, Ebsd::H5Esprit::RadonBandCount, Ebsd::H5Esprit::RadonBandCount_t);
   ANG_READER_ALLOCATE_AND_READ(RadonQuality, Ebsd::H5Esprit::RadonQuality, Ebsd::H5Esprit::RadonQuality_t);
   ANG_READER_ALLOCATE_AND_READ(XBEAM, Ebsd::H5Esprit::XBEAM, Ebsd::H5Esprit::XBEAM_t);
   ANG_READER_ALLOCATE_AND_READ(YBEAM, Ebsd::H5Esprit::YBEAM, Ebsd::H5Esprit::YBEAM_t);
-  ANG_READER_ALLOCATE_AND_READ(XSAMPLE, Ebsd::H5Esprit::XSAMPLE, Ebsd::H5Esprit::XSAMPLE_t);
-  ANG_READER_ALLOCATE_AND_READ(YSAMPLE, Ebsd::H5Esprit::YSAMPLE, Ebsd::H5Esprit::YSAMPLE_t);
+  // ANG_READER_ALLOCATE_AND_READ(XSAMPLE, Ebsd::H5Esprit::XSAMPLE, Ebsd::H5Esprit::XSAMPLE_t);
+  // ANG_READER_ALLOCATE_AND_READ(YSAMPLE, Ebsd::H5Esprit::YSAMPLE, Ebsd::H5Esprit::YSAMPLE_t);
   ANG_READER_ALLOCATE_AND_READ(phi1, Ebsd::H5Esprit::phi1, Ebsd::H5Esprit::phi1_t);
   ANG_READER_ALLOCATE_AND_READ(phi2, Ebsd::H5Esprit::phi2, Ebsd::H5Esprit::phi2_t);
 
@@ -716,36 +716,36 @@ void H5EspritReader::setYDimension(int ydim)
 // -----------------------------------------------------------------------------
 void H5EspritReader::releaseOwnership(const QString& name)
 {
-  if(name == Ebsd::H5Esprit::DD)
-  {
-    m_DD = nullptr;
-    m_DDCleanup = false;
-  }
+  //  if(name == Ebsd::H5Esprit::DD)
+  //  {
+  //    m_DD = nullptr;
+  //    m_DDCleanup = false;
+  //  }
   if(name == Ebsd::H5Esprit::MAD)
   {
     m_MAD = nullptr;
     m_MADCleanup = false;
   }
-  if(name == Ebsd::H5Esprit::MADPhase)
-  {
-    m_MADPhase = nullptr;
-    m_MADPhaseCleanup = false;
-  }
+  //  if(name == Ebsd::H5Esprit::MADPhase)
+  //  {
+  //    m_MADPhase = nullptr;
+  //    m_MADPhaseCleanup = false;
+  //  }
   if(name == Ebsd::H5Esprit::NIndexedBands)
   {
     m_NIndexedBands = nullptr;
     m_NIndexedBandsCleanup = false;
   }
-  if(name == Ebsd::H5Esprit::PCX)
-  {
-    m_PCX = nullptr;
-    m_PCXCleanup = false;
-  }
-  if(name == Ebsd::H5Esprit::PCY)
-  {
-    m_PCY = nullptr;
-    m_PCYCleanup = false;
-  }
+  //  if(name == Ebsd::H5Esprit::PCX)
+  //  {
+  //    m_PCX = nullptr;
+  //    m_PCXCleanup = false;
+  //  }
+  //  if(name == Ebsd::H5Esprit::PCY)
+  //  {
+  //    m_PCY = nullptr;
+  //    m_PCYCleanup = false;
+  //  }
   if(name == Ebsd::H5Esprit::PHI)
   {
     m_PHI = nullptr;
@@ -781,16 +781,16 @@ void H5EspritReader::releaseOwnership(const QString& name)
     m_YBEAM = nullptr;
     m_YBEAMCleanup = false;
   }
-  if(name == Ebsd::H5Esprit::XSAMPLE)
-  {
-    m_XSAMPLE = nullptr;
-    m_XSAMPLECleanup = false;
-  }
-  if(name == Ebsd::H5Esprit::YSAMPLE)
-  {
-    m_YSAMPLE = nullptr;
-    m_YSAMPLECleanup = false;
-  }
+  //  if(name == Ebsd::H5Esprit::XSAMPLE)
+  //  {
+  //    m_XSAMPLE = nullptr;
+  //    m_XSAMPLECleanup = false;
+  //  }
+  //  if(name == Ebsd::H5Esprit::YSAMPLE)
+  //  {
+  //    m_YSAMPLE = nullptr;
+  //    m_YSAMPLECleanup = false;
+  //  }
   if(name == Ebsd::H5Esprit::phi1)
   {
     m_phi1 = nullptr;
@@ -808,30 +808,30 @@ void H5EspritReader::releaseOwnership(const QString& name)
 // -----------------------------------------------------------------------------
 void* H5EspritReader::getPointerByName(const QString& featureName)
 {
-  if(featureName == Ebsd::H5Esprit::DD)
-  {
-    return static_cast<void*>(m_DD);
-  }
+  //  if(featureName == Ebsd::H5Esprit::DD)
+  //  {
+  //    return static_cast<void*>(m_DD);
+  //  }
   if(featureName == Ebsd::H5Esprit::MAD)
   {
     return static_cast<void*>(m_MAD);
   }
-  if(featureName == Ebsd::H5Esprit::MADPhase)
-  {
-    return static_cast<void*>(m_MADPhase);
-  }
+  //  if(featureName == Ebsd::H5Esprit::MADPhase)
+  //  {
+  //    return static_cast<void*>(m_MADPhase);
+  //  }
   if(featureName == Ebsd::H5Esprit::NIndexedBands)
   {
     return static_cast<void*>(m_NIndexedBands);
   }
-  if(featureName == Ebsd::H5Esprit::PCX)
-  {
-    return static_cast<void*>(m_PCX);
-  }
-  if(featureName == Ebsd::H5Esprit::PCY)
-  {
-    return static_cast<void*>(m_PCY);
-  }
+  //  if(featureName == Ebsd::H5Esprit::PCX)
+  //  {
+  //    return static_cast<void*>(m_PCX);
+  //  }
+  //  if(featureName == Ebsd::H5Esprit::PCY)
+  //  {
+  //    return static_cast<void*>(m_PCY);
+  //  }
   if(featureName == Ebsd::H5Esprit::PHI)
   {
     return static_cast<void*>(m_PHI);
@@ -860,14 +860,14 @@ void* H5EspritReader::getPointerByName(const QString& featureName)
   {
     return static_cast<void*>(m_YBEAM);
   }
-  if(featureName == Ebsd::H5Esprit::XSAMPLE)
-  {
-    return static_cast<void*>(m_XSAMPLE);
-  }
-  if(featureName == Ebsd::H5Esprit::YSAMPLE)
-  {
-    return static_cast<void*>(m_YSAMPLE);
-  }
+  //  if(featureName == Ebsd::H5Esprit::XSAMPLE)
+  //  {
+  //    return static_cast<void*>(m_XSAMPLE);
+  //  }
+  //  if(featureName == Ebsd::H5Esprit::YSAMPLE)
+  //  {
+  //    return static_cast<void*>(m_YSAMPLE);
+  //  }
   if(featureName == Ebsd::H5Esprit::phi1)
   {
     return static_cast<void*>(m_phi1);
@@ -886,30 +886,30 @@ void* H5EspritReader::getPointerByName(const QString& featureName)
 Ebsd::NumType H5EspritReader::getPointerType(const QString& featureName)
 {
 
-  if(featureName == Ebsd::H5Esprit::DD)
-  {
-    return Ebsd::Float;
-  }
+  //  if(featureName == Ebsd::H5Esprit::DD)
+  //  {
+  //    return Ebsd::Float;
+  //  }
   if(featureName == Ebsd::H5Esprit::MAD)
   {
     return Ebsd::Float;
   }
-  if(featureName == Ebsd::H5Esprit::MADPhase)
-  {
-    return Ebsd::Int32;
-  }
+  //  if(featureName == Ebsd::H5Esprit::MADPhase)
+  //  {
+  //    return Ebsd::Int32;
+  //  }
   if(featureName == Ebsd::H5Esprit::NIndexedBands)
   {
     return Ebsd::Int32;
   }
-  if(featureName == Ebsd::H5Esprit::PCX)
-  {
-    return Ebsd::Float;
-  }
-  if(featureName == Ebsd::H5Esprit::PCY)
-  {
-    return Ebsd::Float;
-  }
+  //  if(featureName == Ebsd::H5Esprit::PCX)
+  //  {
+  //    return Ebsd::Float;
+  //  }
+  //  if(featureName == Ebsd::H5Esprit::PCY)
+  //  {
+  //    return Ebsd::Float;
+  //  }
   if(featureName == Ebsd::H5Esprit::PHI)
   {
     return Ebsd::Float;
@@ -934,14 +934,14 @@ Ebsd::NumType H5EspritReader::getPointerType(const QString& featureName)
   {
     return Ebsd::Int32;
   }
-  if(featureName == Ebsd::H5Esprit::XSAMPLE)
-  {
-    return Ebsd::Float;
-  }
-  if(featureName == Ebsd::H5Esprit::YSAMPLE)
-  {
-    return Ebsd::Float;
-  }
+  //  if(featureName == Ebsd::H5Esprit::XSAMPLE)
+  //  {
+  //    return Ebsd::Float;
+  //  }
+  //  if(featureName == Ebsd::H5Esprit::YSAMPLE)
+  //  {
+  //    return Ebsd::Float;
+  //  }
   if(featureName == Ebsd::H5Esprit::phi1)
   {
     return Ebsd::Float;

--- a/Source/EbsdLib/BrukerNano/H5EspritReader.h
+++ b/Source/EbsdLib/BrukerNano/H5EspritReader.h
@@ -106,20 +106,20 @@ public:
    * void free[NAME]Pointer();
    *
    */
-  EBSD_POINTER_PROPERTY(DD, DD, Ebsd::H5Esprit::DD_t)
+  // EBSD_POINTER_PROPERTY(DD, DD, Ebsd::H5Esprit::DD_t)
   EBSD_POINTER_PROPERTY(MAD, MAD, Ebsd::H5Esprit::MAD_t)
-  EBSD_POINTER_PROPERTY(MADPhase, MADPhase, Ebsd::H5Esprit::MADPhase_t)
+  //  EBSD_POINTER_PROPERTY(MADPhase, MADPhase, Ebsd::H5Esprit::MADPhase_t)
   EBSD_POINTER_PROPERTY(NIndexedBands, NIndexedBands, Ebsd::H5Esprit::NIndexedBands_t)
-  EBSD_POINTER_PROPERTY(PCX, PCX, Ebsd::H5Esprit::PCX_t)
-  EBSD_POINTER_PROPERTY(PCY, PCY, Ebsd::H5Esprit::PCY_t)
+  //  EBSD_POINTER_PROPERTY(PCX, PCX, Ebsd::H5Esprit::PCX_t)
+  //  EBSD_POINTER_PROPERTY(PCY, PCY, Ebsd::H5Esprit::PCY_t)
   EBSD_POINTER_PROPERTY(PHI, PHI, Ebsd::H5Esprit::PHI_t)
   EBSD_POINTER_PROPERTY(Phase, Phase, Ebsd::H5Esprit::Phase_t)
   EBSD_POINTER_PROPERTY(RadonBandCount, RadonBandCount, Ebsd::H5Esprit::RadonBandCount_t)
   EBSD_POINTER_PROPERTY(RadonQuality, RadonQuality, Ebsd::H5Esprit::RadonQuality_t)
   EBSD_POINTER_PROPERTY(XBEAM, XBEAM, Ebsd::H5Esprit::XBEAM_t)
   EBSD_POINTER_PROPERTY(YBEAM, YBEAM, Ebsd::H5Esprit::YBEAM_t)
-  EBSD_POINTER_PROPERTY(XSAMPLE, XSAMPLE, Ebsd::H5Esprit::XSAMPLE_t)
-  EBSD_POINTER_PROPERTY(YSAMPLE, YSAMPLE, Ebsd::H5Esprit::YSAMPLE_t)
+  //  EBSD_POINTER_PROPERTY(XSAMPLE, XSAMPLE, Ebsd::H5Esprit::XSAMPLE_t)
+  //  EBSD_POINTER_PROPERTY(YSAMPLE, YSAMPLE, Ebsd::H5Esprit::YSAMPLE_t)
   EBSD_POINTER_PROPERTY(phi1, phi1, Ebsd::H5Esprit::phi1_t)
   EBSD_POINTER_PROPERTY(phi2, phi2, Ebsd::H5Esprit::phi2_t)
 

--- a/Source/EbsdLib/EbsdConstants.h
+++ b/Source/EbsdLib/EbsdConstants.h
@@ -93,7 +93,8 @@ enum class OEM : EnumType
   Zeiss = 4,
   Phillips = 5,
   ThermoFisher = 6,
-  Unknown = 7
+  DREAM3D = 7,
+  Unknown = 8
 };
 
 namespace CellData

--- a/Source/EbsdLib/Test/H5EspritReaderTest.cpp
+++ b/Source/EbsdLib/Test/H5EspritReaderTest.cpp
@@ -86,18 +86,18 @@ public:
 
     err = reader->readFile();
 
-    void* ptr = reader->getPointerByName(Ebsd::H5Esprit::DD);
+    //    void* ptr = reader->getPointerByName(Ebsd::H5Esprit::DD);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    void* ptr = reader->getPointerByName(Ebsd::H5Esprit::MAD);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::MAD);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::MADPhase);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::MADPhase);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::NIndexedBands);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::PCX);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::PCY);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::PCX);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::PCY);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::PHI);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::Phase);
@@ -110,10 +110,10 @@ public:
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::YBEAM);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
-    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
+    //    DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::phi1);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
     ptr = reader->getPointerByName(Ebsd::H5Esprit::phi2);
@@ -121,18 +121,18 @@ public:
     ptr = reader->getPointerByName(Ebsd::H5Esprit::RawPatterns);
     DREAM3D_REQUIRE_NULL_POINTER(ptr);
 
-    Ebsd::NumType numType = reader->getPointerType(Ebsd::H5Esprit::DD);
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::DD);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
+    Ebsd::NumType numType = reader->getPointerType(Ebsd::H5Esprit::MAD);
     DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
-    numType = reader->getPointerType(Ebsd::H5Esprit::MAD);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
-    numType = reader->getPointerType(Ebsd::H5Esprit::MADPhase);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Int32)
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::MADPhase);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Int32)
     numType = reader->getPointerType(Ebsd::H5Esprit::NIndexedBands);
     DREAM3D_REQUIRED(numType, ==, Ebsd::Int32)
-    numType = reader->getPointerType(Ebsd::H5Esprit::PCX);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
-    numType = reader->getPointerType(Ebsd::H5Esprit::PCY);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::PCX);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::PCY);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
     numType = reader->getPointerType(Ebsd::H5Esprit::PHI);
     DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
     numType = reader->getPointerType(Ebsd::H5Esprit::Phase);
@@ -145,10 +145,10 @@ public:
     DREAM3D_REQUIRED(numType, ==, Ebsd::Int32)
     numType = reader->getPointerType(Ebsd::H5Esprit::YBEAM);
     DREAM3D_REQUIRED(numType, ==, Ebsd::Int32)
-    numType = reader->getPointerType(Ebsd::H5Esprit::XSAMPLE);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
-    numType = reader->getPointerType(Ebsd::H5Esprit::YSAMPLE);
-    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::XSAMPLE);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
+    //    numType = reader->getPointerType(Ebsd::H5Esprit::YSAMPLE);
+    //    DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
     numType = reader->getPointerType(Ebsd::H5Esprit::phi1);
     DREAM3D_REQUIRED(numType, ==, Ebsd::Float)
     numType = reader->getPointerType(Ebsd::H5Esprit::phi2);
@@ -156,19 +156,19 @@ public:
     numType = reader->getPointerType(Ebsd::H5Esprit::RawPatterns);
     DREAM3D_REQUIRED(numType, ==, Ebsd::UInt8);
 
-    float* xsamplePtr = reader->getXSAMPLEPointer();
-    DREAM3D_REQUIRE_VALID_POINTER(xsamplePtr);
-    reader->releaseXSAMPLEOwnership();
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
-    DREAM3D_REQUIRE_NULL_POINTER(ptr);
-    reader->deallocateArrayData<float>(xsamplePtr);
+    //    float* xsamplePtr = reader->getXSAMPLEPointer();
+    //    DREAM3D_REQUIRE_VALID_POINTER(xsamplePtr);
+    //    reader->releaseXSAMPLEOwnership();
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
+    //    DREAM3D_REQUIRE_NULL_POINTER(ptr);
+    //    reader->deallocateArrayData<float>(xsamplePtr);
 
-    float* ysamplePtr = reader->getYSAMPLEPointer();
-    DREAM3D_REQUIRE_VALID_POINTER(ysamplePtr);
-    reader->releaseYSAMPLEOwnership();
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
-    DREAM3D_REQUIRE_NULL_POINTER(ptr);
-    reader->deallocateArrayData<float>(ysamplePtr);
+    //    float* ysamplePtr = reader->getYSAMPLEPointer();
+    //    DREAM3D_REQUIRE_VALID_POINTER(ysamplePtr);
+    //    reader->releaseYSAMPLEOwnership();
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
+    //    DREAM3D_REQUIRE_NULL_POINTER(ptr);
+    //    reader->deallocateArrayData<float>(ysamplePtr);
 
     // std::cout << "=============================================================" << std::endl;
     QSet<QString> arraysToRead;
@@ -185,10 +185,10 @@ public:
     ptr = reader->getPointerByName(Ebsd::H5Esprit::PHI);
     DREAM3D_REQUIRE_VALID_POINTER(ptr);
 
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
-    DREAM3D_REQUIRE_NULL_POINTER(ptr);
-    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
-    DREAM3D_REQUIRE_NULL_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::XSAMPLE);
+    //    DREAM3D_REQUIRE_NULL_POINTER(ptr);
+    //    ptr = reader->getPointerByName(Ebsd::H5Esprit::YSAMPLE);
+    //    DREAM3D_REQUIRE_NULL_POINTER(ptr);
 
 #if 0
       reader->setReadPatternData(true);

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5EspritData.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ImportH5EspritData.cpp
@@ -245,6 +245,10 @@ Ebsd::OEM ImportH5EspritData::readManufacturer() const
   {
     manuf = Ebsd::OEM::Bruker;
   }
+  if(manufacturer == "DREAM.3D")
+  {
+    manuf = Ebsd::OEM::DREAM3D;
+  }
 
   return manuf;
 }
@@ -253,9 +257,9 @@ Ebsd::OEM ImportH5EspritData::readManufacturer() const
 void ImportH5EspritData::dataCheckOEM()
 {
   // Read the manufacturer from the file
-  Ebsd::OEM manfacturer = readManufacturer();
-  setManufacturer(manfacturer);
-  if(manfacturer != Ebsd::OEM::Bruker)
+  Ebsd::OEM manufacturer = readManufacturer();
+  setManufacturer(manufacturer);
+  if(manufacturer != Ebsd::OEM::Bruker && manufacturer != Ebsd::OEM::DREAM3D)
   {
     QString ss = QObject::tr("The manufacturer is not recognized as a valid entry.");
     setErrorCondition(-384);
@@ -654,19 +658,19 @@ void ImportH5EspritData::copyRawEbsdData(EbsdReader* ebsdReader, QVector<size_t>
   cDims[0] = 1;
 
   // Copy the rest of the data from the pointer in the reader into our IDataArrayPointer
-  copyPointerData<Ebsd::H5Esprit::DD_t, H5EspritReader>(reader, Ebsd::H5Esprit::DD, ebsdArrayMap.value(Ebsd::H5Esprit::DD), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::DD_t, H5EspritReader>(reader, Ebsd::H5Esprit::DD, ebsdArrayMap.value(Ebsd::H5Esprit::DD), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::MAD_t, H5EspritReader>(reader, Ebsd::H5Esprit::MAD, ebsdArrayMap.value(Ebsd::H5Esprit::MAD), offset, totalPoints, ebsdAttrMat);
-  copyPointerData<Ebsd::H5Esprit::MADPhase_t, H5EspritReader>(reader, Ebsd::H5Esprit::MADPhase, ebsdArrayMap.value(Ebsd::H5Esprit::MADPhase), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::MADPhase_t, H5EspritReader>(reader, Ebsd::H5Esprit::MADPhase, ebsdArrayMap.value(Ebsd::H5Esprit::MADPhase), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::NIndexedBands_t, H5EspritReader>(reader, Ebsd::H5Esprit::NIndexedBands, ebsdArrayMap.value(Ebsd::H5Esprit::NIndexedBands), offset, totalPoints, ebsdAttrMat);
-  copyPointerData<Ebsd::H5Esprit::PCX_t, H5EspritReader>(reader, Ebsd::H5Esprit::PCX, ebsdArrayMap.value(Ebsd::H5Esprit::PCX), offset, totalPoints, ebsdAttrMat);
-  copyPointerData<Ebsd::H5Esprit::PCY_t, H5EspritReader>(reader, Ebsd::H5Esprit::PCY, ebsdArrayMap.value(Ebsd::H5Esprit::PCY), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::PCX_t, H5EspritReader>(reader, Ebsd::H5Esprit::PCX, ebsdArrayMap.value(Ebsd::H5Esprit::PCX), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::PCY_t, H5EspritReader>(reader, Ebsd::H5Esprit::PCY, ebsdArrayMap.value(Ebsd::H5Esprit::PCY), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::Phase_t, H5EspritReader>(reader, Ebsd::H5Esprit::Phase, ebsdArrayMap.value(Ebsd::H5Esprit::Phase), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::RadonBandCount_t, H5EspritReader>(reader, Ebsd::H5Esprit::RadonBandCount, ebsdArrayMap.value(Ebsd::H5Esprit::RadonBandCount), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::RadonQuality_t, H5EspritReader>(reader, Ebsd::H5Esprit::RadonQuality, ebsdArrayMap.value(Ebsd::H5Esprit::RadonQuality), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::XBEAM_t, H5EspritReader>(reader, Ebsd::H5Esprit::XBEAM, ebsdArrayMap.value(Ebsd::H5Esprit::XBEAM), offset, totalPoints, ebsdAttrMat);
   copyPointerData<Ebsd::H5Esprit::YBEAM_t, H5EspritReader>(reader, Ebsd::H5Esprit::YBEAM, ebsdArrayMap.value(Ebsd::H5Esprit::YBEAM), offset, totalPoints, ebsdAttrMat);
-  copyPointerData<Ebsd::H5Esprit::XSAMPLE_t, H5EspritReader>(reader, Ebsd::H5Esprit::XSAMPLE, ebsdArrayMap.value(Ebsd::H5Esprit::XSAMPLE), offset, totalPoints, ebsdAttrMat);
-  copyPointerData<Ebsd::H5Esprit::YSAMPLE_t, H5EspritReader>(reader, Ebsd::H5Esprit::YSAMPLE, ebsdArrayMap.value(Ebsd::H5Esprit::YSAMPLE), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::XSAMPLE_t, H5EspritReader>(reader, Ebsd::H5Esprit::XSAMPLE, ebsdArrayMap.value(Ebsd::H5Esprit::XSAMPLE), offset, totalPoints, ebsdAttrMat);
+  // copyPointerData<Ebsd::H5Esprit::YSAMPLE_t, H5EspritReader>(reader, Ebsd::H5Esprit::YSAMPLE, ebsdArrayMap.value(Ebsd::H5Esprit::YSAMPLE), offset, totalPoints, ebsdAttrMat);
 
   if(getReadPatternData()) // Get the pattern Data from the
   {

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ReadAngData.h
@@ -69,7 +69,6 @@ public:
   ~ReadAngData() override;
 
   SIMPL_FILTER_PARAMETER(QString, DataContainerName)
-
   Q_PROPERTY(QString DataContainerName READ getDataContainerName WRITE setDataContainerName)
 
   SIMPL_FILTER_PARAMETER(QString, CellEnsembleAttributeMatrixName)


### PR DESCRIPTION
These were removed so that the DREAM.3D generated HDF5 files from BCF could also
be read using the Import Bruker Esprit HDF5 filter.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>