### PR TITLE
Fixed calculation of Volume Fractions in the FindVolFractions filter.

### DIFF
--- a/Source/Plugins/Statistics/StatisticsFilters/FindVolFractions.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/FindVolFractions.cpp
@@ -152,18 +152,24 @@ void FindVolFractions::execute()
   size_t totalPoints = m_CellPhasesPtr.lock()->getNumberOfTuples();
   size_t totalEnsembles = m_VolFractionsPtr.lock()->getNumberOfTuples();
 
+  std::vector<size_t> ensembleElements(totalEnsembles);
+
+  // Initialize everythign
   for(size_t i = 1; i < totalEnsembles; i++)
   {
     m_VolFractions[i] = 0;
-  }
-  for(size_t i = 0; i < totalPoints; i++)
-  {
-    m_VolFractions[m_CellPhases[i]]++;
+    ensembleElements[i] = 0;
   }
 
+  // Calculate the total number of elements in each Ensemble
+  for(size_t i = 0; i < totalPoints; i++)
+  {
+    ensembleElements[m_CellPhases[i]]++;
+  }
+  // Calculate the Volume Fraction
   for(size_t i = 1; i < totalEnsembles; i++)
   {
-    m_VolFractions[i] /= totalPoints;
+    m_VolFractions[i] = static_cast<double>(ensembleElements[i]) / static_cast<double>(totalPoints);
   }
 
 }


### PR DESCRIPTION
Another instance of accumulating values in a float that exceed the limits of
floating point data. The solution is to calculate the total number of cells for
each phase then use that value casted to a double as the numerator in the division.
The output values are not correct.

First reported by Helal Chowdhury <helalme111@gmail.com>

Fixes #881. Updates #881

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>