### PR TITLE
Moving duplicate file-related functions to QtSFileUtils

### DIFF
--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.cpp
@@ -44,6 +44,7 @@
 #include "SIMPLib/Utilities/FilePathGenerator.h"
 
 #include "SVWidgetsLib/QtSupport/QtSFileCompleter.h"
+#include "SVWidgetsLib/QtSupport/QtSFileUtils.h"
 
 #include "OrientationAnalysis/FilterParameters/ConvertHexGridToSquareGridFilterParameter.h"
 #include "OrientationAnalysis/OrientationAnalysisFilters/ConvertHexGridToSquareGrid.h"
@@ -248,27 +249,9 @@ void ConvertHexGridToSquareGridWidget::resolutionChanged(const QString& string)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool ConvertHexGridToSquareGridWidget::verifyPathExists(QString outFilePath, QLineEdit* lineEdit)
-{
-  //  std::cout << "outFilePath: " << outFilePath << std::endl;
-  QFileInfo fileinfo(outFilePath);
-  if(!fileinfo.exists())
-  {
-    lineEdit->setStyleSheet("border: 1px solid red;");
-  }
-  else
-  {
-    lineEdit->setStyleSheet("");
-  }
-  return fileinfo.exists();
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void ConvertHexGridToSquareGridWidget::checkIOFiles()
 {
-  if(this->verifyPathExists(m_InputDir->text(), this->m_InputDir))
+  if(QtSFileUtils::VerifyPathExists(m_InputDir->text(), this->m_InputDir))
   {
     findMaxSliceAndPrefix();
   }
@@ -296,7 +279,7 @@ void ConvertHexGridToSquareGridWidget::on_m_InputDirBtn_clicked()
 // -----------------------------------------------------------------------------
 void ConvertHexGridToSquareGridWidget::on_m_InputDir_textChanged(const QString& text)
 {
-  if(verifyPathExists(m_InputDir->text(), m_InputDir))
+  if(QtSFileUtils::VerifyPathExists(m_InputDir->text(), m_InputDir))
   {
     findMaxSliceAndPrefix();
     QDir dir(m_InputDir->text());
@@ -343,7 +326,7 @@ void ConvertHexGridToSquareGridWidget::on_m_OutputDirBtn_clicked()
 // -----------------------------------------------------------------------------
 void ConvertHexGridToSquareGridWidget::on_m_OutputDir_textChanged(const QString& text)
 {
-  // if (verifyPathExists(text, m_OutputFile) == true )
+  // if (QtSFileUtils::VerifyPathExists(text, m_OutputFile) == true )
   //{
   //  QFileInfo fi(text);
   //  setOpenDialogLastFilePath(fi.path());

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ConvertHexGridToSquareGridWidget.h
@@ -140,14 +140,6 @@ class ConvertHexGridToSquareGridWidget : public FilterParameterWidget, private U
     void validateInputFile();
 
     /**
-     * @brief verifyPathExists
-     * @param outFilePath
-     * @param lineEdit
-     * @return
-     */
-    bool verifyPathExists(QString outFilePath, QLineEdit* lineEdit);
-
-    /**
      * @brief setWidgetListEnabled
      */
     void setWidgetListEnabled(bool v);

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdMontageImportWidget.cpp
@@ -331,7 +331,7 @@ void EbsdMontageImportWidget::inputDir_textChanged(const QString& text)
 
   m_Ui->inputDir->setToolTip("Absolute File Path: " + inputPath);
 
-  if(verifyPathExists(inputPath, m_Ui->inputDir))
+  if(QtSFileUtils::VerifyPathExists(inputPath, m_Ui->inputDir))
   {
     m_ShowFileAction->setEnabled(true);
     QDir dir(inputPath);

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdToH5EbsdWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/EbsdToH5EbsdWidget.cpp
@@ -351,7 +351,7 @@ void EbsdToH5EbsdWidget::on_m_OutputFile_textChanged(const QString& text)
 // -----------------------------------------------------------------------------
 void EbsdToH5EbsdWidget::checkIOFiles()
 {
-  if(this->verifyPathExists(m_LineEdit->text(), this->m_LineEdit))
+  if(QtSFileUtils::VerifyPathExists(m_LineEdit->text(), this->m_LineEdit))
   {
     findEbsdMaxSliceAndPrefix();
   }
@@ -410,7 +410,7 @@ void EbsdToH5EbsdWidget::on_m_LineEdit_textChanged(const QString& text)
     inputAbsPathLabel->hide();
   }
 
-  if(verifyPathExists(inputPath, m_LineEdit))
+  if(QtSFileUtils::VerifyPathExists(inputPath, m_LineEdit))
   {
     m_ShowFileAction->setEnabled(true);
     m_RefFrameOptionsBtn->setEnabled(true);
@@ -903,7 +903,7 @@ void EbsdToH5EbsdWidget::setInputDirectory(const QString &val)
 // -----------------------------------------------------------------------------
 void EbsdToH5EbsdWidget::showFileInFileSystem()
 {
-  verifyPathExists(m_LineEdit->text(), m_LineEdit); // This basically sets an internal variable of the superclass.
+  QtSFileUtils::VerifyPathExists(m_LineEdit->text(), m_LineEdit); // This basically sets an internal variable of the superclass.
   FilterParameterWidget::showFileInFileSystem();
 #if 0
   QFileInfo fi(m_CurrentlyValidPath);

--- a/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadH5EbsdWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/FilterParameterWidgets/ReadH5EbsdWidget.cpp
@@ -335,7 +335,7 @@ void ReadH5EbsdWidget::on_m_LineEdit_textChanged(const QString& text)
     absPathLabel->hide();
   }
   
-  if(verifyPathExists(inputPath, m_LineEdit))
+  if(QtSFileUtils::VerifyPathExists(inputPath, m_LineEdit))
   {
     m_ShowFileAction->setEnabled(true);
   }
@@ -591,7 +591,7 @@ void ReadH5EbsdWidget::updateFileInfoWidgets()
   SIMPLDataPathValidator* validator = SIMPLDataPathValidator::Instance();
   QString inputPath = validator->convertToAbsolutePath(m_LineEdit->text());
 
-  if(verifyPathExists(inputPath, m_LineEdit))
+  if(QtSFileUtils::VerifyPathExists(inputPath, m_LineEdit))
   {
     QFileInfo fi(inputPath);
     if(fi.exists() && fi.isFile())

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.cpp
@@ -61,6 +61,7 @@
 #include "SIMPLib/StatsData/StatsData.h"
 
 #include "SVWidgetsLib/QtSupport/QtSFileCompleter.h"
+#include "SVWidgetsLib/QtSupport/QtSFileUtils.h"
 
 #include "SyntheticBuilding/SyntheticBuildingFilters/InitializeSyntheticVolume.h"
 
@@ -180,7 +181,7 @@ void InitializeSyntheticVolumeWidget::on_m_InputFile_textChanged(const QString& 
   {
     return;
   }
-  if(!verifyPathExists(m_InputFile->text(), m_InputFile))
+  if(!QtSFileUtils::VerifyPathExists(m_InputFile->text(), m_InputFile))
   {
     return;
   }
@@ -553,24 +554,6 @@ void InitializeSyntheticVolumeWidget::estimateNumFeaturesSetup()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool InitializeSyntheticVolumeWidget::verifyPathExists(QString outFilePath, QLineEdit* lineEdit)
-{
-  //  std::cout << "outFilePath: " << outFilePath << std::endl;
-  QFileInfo fileinfo(outFilePath);
-  if(!fileinfo.exists())
-  {
-    lineEdit->setStyleSheet("border: 1px solid red;");
-  }
-  else
-  {
-    lineEdit->setStyleSheet("");
-  }
-  return fileinfo.exists();
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void InitializeSyntheticVolumeWidget::setInputFilePath(QString val)
 {
   m_InputFile->setText(val);
@@ -732,23 +715,5 @@ QFilterWidget* InitializeSyntheticVolumeWidget::createDeepCopy()
 // -----------------------------------------------------------------------------
 void InitializeSyntheticVolumeWidget::setShapeTypes(DataArray<unsigned int>::Pointer array)
 {}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-bool InitializeSyntheticVolumeWidget::verifyPathExists(QString outFilePath, QLineEdit* lineEdit)
-{
-  //  qDebug() << "outFilePath: " << outFilePath() << "\n";
-  QFileInfo fileinfo(outFilePath);
-  if (false == fileinfo.exists() )
-  {
-    lineEdit->setStyleSheet("border: 1px solid red;");
-  }
-  else
-  {
-    lineEdit->setStyleSheet("");
-  }
-  return fileinfo.exists();
-}
 
 #endif

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/InitializeSyntheticVolumeWidget.h
@@ -106,14 +106,6 @@ class InitializeSyntheticVolumeWidget : public FilterParameterWidget, private Ui
     void setWidgetListEnabled(bool v);
 
     /**
-     * @brief verifyPathExists
-     * @param outFilePath
-     * @param lineEdit
-     * @return
-     */
-    bool verifyPathExists(QString outFilePath, QLineEdit* lineEdit);
-
-    /**
      * @brief estimate_numFeatures
      * @param xpoints
      * @param ypoints

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.cpp
@@ -632,23 +632,6 @@ bool StatsGeneratorWidget::verifyOutputPathParentExists(QString outFilePath, QLi
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool StatsGeneratorWidget::verifyPathExists(const QString& outFilePath, QLineEdit* lineEdit)
-{
-  QFileInfo fileinfo(outFilePath);
-  if(!fileinfo.exists())
-  {
-    lineEdit->setStyleSheet("border: 1px solid red;");
-  }
-  else
-  {
-    lineEdit->setStyleSheet("");
-  }
-  return fileinfo.exists();
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void StatsGeneratorWidget::on_actionSaveAs_triggered()
 {
 }

--- a/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/FilterParameterWidgets/StatsGeneratorWidget.h
@@ -105,13 +105,6 @@ protected:
   void setupGui();
 
   /**
-   * @brief Verifies that a path exists on the file system.
-   * @param outFilePath The file path to check
-   * @param lineEdit The QLineEdit object to modify visuals of (Usually by placing a red line around the QLineEdit widget)
-   */
-  bool verifyPathExists(const QString& outFilePath, QLineEdit* lineEdit);
-
-  /**
    * @brief Verifies that a parent path exists on the file system.
    * @param outFilePath The parent file path to check
    * @param lineEdit The QLineEdit object to modify visuals of (Usually by placing a red line around the QLineEdit widget)


### PR DESCRIPTION
Removes the various duplicate verifyPathExists and hasValidPath methods. All plugins and widgets can then call the same methods from the QtSFileUtils class.