### PR TITLE
API updates in OrientationLib

### DIFF
--- a/Source/OrientationLib/Core/Orientation.hpp
+++ b/Source/OrientationLib/Core/Orientation.hpp
@@ -33,7 +33,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <cstring>
 #include <iostream>
 
@@ -106,13 +105,19 @@ public:
     ::memcpy(m_Array, rhs.m_Array, sizeof(T) * m_Size); // Copy the bytes over to the new array
   }
 
-  //  Orientation(const Orientation<T>&& rhs) noexcept // move Constructor
-  //  : m_Size(rhs.m_Size)
-  //  {
-  //    m_OwnsData = std::move(rhs.m_OwnsData);
-  //    m_Size = std::move(rhs.m_Size);
-  //    m_Array = std::move(rhs.m_Array);
-  //  }
+  /**
+   * @brief Converts from an Orientation object that uses a different type
+   */
+  template <typename FromType>
+  Orientation(const Orientation<FromType>& in)
+  {
+    m_Size = in.size();
+    allocate();
+    for(size_t i = 0; i < m_Size; i++)
+    {
+      m_Array[i] = static_cast<T>(in[i]);
+    }
+  }
 
   /**
    * @brief Orientation
@@ -196,8 +201,16 @@ public:
     }
     if(m_OwnsData == false)
     {
-      assert(m_Size == rhs.size());
-      assert(m_Array != nullptr);
+      if(m_Size != rhs.size())
+      {
+        throw std::out_of_range("Orientation m_Size != rhs.size()");
+      }
+
+      if(m_Array == nullptr)
+      {
+        throw std::out_of_range("Orientation m_Array == nullptr");
+      }
+
       ::memcpy(m_Array, rhs.m_Array, sizeof(T) * m_Size); // Copy the bytes over to the new array
     }
     return *this;
@@ -207,7 +220,7 @@ public:
    * the incoming Orientation instance *ONLY* if it owns its pointer. The data from `rhs` will be copied into this instance.
    * @param rhs
    */
-  Orientation& operator=(Orientation&& rhs) noexcept // Move Assignment
+  Orientation& operator=(Orientation&& rhs) // Move Assignment
   {
     // If we own our data deallocate it.
     if(m_OwnsData)
@@ -222,8 +235,15 @@ public:
     }
     else
     {
-      assert(m_Size == rhs.size());
-      assert(m_Array != nullptr);
+      if(m_Size != rhs.size())
+      {
+        throw std::out_of_range("Orientation m_Size != rhs.size()");
+      }
+
+      if(m_Array == nullptr)
+      {
+        throw std::out_of_range("Orientation m_Array == nullptr");
+      }
       ::memcpy(m_Array, rhs.m_Array, sizeof(T) * m_Size); // Copy the bytes over to the new array
     }
     return *this;
@@ -397,25 +417,29 @@ public:
 
   inline reference operator[](size_type index)
   {
-    // assert(index < m_Size);
     return m_Array[index];
   }
 
   inline const T& operator[](size_type index) const
   {
-    // assert(index < m_Size);
     return m_Array[index];
   }
 
   inline reference at(size_type index)
   {
-    assert(index < m_Size);
+    if(index >= m_Size)
+    {
+      throw std::out_of_range("DataArray subscript out of range");
+    }
     return m_Array[index];
   }
 
   inline const T& at(size_type index) const
   {
-    assert(index < m_Size);
+    if(index >= m_Size)
+    {
+      throw std::out_of_range("DataArray subscript out of range");
+    }
     return m_Array[index];
   }
 
@@ -525,7 +549,10 @@ public:
    */
   void toGMatrix(T g[3][3]) const
   {
-    assert(m_Size == 9);
+    if(m_Size != 9)
+    {
+      throw std::out_of_range("Orientation subscript out of range");
+    }
     g[0][0] = m_Array[0];
     g[0][1] = m_Array[1];
     g[0][2] = m_Array[2];
@@ -718,7 +745,7 @@ protected:
           || MUD_FLAP_4 != 0xABABABABABABABABul
           || MUD_FLAP_5 != 0xABABABABABABABABul)
       {
-        Q_ASSERT(false);
+        Q_∂(false);
       }
 #endif
     delete[](m_Array);

--- a/Source/OrientationLib/Core/OrientationRepresentation.h
+++ b/Source/OrientationLib/Core/OrientationRepresentation.h
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 BlueQuartz Software, LLC
+ * Copyright (c) 2020 BlueQuartz Software, LLC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/Source/OrientationLib/Core/Quaternion.hpp
+++ b/Source/OrientationLib/Core/Quaternion.hpp
@@ -36,6 +36,17 @@ public:
     quat[3] = 1.0;
   }
 
+  template <typename FromType>
+  Quaternion(const Quaternion<FromType>& in)
+  : Orientation<T>(4)
+  {
+    T* quat = this->data();
+    quat[0] = static_cast<T>(in[0]);
+    quat[1] = static_cast<T>(in[1]);
+    quat[2] = static_cast<T>(in[2]);
+    quat[3] = static_cast<T>(in[3]);
+  }
+
   Quaternion(size_type size)
   : Orientation<T>(4)
   {

--- a/Source/OrientationLib/Core/SourceList.cmake
+++ b/Source/OrientationLib/Core/SourceList.cmake
@@ -6,7 +6,7 @@ set(OrientationLib_Core_HDRS
   ${OrientationLib_SOURCE_DIR}/Core/OrientationTransformation.hpp
   ${OrientationLib_SOURCE_DIR}/Core/Quaternion.hpp
   ${OrientationLib_SOURCE_DIR}/Core/OrientationMath.h
-
+  ${OrientationLib_SOURCE_DIR}/Core/OrientationRepresentation.h
   )
 
 set(OrientationLib_Core_SRCS

--- a/Source/OrientationLib/IO/AngleFileLoader.h
+++ b/Source/OrientationLib/IO/AngleFileLoader.h
@@ -1,46 +1,44 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
-
-
 #include <memory>
-
 #include <vector>
 
+#include <QtCore/QString>
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
@@ -55,139 +53,140 @@
  */
 class OrientationLib_EXPORT AngleFileLoader
 {
-  public:
-    using Self = AngleFileLoader;
-    using Pointer = std::shared_ptr<Self>;
-    using ConstPointer = std::shared_ptr<const Self>;
-    using WeakPointer = std::weak_ptr<Self>;
-    using ConstWeakPointer = std::weak_ptr<const Self>;
-    static Pointer NullPointer();
+public:
+  using Self = AngleFileLoader;
+  using Pointer = std::shared_ptr<Self>;
+  using ConstPointer = std::shared_ptr<const Self>;
+  using WeakPointer = std::weak_ptr<Self>;
+  using ConstWeakPointer = std::weak_ptr<const Self>;
+  static Pointer NullPointer();
 
-    static Pointer New();
+  static Pointer New();
 
-    /**
-     * @brief Returns the name of the class for AngleFileLoader
-     */
-    virtual QString getNameOfClass() const;
-    /**
-     * @brief Returns the name of the class for AngleFileLoader
-     */
-    static QString ClassName();
+  /**
+   * @brief Returns the name of the class for AngleFileLoader
+   */
+  QString getNameOfClass() const;
+  /**
+   * @brief Returns the name of the class for AngleFileLoader
+   */
+  static QString ClassName();
 
-    virtual ~AngleFileLoader();
+  ~AngleFileLoader();
 
-    enum AngleRepresentation
-    {
-      EulerAngles,
-      QuaternionAngles,
-      RodriguezAngles
-    };
+  enum AngleRepresentation
+  {
+    EulerAngles,
+    QuaternionAngles,
+    RodriguezAngles
+  };
 
-    /**
-     * @brief Setter property for ErrorMessage
-     */
-    void setErrorMessage(const QString& value);
-    /**
-     * @brief Getter property for ErrorMessage
-     * @return Value of ErrorMessage
-     */
-    QString getErrorMessage() const;
+  /**
+   * @brief Setter property for ErrorMessage
+   */
+  void setErrorMessage(const QString& value);
 
-    /**
-     * @brief Setter property for ErrorCode
-     */
-    void setErrorCode(int value);
-    /**
-     * @brief Getter property for ErrorCode
-     * @return Value of ErrorCode
-     */
-    int getErrorCode() const;
+  /**
+   * @brief Getter property for ErrorMessage
+   * @return Value of ErrorMessage
+   */
+  QString getErrorMessage() const;
 
-    /**
-     * @brief Setter property for InputFile
-     */
-    void setInputFile(const QString& value);
-    /**
-     * @brief Getter property for InputFile
-     * @return Value of InputFile
-     */
-    QString getInputFile() const;
+  /**
+   * @brief Setter property for ErrorCode
+   */
+  void setErrorCode(int value);
 
-    /**
-     * @brief Setter property for FileAnglesInDegrees
-     */
-    void setFileAnglesInDegrees(bool value);
-    /**
-     * @brief Getter property for FileAnglesInDegrees
-     * @return Value of FileAnglesInDegrees
-     */
-    bool getFileAnglesInDegrees() const;
+  /**
+   * @brief Getter property for ErrorCode
+   * @return Value of ErrorCode
+   */
+  int getErrorCode() const;
 
-    /**
-     * @brief Setter property for OutputAnglesInDegrees
-     */
-    void setOutputAnglesInDegrees(bool value);
-    /**
-     * @brief Getter property for OutputAnglesInDegrees
-     * @return Value of OutputAnglesInDegrees
-     */
-    bool getOutputAnglesInDegrees() const;
+  /**
+   * @brief Setter property for InputFile
+   */
+  void setInputFile(const QString& value);
 
-    /**
-     * @brief Setter property for AngleRepresentation
-     */
-    void setAngleRepresentation(uint32_t value);
-    /**
-     * @brief Getter property for AngleRepresentation
-     * @return Value of AngleRepresentation
-     */
-    uint32_t getAngleRepresentation() const;
+  /**
+   * @brief Getter property for InputFile
+   * @return Value of InputFile
+   */
+  QString getInputFile() const;
 
-    /**
-     * @brief Setter property for Delimiter
-     */
-    void setDelimiter(const QString& value);
-    /**
-     * @brief Getter property for Delimiter
-     * @return Value of Delimiter
-     */
-    QString getDelimiter() const;
+  /**
+   * @brief Setter property for FileAnglesInDegrees
+   */
+  void setFileAnglesInDegrees(bool value);
 
-    /**
-     * @brief Setter property for IgnoreMultipleDelimiters
-     */
-    void setIgnoreMultipleDelimiters(bool value);
-    /**
-     * @brief Getter property for IgnoreMultipleDelimiters
-     * @return Value of IgnoreMultipleDelimiters
-     */
-    bool getIgnoreMultipleDelimiters() const;
+  /**
+   * @brief Getter property for FileAnglesInDegrees
+   * @return Value of FileAnglesInDegrees
+   */
+  bool getFileAnglesInDegrees() const;
 
-    FloatArrayType::Pointer loadData();
+  /**
+   * @brief Setter property for OutputAnglesInDegrees
+   */
+  void setOutputAnglesInDegrees(bool value);
 
+  /**
+   * @brief Getter property for OutputAnglesInDegrees
+   * @return Value of OutputAnglesInDegrees
+   */
+  bool getOutputAnglesInDegrees() const;
 
-  protected:
-    AngleFileLoader();
+  /**
+   * @brief Setter property for AngleRepresentation
+   */
+  void setAngleRepresentation(uint32_t value);
 
+  /**
+   * @brief Getter property for AngleRepresentation
+   * @return Value of AngleRepresentation
+   */
+  uint32_t getAngleRepresentation() const;
 
-  public:
-    AngleFileLoader(const AngleFileLoader&) = delete; // Copy Constructor Not Implemented
-    AngleFileLoader(AngleFileLoader&&) = delete;      // Move Constructor Not Implemented
-    AngleFileLoader& operator=(const AngleFileLoader&) = delete; // Copy Assignment Not Implemented
-    AngleFileLoader& operator=(AngleFileLoader&&) = delete;      // Move Assignment Not Implemented
+  /**
+   * @brief Setter property for Delimiter
+   */
+  void setDelimiter(const QString& value);
 
-  private:
-    QString m_ErrorMessage = {};
-    int m_ErrorCode = {};
-    QString m_InputFile = {};
-    bool m_FileAnglesInDegrees = {};
-    bool m_OutputAnglesInDegrees = {};
-    uint32_t m_AngleRepresentation = {};
-    QString m_Delimiter = {};
-    bool m_IgnoreMultipleDelimiters = {};
+  /**
+   * @brief Getter property for Delimiter
+   * @return Value of Delimiter
+   */
+  QString getDelimiter() const;
+
+  /**
+   * @brief Setter property for IgnoreMultipleDelimiters
+   */
+  void setIgnoreMultipleDelimiters(bool value);
+
+  /**
+   * @brief Getter property for IgnoreMultipleDelimiters
+   * @return Value of IgnoreMultipleDelimiters
+   */
+  bool getIgnoreMultipleDelimiters() const;
+
+  FloatArrayType::Pointer loadData();
+
+protected:
+  AngleFileLoader();
+
+public:
+  AngleFileLoader(const AngleFileLoader&) = delete;            // Copy Constructor Not Implemented
+  AngleFileLoader(AngleFileLoader&&) = delete;                 // Move Constructor Not Implemented
+  AngleFileLoader& operator=(const AngleFileLoader&) = delete; // Copy Assignment Not Implemented
+  AngleFileLoader& operator=(AngleFileLoader&&) = delete;      // Move Assignment Not Implemented
+
+private:
+  QString m_ErrorMessage = {};
+  int m_ErrorCode = {};
+  QString m_InputFile = {};
+  bool m_FileAnglesInDegrees = {};
+  bool m_OutputAnglesInDegrees = {};
+  uint32_t m_AngleRepresentation = {};
+  QString m_Delimiter = {};
+  bool m_IgnoreMultipleDelimiters = {};
 };
-
-
-
-
-

--- a/Source/OrientationLib/LaueOps/CubicLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.cpp
@@ -33,9 +33,10 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "CubicLowOps.h"
+
 #include <memory>
 
-#include "CubicLowOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -947,7 +948,7 @@ SIMPL::Rgb CubicLowOps::generateRodriguesColor(double r1, double r2, double r3) 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> CubicLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> CubicLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<011>");
@@ -1060,7 +1061,7 @@ QVector<UInt8ArrayType::Pointer> CubicLowOps::generatePoleFigure(PoleFigureConfi
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/CubicLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.cpp
@@ -211,60 +211,6 @@ OrientationF CubicLowOps::calculateMisorientation(const QuatF& q1f, const QuatF&
   return axisAngle;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD CubicLowOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for (int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1.0;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1.0;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 QuatType CubicLowOps::getQuatSymOp(int32_t i) const
 {
   return CubicLow::QuatSym[i];

--- a/Source/OrientationLib/LaueOps/CubicLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.cpp
@@ -196,38 +196,33 @@ QString CubicLowOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double CubicLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD CubicLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float CubicLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF CubicLowOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double CubicLowOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD CubicLowOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
   for (int i = 0; i < numsym; i++)
@@ -243,37 +238,31 @@ double CubicLowOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatTy
       qc.w() = 1.0;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
-
-    if (w > SIMPLib::Constants::k_Pi)
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
 QuatType CubicLowOps::getQuatSymOp(int32_t i) const
@@ -1181,9 +1170,9 @@ UInt8ArrayType::Pointer CubicLowOps::generateIPFTriangleLegend(int imageDim) con
 // -----------------------------------------------------------------------------
 SIMPL::Rgb CubicLowOps::generateMisorientationColor(const QuatType& q, const QuatType& refFrame) const
 {
-  Q_ASSERT(false);
+  throw std::out_of_range("generateMisorientationColor::generateMisorientationColor NOT Implemented");
 
-  double n1, n2, n3, w;
+  // double n1, n2, n3, w;
   double x, x1, x2, x3, x4;
   double y, y1, y2, y3, y4;
   double z, z1, z2, z3, z4;
@@ -1192,13 +1181,13 @@ SIMPL::Rgb CubicLowOps::generateMisorientationColor(const QuatType& q, const Qua
   QuatType q1 = q;
   QuatType q2 = refFrame;
 
-  w = getMisoQuat(q1, q2, n1, n2, n3);
+  OrientationD axisAngle = calculateMisorientation(q1, q2);
 
   //eq c7.1
-  k = tan(w / 2.0);
-  x = n1;
-  y = n2;
-  z = n3;
+  k = tan(axisAngle[3] / 2.0);
+  x = axisAngle[0];
+  y = axisAngle[1];
+  z = axisAngle[2];
   OrientationType rod(x, y, z, k);
   rod = getMDFFZRod(rod);
   x = rod[0];

--- a/Source/OrientationLib/LaueOps/CubicLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.cpp
@@ -57,40 +57,32 @@
 #include "OrientationLib/Utilities/ModifiedLambertProjection.h"
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 
-namespace Detail
-{
-static const double CubicLowDim1InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0));
-static const double CubicLowDim2InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0));
-static const double CubicLowDim3InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0));
-static const double CubicLowDim1StepValue = CubicLowDim1InitValue / 18.0f;
-static const double CubicLowDim2StepValue = CubicLowDim2InitValue / 18.0f;
-static const double CubicLowDim3StepValue = CubicLowDim3InitValue / 18.0f;
-
-} // namespace Detail
-
 namespace CubicLow
 {
+
+static const std::array<size_t, 3> OdfNumBins = {36, 36, 36}; // Represents a 5Deg bin
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
 
 static const int symSize0 = 6;
 static const int symSize1 = 12;
 static const int symSize2 = 8;
+
+static const int k_OdfSize = 46656;
+static const int k_MdfSize = 46656;
+static const int k_NumSymQuats = 12;
+
 static const QuatType QuatSym[12] = {
     QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),   QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),   QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
     QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),   QuatType(0.500000000, 0.500000000, 0.500000000, 0.500000000),   QuatType(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
     QuatType(0.500000000, -0.500000000, 0.500000000, 0.500000000),  QuatType(-0.500000000, 0.500000000, -0.500000000, 0.500000000), QuatType(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
     QuatType(0.500000000, -0.500000000, -0.500000000, 0.500000000), QuatType(-0.500000000, -0.500000000, 0.500000000, 0.500000000), QuatType(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
+
 static const double RodSym[12][3] = {{0.0, 0.0, 0.0},  {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}, {0.0, 0.0, 10000000000.0}, {1.0, 1.0, 1.0},   {-1.0, -1.0, -1.0},
                                      {1.0, -1.0, 1.0}, {-1.0, 1.0, -1.0},         {-1.0, 1.0, 1.0},          {1.0, -1.0, -1.0},         {-1.0, -1.0, 1.0}, {1.0, 1.0, -1.0}};
-
-} // namespace CubicLow
-static const QuatType CubicLowQuatSym[12] = {
-    QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),   QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),   QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
-    QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),   QuatType(0.500000000, 0.500000000, 0.500000000, 0.500000000),   QuatType(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
-    QuatType(0.500000000, -0.500000000, 0.500000000, 0.500000000),  QuatType(-0.500000000, 0.500000000, -0.500000000, 0.500000000), QuatType(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
-    QuatType(0.500000000, -0.500000000, -0.500000000, 0.500000000), QuatType(-0.500000000, -0.500000000, 0.500000000, 0.500000000), QuatType(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
-
-static const double CubicLowRodSym[12][3] = {{0.0, 0.0, 0.0},  {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}, {0.0, 0.0, 10000000000.0}, {1.0, 1.0, 1.0},   {-1.0, -1.0, -1.0},
-                                             {1.0, -1.0, 1.0}, {-1.0, 1.0, -1.0},         {-1.0, 1.0, 1.0},          {1.0, -1.0, -1.0},         {-1.0, -1.0, 1.0}, {1.0, 1.0, -1.0}};
 
 // static const double CubicLowSlipDirections[12][3] = {{0.0, 1.0, -1.0},
 //  {1.0, 0.0, -1.0},
@@ -143,8 +135,7 @@ static const double CubicLowMatSym[12][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0
                                                 {{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}},
 
                                                 {{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}}};
-
-using namespace Detail;
+} // namespace CubicLow
 
 // -----------------------------------------------------------------------------
 //
@@ -169,7 +160,7 @@ bool CubicLowOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int CubicLowOps::getODFSize() const
 {
-  return k_OdfSize;
+  return CubicLow::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -177,7 +168,7 @@ int CubicLowOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int CubicLowOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return CubicLow::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -185,7 +176,13 @@ int CubicLowOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int CubicLowOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return CubicLow::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> CubicLowOps::getOdfNumBins() const
+{
+  return CubicLow::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -201,7 +198,7 @@ QString CubicLowOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 double CubicLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(CubicLowQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -212,7 +209,7 @@ float CubicLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, f
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(CubicLowQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -286,35 +283,35 @@ QuatType CubicLowOps::getQuatSymOp(int32_t i) const
 
 void CubicLowOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = CubicLowRodSym[i][0];
-  r[1] = CubicLowRodSym[i][1];
-  r[2] = CubicLowRodSym[i][2];
+  r[0] = CubicLow::RodSym[i][0];
+  r[1] = CubicLow::RodSym[i][1];
+  r[2] = CubicLow::RodSym[i][2];
 }
 
 void CubicLowOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = CubicLowMatSym[i][0][0];
-  g[0][1] = CubicLowMatSym[i][0][1];
-  g[0][2] = CubicLowMatSym[i][0][2];
-  g[1][0] = CubicLowMatSym[i][1][0];
-  g[1][1] = CubicLowMatSym[i][1][1];
-  g[1][2] = CubicLowMatSym[i][1][2];
-  g[2][0] = CubicLowMatSym[i][2][0];
-  g[2][1] = CubicLowMatSym[i][2][1];
-  g[2][2] = CubicLowMatSym[i][2][2];
+  g[0][0] = CubicLow::CubicLowMatSym[i][0][0];
+  g[0][1] = CubicLow::CubicLowMatSym[i][0][1];
+  g[0][2] = CubicLow::CubicLowMatSym[i][0][2];
+  g[1][0] = CubicLow::CubicLowMatSym[i][1][0];
+  g[1][1] = CubicLow::CubicLowMatSym[i][1][1];
+  g[1][2] = CubicLow::CubicLowMatSym[i][1][2];
+  g[2][0] = CubicLow::CubicLowMatSym[i][2][0];
+  g[2][1] = CubicLow::CubicLowMatSym[i][2][1];
+  g[2][2] = CubicLow::CubicLowMatSym[i][2][2];
 }
 
 void CubicLowOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = CubicLowMatSym[i][0][0];
-  g[0][1] = CubicLowMatSym[i][0][1];
-  g[0][2] = CubicLowMatSym[i][0][2];
-  g[1][0] = CubicLowMatSym[i][1][0];
-  g[1][1] = CubicLowMatSym[i][1][1];
-  g[1][2] = CubicLowMatSym[i][1][2];
-  g[2][0] = CubicLowMatSym[i][2][0];
-  g[2][1] = CubicLowMatSym[i][2][1];
-  g[2][2] = CubicLowMatSym[i][2][2];
+  g[0][0] = CubicLow::CubicLowMatSym[i][0][0];
+  g[0][1] = CubicLow::CubicLowMatSym[i][0][1];
+  g[0][2] = CubicLow::CubicLowMatSym[i][0][2];
+  g[1][0] = CubicLow::CubicLowMatSym[i][1][0];
+  g[1][1] = CubicLow::CubicLowMatSym[i][1][1];
+  g[1][2] = CubicLow::CubicLowMatSym[i][1][2];
+  g[2][0] = CubicLow::CubicLowMatSym[i][2][0];
+  g[2][1] = CubicLow::CubicLowMatSym[i][2][1];
+  g[2][2] = CubicLow::CubicLowMatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -323,7 +320,7 @@ void CubicLowOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType CubicLowOps::getODFFZRod(const OrientationType& rod) const
 {
   int numsym = 12;
-  return  _calcRodNearestOrigin(CubicLowRodSym, numsym, rod);
+  return _calcRodNearestOrigin(CubicLow::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -334,7 +331,7 @@ OrientationType CubicLowOps::getMDFFZRod(const OrientationType& inRod) const
   double w = 0.0, n1 = 0.0, n2 = 0.0, n3 = 0.0;
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
 
-  OrientationType rod = _calcRodNearestOrigin(CubicLowRodSym, k_NumSymQuats, inRod);
+  OrientationType rod = _calcRodNearestOrigin(CubicLow::RodSym, CubicLow::k_NumSymQuats, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
   n1 = ax[0];
@@ -388,14 +385,14 @@ OrientationType CubicLowOps::getMDFFZRod(const OrientationType& inRod) const
 
 QuatType CubicLowOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(CubicLowQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2);
 }
 
 QuatF CubicLowOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(CubicLowQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(CubicLow::QuatSym, CubicLow::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -411,15 +408,15 @@ int CubicLowOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::CubicLowDim1InitValue;
-  dim[1] = Detail::CubicLowDim2InitValue;
-  dim[2] = Detail::CubicLowDim3InitValue;
-  step[0] = Detail::CubicLowDim1StepValue;
-  step[1] = Detail::CubicLowDim2StepValue;
-  step[2] = Detail::CubicLowDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 36.0f;
+  dim[0] = CubicLow::OdfDimInitValue[0];
+  dim[1] = CubicLow::OdfDimInitValue[1];
+  dim[2] = CubicLow::OdfDimInitValue[2];
+  step[0] = CubicLow::OdfDimStepValue[0];
+  step[1] = CubicLow::OdfDimStepValue[1];
+  step[2] = CubicLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(CubicLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(CubicLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(CubicLow::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -427,24 +424,24 @@ int CubicLowOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType CubicLowOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType CubicLowOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::CubicLowDim1InitValue;
-  init[1] = Detail::CubicLowDim2InitValue;
-  init[2] = Detail::CubicLowDim3InitValue;
-  step[0] = Detail::CubicLowDim1StepValue;
-  step[1] = Detail::CubicLowDim2StepValue;
-  step[2] = Detail::CubicLowDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = CubicLow::OdfDimInitValue[0];
+  init[1] = CubicLow::OdfDimInitValue[1];
+  init[2] = CubicLow::OdfDimInitValue[2];
+  step[0] = CubicLow::OdfDimStepValue[0];
+  step[1] = CubicLow::OdfDimStepValue[1];
+  step[2] = CubicLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % CubicLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / CubicLow::OdfNumBins[0]) % CubicLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (CubicLow::OdfNumBins[0] * CubicLow::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -458,33 +455,33 @@ OrientationType CubicLowOps::determineEulerAngles(uint64_t seed, int choose) con
 // -----------------------------------------------------------------------------
 OrientationType CubicLowOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(CubicLow::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = CubicLowQuatSym[symOp] * quat;
+  QuatType qc = CubicLow::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType CubicLowOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType CubicLowOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::CubicLowDim1InitValue;
-  init[1] = Detail::CubicLowDim2InitValue;
-  init[2] = Detail::CubicLowDim3InitValue;
-  step[0] = Detail::CubicLowDim1StepValue;
-  step[1] = Detail::CubicLowDim2StepValue;
-  step[2] = Detail::CubicLowDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = CubicLow::OdfDimInitValue[0];
+  init[1] = CubicLow::OdfDimInitValue[1];
+  init[2] = CubicLow::OdfDimInitValue[2];
+  step[0] = CubicLow::OdfDimStepValue[0];
+  step[1] = CubicLow::OdfDimStepValue[1];
+  step[2] = CubicLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % CubicLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / CubicLow::OdfNumBins[0]) % CubicLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (CubicLow::OdfNumBins[0] * CubicLow::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -502,15 +499,15 @@ int CubicLowOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::CubicLowDim1InitValue;
-  dim[1] = Detail::CubicLowDim2InitValue;
-  dim[2] = Detail::CubicLowDim3InitValue;
-  step[0] = Detail::CubicLowDim1StepValue;
-  step[1] = Detail::CubicLowDim2StepValue;
-  step[2] = Detail::CubicLowDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 36.0f;
+  dim[0] = CubicLow::OdfDimInitValue[0];
+  dim[1] = CubicLow::OdfDimInitValue[1];
+  dim[2] = CubicLow::OdfDimInitValue[2];
+  step[0] = CubicLow::OdfDimStepValue[0];
+  step[1] = CubicLow::OdfDimStepValue[1];
+  step[2] = CubicLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(CubicLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(CubicLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(CubicLow::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -538,22 +535,22 @@ void CubicLowOps::getSchmidFactorAndSS(double load[3], double plane[3], double d
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < CubicLow::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = CubicLowMatSym[i][2][0] * plane[0] + CubicLowMatSym[i][2][1] * plane[1] + CubicLowMatSym[i][2][2] * plane[2];
+    slipPlane[2] = CubicLow::CubicLowMatSym[i][2][0] * plane[0] + CubicLow::CubicLowMatSym[i][2][1] * plane[1] + CubicLow::CubicLowMatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = CubicLowMatSym[i][0][0] * plane[0] + CubicLowMatSym[i][0][1] * plane[1] + CubicLowMatSym[i][0][2] * plane[2];
-      slipPlane[1] = CubicLowMatSym[i][1][0] * plane[0] + CubicLowMatSym[i][1][1] * plane[1] + CubicLowMatSym[i][1][2] * plane[2];
+      slipPlane[0] = CubicLow::CubicLowMatSym[i][0][0] * plane[0] + CubicLow::CubicLowMatSym[i][0][1] * plane[1] + CubicLow::CubicLowMatSym[i][0][2] * plane[2];
+      slipPlane[1] = CubicLow::CubicLowMatSym[i][1][0] * plane[0] + CubicLow::CubicLowMatSym[i][1][1] * plane[1] + CubicLow::CubicLowMatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = CubicLowMatSym[i][0][0] * direction[0] + CubicLowMatSym[i][0][1] * direction[1] + CubicLowMatSym[i][0][2] * direction[2];
-      slipDirection[1] = CubicLowMatSym[i][1][0] * direction[0] + CubicLowMatSym[i][1][1] * direction[1] + CubicLowMatSym[i][1][2] * direction[2];
-      slipDirection[2] = CubicLowMatSym[i][2][0] * direction[0] + CubicLowMatSym[i][2][1] * direction[1] + CubicLowMatSym[i][2][2] * direction[2];
+      slipDirection[0] = CubicLow::CubicLowMatSym[i][0][0] * direction[0] + CubicLow::CubicLowMatSym[i][0][1] * direction[1] + CubicLow::CubicLowMatSym[i][0][2] * direction[2];
+      slipDirection[1] = CubicLow::CubicLowMatSym[i][1][0] * direction[0] + CubicLow::CubicLowMatSym[i][1][1] * direction[1] + CubicLow::CubicLowMatSym[i][1][2] * direction[2];
+      slipDirection[2] = CubicLow::CubicLowMatSym[i][2][0] * direction[0] + CubicLow::CubicLowMatSym[i][2][1] * direction[1] + CubicLow::CubicLowMatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -934,7 +931,7 @@ SIMPL::Rgb CubicLowOps::generateIPFColor(double phi1, double phi, double phi2, d
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < CubicLow::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -994,9 +991,9 @@ SIMPL::Rgb CubicLowOps::generateIPFColor(double phi1, double phi, double phi2, d
 // -----------------------------------------------------------------------------
 SIMPL::Rgb CubicLowOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * CubicLowDim1InitValue;
-  double range2 = 2.0f * CubicLowDim2InitValue;
-  double range3 = 2.0f * CubicLowDim3InitValue;
+  double range1 = 2.0f * CubicLow::OdfDimInitValue[0];
+  double range2 = 2.0f * CubicLow::OdfDimInitValue[1];
+  double range3 = 2.0f * CubicLow::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;

--- a/Source/OrientationLib/LaueOps/CubicLowOps.h
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.h
@@ -77,9 +77,6 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
     CubicLowOps();
     ~CubicLowOps() override;
 
-    static const int k_OdfSize = 46656;
-    static const int k_MdfSize = 46656;
-    static const int k_NumSymQuats = 12;
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +107,12 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -127,9 +130,9 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/CubicLowOps.h
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.h
@@ -213,15 +213,6 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     CubicLowOps(const CubicLowOps&) = delete;    // Copy Constructor Not Implemented
@@ -229,7 +220,6 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
     CubicLowOps& operator=(const CubicLowOps&) = delete; // Copy Assignment Not Implemented
     CubicLowOps& operator=(CubicLowOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 };
 
 

--- a/Source/OrientationLib/LaueOps/CubicLowOps.h
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/CubicLowOps.h
+++ b/Source/OrientationLib/LaueOps/CubicLowOps.h
@@ -113,8 +113,21 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -200,7 +213,15 @@ class OrientationLib_EXPORT CubicLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[12], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     CubicLowOps(const CubicLowOps&) = delete;    // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/CubicOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicOps.cpp
@@ -33,9 +33,10 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "CubicOps.h"
+
 #include <memory>
 
-#include "CubicOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -1711,7 +1712,7 @@ SIMPL::Rgb CubicOps::generateRodriguesColor(double r1, double r2, double r3) con
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> CubicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> CubicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<011>");
@@ -1823,7 +1824,7 @@ QVector<UInt8ArrayType::Pointer> CubicOps::generatePoleFigure(PoleFigureConfigur
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(static_cast<size_t>(config.imageDim * config.imageDim), dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(static_cast<size_t>(config.imageDim * config.imageDim), dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[static_cast<int>(config.order[0])] = image001;

--- a/Source/OrientationLib/LaueOps/CubicOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicOps.cpp
@@ -1,37 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <memory>
 
@@ -56,128 +56,130 @@
 
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 
-namespace Detail
-{
-
-static const double CubicDim1InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0));
-static const double CubicDim2InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0));
-static const double CubicDim3InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0));
-static const double CubicDim1StepValue = CubicDim1InitValue / 9.0f;
-static const double CubicDim2StepValue = CubicDim2InitValue / 9.0f;
-static const double CubicDim3StepValue = CubicDim3InitValue / 9.0f;
 namespace CubicHigh
 {
+
+static const std::array<size_t, 3> OdfNumBins = {18, 18, 18}; // Represents a 5Deg bin
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver4 - sinf(SIMPLib::Constants::k_PiOver4))), (1.0f / 3.0))};
+
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 6;
 static const int symSize1 = 12;
 static const int symSize2 = 8;
+
+static const int k_OdfSize = 5832;
+static const int k_MdfSize = 5832;
+static const int k_NumSymQuats = 24;
+
+static const QuatType QuatSym[24] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),
+                                     QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
+                                     QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
+                                     QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
+                                     QuatType(SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(-SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(0.000000000, -SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(0.000000000, 0.000000000, -SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
+                                     QuatType(SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
+                                     QuatType(-SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
+                                     QuatType(0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
+                                     QuatType(0.000000000, -SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
+                                     QuatType(SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
+                                     QuatType(-SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
+                                     QuatType(0.500000000, 0.500000000, 0.500000000, 0.500000000),
+                                     QuatType(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
+                                     QuatType(0.500000000, -0.500000000, 0.500000000, 0.500000000),
+                                     QuatType(-0.500000000, 0.500000000, -0.500000000, 0.500000000),
+                                     QuatType(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
+                                     QuatType(0.500000000, -0.500000000, -0.500000000, 0.500000000),
+                                     QuatType(-0.500000000, -0.500000000, 0.500000000, 0.500000000),
+                                     QuatType(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
+
+static const double RodSym[24][3] = {{0.0, 0.0, 0.0},
+                                     {10000000000.0, 0.0, 0.0},
+                                     {0.0, 10000000000.0, 0.0},
+                                     {0.0, 0.0, 10000000000.0},
+                                     {1.0, 0.0, 0.0},
+                                     {0.0, 1.0, 0.0},
+                                     {0.0, 0.0, 1.0},
+                                     {-1.0, 0.0, 0.0},
+                                     {0.0, -1.0, 0.0},
+                                     {0.0, 0.0, -1.0},
+                                     {10000000000.0, 10000000000.0, 0.0},
+                                     {-10000000000.0, 10000000000.0, 0.0},
+                                     {0.0, 10000000000.0, 10000000000.0},
+                                     {0.0, -10000000000.0, 10000000000.0},
+                                     {10000000000.0, 0.0, 10000000000.0},
+                                     {-10000000000.0, 0.0, 10000000000.0},
+                                     {1.0, 1.0, 1.0},
+                                     {-1.0, -1.0, -1.0},
+                                     {1.0, -1.0, 1.0},
+                                     {-1.0, 1.0, -1.0},
+                                     {-1.0, 1.0, 1.0},
+                                     {1.0, -1.0, -1.0},
+                                     {-1.0, -1.0, 1.0},
+                                     {1.0, 1.0, -1.0}};
+
+static const double SlipDirections[12][3] = {{0.0, 1.0, -1.0}, {1.0, 0.0, -1.0}, {1.0, -1.0, 0.0}, {1.0, -1.0, 0.0}, {1.0, 0.0, 1.0}, {0.0, 1.0, 1.0},
+                                             {1.0, 1.0, 0.0},  {0.0, 1.0, 1.0},  {1.0, 0.0, -1.0}, {1.0, 1.0, 0.0},  {1.0, 0.0, 1.0}, {0.0, 1.0, -1.0}};
+
+static const double SlipPlanes[12][3] = {{1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0},
+                                         {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}};
+
+static const double MatSym[24][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                        {{1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}},
+
+                                        {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                        {{1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}},
+
+                                        {{0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}},
+
+                                        {{0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}},
+
+                                        {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                        {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                        {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                        {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                        {{0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}},
+
+                                        {{0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
+
+                                        {{0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}},
+
+                                        {{0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
+
+                                        {{0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}},
+
+                                        {{0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
+
+                                        {{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}},
+
+                                        {{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
+
+                                        {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                        {{-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}},
+
+                                        {{0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}},
+
+                                        {{-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}},
+
+                                        {{0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}},
+
+                                        {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
+
 } // namespace CubicHigh
-}
-
-static const QuatType CubicQuatSym[24] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),
-                                          QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
-                                          QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
-                                          QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
-                                          QuatType(SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(-SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(0.000000000, -SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(0.000000000, 0.000000000, -SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
-                                          QuatType(SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
-                                          QuatType(-SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
-                                          QuatType(0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
-                                          QuatType(0.000000000, -SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
-                                          QuatType(SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
-                                          QuatType(-SIMPLib::Constants::k_1OverRoot2, 0.000000000, SIMPLib::Constants::k_1OverRoot2, 0.000000000),
-                                          QuatType(0.500000000, 0.500000000, 0.500000000, 0.500000000),
-                                          QuatType(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
-                                          QuatType(0.500000000, -0.500000000, 0.500000000, 0.500000000),
-                                          QuatType(-0.500000000, 0.500000000, -0.500000000, 0.500000000),
-                                          QuatType(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
-                                          QuatType(0.500000000, -0.500000000, -0.500000000, 0.500000000),
-                                          QuatType(-0.500000000, -0.500000000, 0.500000000, 0.500000000),
-                                          QuatType(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
-
-static const double CubicRodSym[24][3] = {{0.0, 0.0, 0.0},
-                                          {10000000000.0, 0.0, 0.0},
-                                          {0.0, 10000000000.0, 0.0},
-                                          {0.0, 0.0, 10000000000.0},
-                                          {1.0, 0.0, 0.0},
-                                          {0.0, 1.0, 0.0},
-                                          {0.0, 0.0, 1.0},
-                                          {-1.0, 0.0, 0.0},
-                                          {0.0, -1.0, 0.0},
-                                          {0.0, 0.0, -1.0},
-                                          {10000000000.0, 10000000000.0, 0.0},
-                                          {-10000000000.0, 10000000000.0, 0.0},
-                                          {0.0, 10000000000.0, 10000000000.0},
-                                          {0.0, -10000000000.0, 10000000000.0},
-                                          {10000000000.0, 0.0, 10000000000.0},
-                                          {-10000000000.0, 0.0, 10000000000.0},
-                                          {1.0, 1.0, 1.0},
-                                          {-1.0, -1.0, -1.0},
-                                          {1.0, -1.0, 1.0},
-                                          {-1.0, 1.0, -1.0},
-                                          {-1.0, 1.0, 1.0},
-                                          {1.0, -1.0, -1.0},
-                                          {-1.0, -1.0, 1.0},
-                                          {1.0, 1.0, -1.0}};
-
-static const double CubicSlipDirections[12][3] = {{0.0, 1.0, -1.0}, {1.0, 0.0, -1.0}, {1.0, -1.0, 0.0}, {1.0, -1.0, 0.0}, {1.0, 0.0, 1.0}, {0.0, 1.0, 1.0},
-                                                  {1.0, 1.0, 0.0},  {0.0, 1.0, 1.0},  {1.0, 0.0, -1.0}, {1.0, 1.0, 0.0},  {1.0, 0.0, 1.0}, {0.0, 1.0, -1.0}};
-
-static const double CubicSlipPlanes[12][3] = {{1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0},
-                                              {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}};
-
-static const double CubicMatSym[24][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                             {{1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}},
-
-                                             {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                             {{1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}},
-
-                                             {{0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}},
-
-                                             {{0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}},
-
-                                             {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                             {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                             {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                             {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                             {{0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}},
-
-                                             {{0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
-
-                                             {{0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}},
-
-                                             {{0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
-
-                                             {{0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}},
-
-                                             {{0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
-
-                                             {{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}},
-
-                                             {{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
-
-                                             {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                             {{-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}},
-
-                                             {{0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}},
-
-                                             {{-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}},
-
-                                             {{0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}},
-
-                                             {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
-
-using namespace Detail;
 
 // -----------------------------------------------------------------------------
 //
@@ -202,7 +204,7 @@ bool CubicOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int CubicOps::getODFSize() const
 {
-  return k_OdfSize;
+  return CubicHigh::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -210,7 +212,7 @@ int CubicOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int CubicOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return CubicHigh::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -218,7 +220,13 @@ int CubicOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int CubicOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return CubicHigh::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> CubicOps::getOdfNumBins() const
+{
+  return CubicHigh::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -234,7 +242,7 @@ QString CubicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 double CubicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(CubicQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -245,7 +253,7 @@ float CubicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, floa
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(CubicQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -508,40 +516,40 @@ double CubicOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType&
 
 QuatType CubicOps::getQuatSymOp(int32_t i) const
 {
-  return CubicQuatSym[i];
+  return CubicHigh::QuatSym[i];
 }
 
 void CubicOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = CubicRodSym[i][0];
-  r[1] = CubicRodSym[i][1];
-  r[2] = CubicRodSym[i][2];
+  r[0] = CubicHigh::RodSym[i][0];
+  r[1] = CubicHigh::RodSym[i][1];
+  r[2] = CubicHigh::RodSym[i][2];
 }
 
 void CubicOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = CubicMatSym[i][0][0];
-  g[0][1] = CubicMatSym[i][0][1];
-  g[0][2] = CubicMatSym[i][0][2];
-  g[1][0] = CubicMatSym[i][1][0];
-  g[1][1] = CubicMatSym[i][1][1];
-  g[1][2] = CubicMatSym[i][1][2];
-  g[2][0] = CubicMatSym[i][2][0];
-  g[2][1] = CubicMatSym[i][2][1];
-  g[2][2] = CubicMatSym[i][2][2];
+  g[0][0] = CubicHigh::MatSym[i][0][0];
+  g[0][1] = CubicHigh::MatSym[i][0][1];
+  g[0][2] = CubicHigh::MatSym[i][0][2];
+  g[1][0] = CubicHigh::MatSym[i][1][0];
+  g[1][1] = CubicHigh::MatSym[i][1][1];
+  g[1][2] = CubicHigh::MatSym[i][1][2];
+  g[2][0] = CubicHigh::MatSym[i][2][0];
+  g[2][1] = CubicHigh::MatSym[i][2][1];
+  g[2][2] = CubicHigh::MatSym[i][2][2];
 }
 
 void CubicOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = CubicMatSym[i][0][0];
-  g[0][1] = CubicMatSym[i][0][1];
-  g[0][2] = CubicMatSym[i][0][2];
-  g[1][0] = CubicMatSym[i][1][0];
-  g[1][1] = CubicMatSym[i][1][1];
-  g[1][2] = CubicMatSym[i][1][2];
-  g[2][0] = CubicMatSym[i][2][0];
-  g[2][1] = CubicMatSym[i][2][1];
-  g[2][2] = CubicMatSym[i][2][2];
+  g[0][0] = CubicHigh::MatSym[i][0][0];
+  g[0][1] = CubicHigh::MatSym[i][0][1];
+  g[0][2] = CubicHigh::MatSym[i][0][2];
+  g[1][0] = CubicHigh::MatSym[i][1][0];
+  g[1][1] = CubicHigh::MatSym[i][1][1];
+  g[1][2] = CubicHigh::MatSym[i][1][2];
+  g[2][0] = CubicHigh::MatSym[i][2][0];
+  g[2][1] = CubicHigh::MatSym[i][2][1];
+  g[2][2] = CubicHigh::MatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -549,7 +557,7 @@ void CubicOps::getMatSymOp(int i, float g[3][3]) const
 // -----------------------------------------------------------------------------
 OrientationType CubicOps::getODFFZRod(const OrientationType& rod) const
 {
-  return _calcRodNearestOrigin(CubicRodSym, k_NumSymQuats, rod);
+  return _calcRodNearestOrigin(CubicHigh::RodSym, CubicHigh::k_NumSymQuats, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -560,7 +568,7 @@ OrientationType CubicOps::getMDFFZRod(const OrientationType& inRod) const
   double w, n1, n2, n3;
   double FZw, FZn1, FZn2, FZn3;
 
-  OrientationType rod = _calcRodNearestOrigin(CubicRodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(CubicHigh::RodSym, 12, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
   n1 = ax[0];
@@ -614,21 +622,21 @@ OrientationType CubicOps::getMDFFZRod(const OrientationType& inRod) const
 
 QuatType CubicOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(CubicQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
 }
 
 QuatF CubicOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(CubicQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
 
 QuatType CubicOps::getFZQuat(const QuatType& qr) const
 {
-  return _calcQuatNearestOrigin(CubicQuatSym, k_NumSymQuats, qr);
+  return _calcQuatNearestOrigin(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, qr);
 }
 
 // -----------------------------------------------------------------------------
@@ -642,15 +650,15 @@ int CubicOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::CubicDim1InitValue;
-  dim[1] = Detail::CubicDim2InitValue;
-  dim[2] = Detail::CubicDim3InitValue;
-  step[0] = Detail::CubicDim1StepValue;
-  step[1] = Detail::CubicDim2StepValue;
-  step[2] = Detail::CubicDim3StepValue;
-  bins[0] = 18.0f;
-  bins[1] = 18.0f;
-  bins[2] = 18.0f;
+  dim[0] = CubicHigh::OdfDimInitValue[0];
+  dim[1] = CubicHigh::OdfDimInitValue[1];
+  dim[2] = CubicHigh::OdfDimInitValue[2];
+  step[0] = CubicHigh::OdfDimStepValue[0];
+  step[1] = CubicHigh::OdfDimStepValue[1];
+  step[2] = CubicHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(CubicHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(CubicHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(CubicHigh::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -658,24 +666,24 @@ int CubicOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType CubicOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType CubicOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::CubicDim1InitValue;
-  init[1] = Detail::CubicDim2InitValue;
-  init[2] = Detail::CubicDim3InitValue;
-  step[0] = Detail::CubicDim1StepValue;
-  step[1] = Detail::CubicDim2StepValue;
-  step[2] = Detail::CubicDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 18);
-  phi[1] = static_cast<int32_t>((choose / 18) % 18);
-  phi[2] = static_cast<int32_t>(choose / (18 * 18));
+  init[0] = CubicHigh::OdfDimInitValue[0];
+  init[1] = CubicHigh::OdfDimInitValue[1];
+  init[2] = CubicHigh::OdfDimInitValue[2];
+  step[0] = CubicHigh::OdfDimStepValue[0];
+  step[1] = CubicHigh::OdfDimStepValue[1];
+  step[2] = CubicHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % CubicHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / CubicHigh::OdfNumBins[0]) % CubicHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (CubicHigh::OdfNumBins[0] * CubicHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -689,33 +697,33 @@ OrientationType CubicOps::determineEulerAngles(uint64_t seed, int choose) const
 // -----------------------------------------------------------------------------
 OrientationType CubicOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(CubicHigh::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = CubicQuatSym[symOp] * quat;
+  QuatType qc = CubicHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType CubicOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType CubicOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::CubicDim1InitValue;
-  init[1] = Detail::CubicDim2InitValue;
-  init[2] = Detail::CubicDim3InitValue;
-  step[0] = Detail::CubicDim1StepValue;
-  step[1] = Detail::CubicDim2StepValue;
-  step[2] = Detail::CubicDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 18);
-  phi[1] = static_cast<int32_t>((choose / 18) % 18);
-  phi[2] = static_cast<int32_t>(choose / (18 * 18));
+  init[0] = CubicHigh::OdfDimInitValue[0];
+  init[1] = CubicHigh::OdfDimInitValue[1];
+  init[2] = CubicHigh::OdfDimInitValue[2];
+  step[0] = CubicHigh::OdfDimStepValue[0];
+  step[1] = CubicHigh::OdfDimStepValue[1];
+  step[2] = CubicHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % CubicHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / CubicHigh::OdfNumBins[0]) % CubicHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (CubicHigh::OdfNumBins[0] * CubicHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -733,15 +741,15 @@ int CubicOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::CubicDim1InitValue;
-  dim[1] = Detail::CubicDim2InitValue;
-  dim[2] = Detail::CubicDim3InitValue;
-  step[0] = Detail::CubicDim1StepValue;
-  step[1] = Detail::CubicDim2StepValue;
-  step[2] = Detail::CubicDim3StepValue;
-  bins[0] = 18.0f;
-  bins[1] = 18.0f;
-  bins[2] = 18.0f;
+  dim[0] = CubicHigh::OdfDimInitValue[0];
+  dim[1] = CubicHigh::OdfDimInitValue[1];
+  dim[2] = CubicHigh::OdfDimInitValue[2];
+  step[0] = CubicHigh::OdfDimStepValue[0];
+  step[1] = CubicHigh::OdfDimStepValue[1];
+  step[2] = CubicHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(CubicHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(CubicHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(CubicHigh::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -890,22 +898,22 @@ void CubicOps::getSchmidFactorAndSS(double load[3], double plane[3], double dire
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < CubicHigh::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = CubicMatSym[i][2][0] * plane[0] + CubicMatSym[i][2][1] * plane[1] + CubicMatSym[i][2][2] * plane[2];
+    slipPlane[2] = CubicHigh::MatSym[i][2][0] * plane[0] + CubicHigh::MatSym[i][2][1] * plane[1] + CubicHigh::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = CubicMatSym[i][0][0] * plane[0] + CubicMatSym[i][0][1] * plane[1] + CubicMatSym[i][0][2] * plane[2];
-      slipPlane[1] = CubicMatSym[i][1][0] * plane[0] + CubicMatSym[i][1][1] * plane[1] + CubicMatSym[i][1][2] * plane[2];
+      slipPlane[0] = CubicHigh::MatSym[i][0][0] * plane[0] + CubicHigh::MatSym[i][0][1] * plane[1] + CubicHigh::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = CubicHigh::MatSym[i][1][0] * plane[0] + CubicHigh::MatSym[i][1][1] * plane[1] + CubicHigh::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = CubicMatSym[i][0][0] * direction[0] + CubicMatSym[i][0][1] * direction[1] + CubicMatSym[i][0][2] * direction[2];
-      slipDirection[1] = CubicMatSym[i][1][0] * direction[0] + CubicMatSym[i][1][1] * direction[1] + CubicMatSym[i][1][2] * direction[2];
-      slipDirection[2] = CubicMatSym[i][2][0] * direction[0] + CubicMatSym[i][2][1] * direction[1] + CubicMatSym[i][2][2] * direction[2];
+      slipDirection[0] = CubicHigh::MatSym[i][0][0] * direction[0] + CubicHigh::MatSym[i][0][1] * direction[1] + CubicHigh::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = CubicHigh::MatSym[i][1][0] * direction[0] + CubicHigh::MatSym[i][1][1] * direction[1] + CubicHigh::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = CubicHigh::MatSym[i][2][0] * direction[0] + CubicHigh::MatSym[i][2][1] * direction[1] + CubicHigh::MatSym[i][2][2] * direction[2];
 
       double cosPhi = std::fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = std::fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -941,12 +949,12 @@ double CubicOps::getmPrime(const QuatType& q1, const QuatType& q2, double LD[3])
   MatrixMath::Transpose3x3(g2, g2);
   for(int i = 0; i < 12; i++)
   {
-    slipDirection[0] = CubicSlipDirections[i][0];
-    slipDirection[1] = CubicSlipDirections[i][1];
-    slipDirection[2] = CubicSlipDirections[i][2];
-    slipPlane[0] = CubicSlipPlanes[i][0];
-    slipPlane[1] = CubicSlipPlanes[i][1];
-    slipPlane[2] = CubicSlipPlanes[i][2];
+    slipDirection[0] = CubicHigh::SlipDirections[i][0];
+    slipDirection[1] = CubicHigh::SlipDirections[i][1];
+    slipDirection[2] = CubicHigh::SlipDirections[i][2];
+    slipPlane[0] = CubicHigh::SlipPlanes[i][0];
+    slipPlane[1] = CubicHigh::SlipPlanes[i][1];
+    slipPlane[2] = CubicHigh::SlipPlanes[i][2];
     MatrixMath::Multiply3x3with3x1(g1, slipDirection, hkl1);
     MatrixMath::Multiply3x3with3x1(g1, slipPlane, uvw1);
     MatrixMath::Normalize3x1(hkl1);
@@ -960,12 +968,12 @@ double CubicOps::getmPrime(const QuatType& q1, const QuatType& q2, double LD[3])
       ss1 = i;
     }
   }
-  slipDirection[0] = CubicSlipDirections[ss1][0];
-  slipDirection[1] = CubicSlipDirections[ss1][1];
-  slipDirection[2] = CubicSlipDirections[ss1][2];
-  slipPlane[0] = CubicSlipPlanes[ss1][0];
-  slipPlane[1] = CubicSlipPlanes[ss1][1];
-  slipPlane[2] = CubicSlipPlanes[ss1][2];
+  slipDirection[0] = CubicHigh::SlipDirections[ss1][0];
+  slipDirection[1] = CubicHigh::SlipDirections[ss1][1];
+  slipDirection[2] = CubicHigh::SlipDirections[ss1][2];
+  slipPlane[0] = CubicHigh::SlipPlanes[ss1][0];
+  slipPlane[1] = CubicHigh::SlipPlanes[ss1][1];
+  slipPlane[2] = CubicHigh::SlipPlanes[ss1][2];
   MatrixMath::Multiply3x3with3x1(g1, slipDirection, hkl1);
   MatrixMath::Multiply3x3with3x1(g1, slipPlane, uvw1);
   MatrixMath::Normalize3x1(hkl1);
@@ -974,12 +982,12 @@ double CubicOps::getmPrime(const QuatType& q1, const QuatType& q2, double LD[3])
   maxSchmidFactor = 0;
   for(int j = 0; j < 12; j++)
   {
-    slipDirection[0] = CubicSlipDirections[j][0];
-    slipDirection[1] = CubicSlipDirections[j][1];
-    slipDirection[2] = CubicSlipDirections[j][2];
-    slipPlane[0] = CubicSlipPlanes[j][0];
-    slipPlane[1] = CubicSlipPlanes[j][1];
-    slipPlane[2] = CubicSlipPlanes[j][2];
+    slipDirection[0] = CubicHigh::SlipDirections[j][0];
+    slipDirection[1] = CubicHigh::SlipDirections[j][1];
+    slipDirection[2] = CubicHigh::SlipDirections[j][2];
+    slipPlane[0] = CubicHigh::SlipPlanes[j][0];
+    slipPlane[1] = CubicHigh::SlipPlanes[j][1];
+    slipPlane[2] = CubicHigh::SlipPlanes[j][2];
     MatrixMath::Multiply3x3with3x1(g2, slipDirection, hkl2);
     MatrixMath::Multiply3x3with3x1(g2, slipPlane, uvw2);
     MatrixMath::Normalize3x1(hkl2);
@@ -993,12 +1001,12 @@ double CubicOps::getmPrime(const QuatType& q1, const QuatType& q2, double LD[3])
       ss2 = j;
     }
   }
-  slipDirection[0] = CubicSlipDirections[ss2][0];
-  slipDirection[1] = CubicSlipDirections[ss2][1];
-  slipDirection[2] = CubicSlipDirections[ss2][2];
-  slipPlane[0] = CubicSlipPlanes[ss2][0];
-  slipPlane[1] = CubicSlipPlanes[ss2][1];
-  slipPlane[2] = CubicSlipPlanes[ss2][2];
+  slipDirection[0] = CubicHigh::SlipDirections[ss2][0];
+  slipDirection[1] = CubicHigh::SlipDirections[ss2][1];
+  slipDirection[2] = CubicHigh::SlipDirections[ss2][2];
+  slipPlane[0] = CubicHigh::SlipPlanes[ss2][0];
+  slipPlane[1] = CubicHigh::SlipPlanes[ss2][1];
+  slipPlane[2] = CubicHigh::SlipPlanes[ss2][2];
   MatrixMath::Multiply3x3with3x1(g2, slipDirection, hkl2);
   MatrixMath::Multiply3x3with3x1(g2, slipPlane, uvw2);
   MatrixMath::Normalize3x1(hkl2);
@@ -1035,12 +1043,12 @@ double CubicOps::getF1(const QuatType& q1, const QuatType& q2, double LD[3], boo
   }
   for(int i = 0; i < 12; i++)
   {
-    slipDirection[0] = CubicSlipDirections[i][0];
-    slipDirection[1] = CubicSlipDirections[i][1];
-    slipDirection[2] = CubicSlipDirections[i][2];
-    slipPlane[0] = CubicSlipPlanes[i][0];
-    slipPlane[1] = CubicSlipPlanes[i][1];
-    slipPlane[2] = CubicSlipPlanes[i][2];
+    slipDirection[0] = CubicHigh::SlipDirections[i][0];
+    slipDirection[1] = CubicHigh::SlipDirections[i][1];
+    slipDirection[2] = CubicHigh::SlipDirections[i][2];
+    slipPlane[0] = CubicHigh::SlipPlanes[i][0];
+    slipPlane[1] = CubicHigh::SlipPlanes[i][1];
+    slipPlane[2] = CubicHigh::SlipPlanes[i][2];
     MatrixMath::Multiply3x3with3x1(g1, slipDirection, hkl1);
     MatrixMath::Multiply3x3with3x1(g1, slipPlane, uvw1);
     MatrixMath::Normalize3x1(hkl1);
@@ -1057,12 +1065,12 @@ double CubicOps::getF1(const QuatType& q1, const QuatType& q2, double LD[3], boo
       }
       for(int j = 0; j < 12; j++)
       {
-        slipDirection[0] = CubicSlipDirections[j][0];
-        slipDirection[1] = CubicSlipDirections[j][1];
-        slipDirection[2] = CubicSlipDirections[j][2];
-        slipPlane[0] = CubicSlipPlanes[j][0];
-        slipPlane[1] = CubicSlipPlanes[j][1];
-        slipPlane[2] = CubicSlipPlanes[j][2];
+        slipDirection[0] = CubicHigh::SlipDirections[j][0];
+        slipDirection[1] = CubicHigh::SlipDirections[j][1];
+        slipDirection[2] = CubicHigh::SlipDirections[j][2];
+        slipPlane[0] = CubicHigh::SlipPlanes[j][0];
+        slipPlane[1] = CubicHigh::SlipPlanes[j][1];
+        slipPlane[2] = CubicHigh::SlipPlanes[j][2];
         MatrixMath::Multiply3x3with3x1(g2, slipDirection, hkl2);
         MatrixMath::Multiply3x3with3x1(g2, slipPlane, uvw2);
         MatrixMath::Normalize3x1(hkl2);
@@ -1117,12 +1125,12 @@ double CubicOps::getF1spt(const QuatType& q1, const QuatType& q2, double LD[3], 
   }
   for(int i = 0; i < 12; i++)
   {
-    slipDirection[0] = CubicSlipDirections[i][0];
-    slipDirection[1] = CubicSlipDirections[i][1];
-    slipDirection[2] = CubicSlipDirections[i][2];
-    slipPlane[0] = CubicSlipPlanes[i][0];
-    slipPlane[1] = CubicSlipPlanes[i][1];
-    slipPlane[2] = CubicSlipPlanes[i][2];
+    slipDirection[0] = CubicHigh::SlipDirections[i][0];
+    slipDirection[1] = CubicHigh::SlipDirections[i][1];
+    slipDirection[2] = CubicHigh::SlipDirections[i][2];
+    slipPlane[0] = CubicHigh::SlipPlanes[i][0];
+    slipPlane[1] = CubicHigh::SlipPlanes[i][1];
+    slipPlane[2] = CubicHigh::SlipPlanes[i][2];
     MatrixMath::Multiply3x3with3x1(g1, slipDirection, hkl1);
     MatrixMath::Multiply3x3with3x1(g1, slipPlane, uvw1);
     MatrixMath::Normalize3x1(hkl1);
@@ -1140,12 +1148,12 @@ double CubicOps::getF1spt(const QuatType& q1, const QuatType& q2, double LD[3], 
       }
       for(int j = 0; j < 12; j++)
       {
-        slipDirection[0] = CubicSlipDirections[j][0];
-        slipDirection[1] = CubicSlipDirections[j][1];
-        slipDirection[2] = CubicSlipDirections[j][2];
-        slipPlane[0] = CubicSlipPlanes[j][0];
-        slipPlane[1] = CubicSlipPlanes[j][1];
-        slipPlane[2] = CubicSlipPlanes[j][2];
+        slipDirection[0] = CubicHigh::SlipDirections[j][0];
+        slipDirection[1] = CubicHigh::SlipDirections[j][1];
+        slipDirection[2] = CubicHigh::SlipDirections[j][2];
+        slipPlane[0] = CubicHigh::SlipPlanes[j][0];
+        slipPlane[1] = CubicHigh::SlipPlanes[j][1];
+        slipPlane[2] = CubicHigh::SlipPlanes[j][2];
         MatrixMath::Multiply3x3with3x1(g2, slipDirection, hkl2);
         MatrixMath::Multiply3x3with3x1(g2, slipPlane, uvw2);
         MatrixMath::Normalize3x1(hkl2);
@@ -1200,12 +1208,12 @@ double CubicOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3], boo
 
   for(int i = 0; i < 12; i++)
   {
-    slipDirection[0] = CubicSlipDirections[i][0];
-    slipDirection[1] = CubicSlipDirections[i][1];
-    slipDirection[2] = CubicSlipDirections[i][2];
-    slipPlane[0] = CubicSlipPlanes[i][0];
-    slipPlane[1] = CubicSlipPlanes[i][1];
-    slipPlane[2] = CubicSlipPlanes[i][2];
+    slipDirection[0] = CubicHigh::SlipDirections[i][0];
+    slipDirection[1] = CubicHigh::SlipDirections[i][1];
+    slipDirection[2] = CubicHigh::SlipDirections[i][2];
+    slipPlane[0] = CubicHigh::SlipPlanes[i][0];
+    slipPlane[1] = CubicHigh::SlipPlanes[i][1];
+    slipPlane[2] = CubicHigh::SlipPlanes[i][2];
     MatrixMath::Multiply3x3with3x1(g1, slipDirection, hkl1);
     MatrixMath::Multiply3x3with3x1(g1, slipPlane, uvw1);
     MatrixMath::Normalize3x1(hkl1);
@@ -1222,12 +1230,12 @@ double CubicOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3], boo
       }
       for(int j = 0; j < 12; j++)
       {
-        slipDirection[0] = CubicSlipDirections[j][0];
-        slipDirection[1] = CubicSlipDirections[j][1];
-        slipDirection[2] = CubicSlipDirections[j][2];
-        slipPlane[0] = CubicSlipPlanes[j][0];
-        slipPlane[1] = CubicSlipPlanes[j][1];
-        slipPlane[2] = CubicSlipPlanes[j][2];
+        slipDirection[0] = CubicHigh::SlipDirections[j][0];
+        slipDirection[1] = CubicHigh::SlipDirections[j][1];
+        slipDirection[2] = CubicHigh::SlipDirections[j][2];
+        slipPlane[0] = CubicHigh::SlipPlanes[j][0];
+        slipPlane[1] = CubicHigh::SlipPlanes[j][1];
+        slipPlane[2] = CubicHigh::SlipPlanes[j][2];
         MatrixMath::Multiply3x3with3x1(g2, slipDirection, hkl2);
         MatrixMath::Multiply3x3with3x1(g2, slipPlane, uvw2);
         MatrixMath::Normalize3x1(hkl2);
@@ -1258,128 +1266,126 @@ double CubicOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3], boo
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
+namespace CubicHigh
 {
-  namespace CubicHigh
+class GenerateSphereCoordsImpl
+{
+  FloatArrayType* m_Eulers;
+  FloatArrayType* m_xyz001;
+  FloatArrayType* m_xyz011;
+  FloatArrayType* m_xyz111;
+
+public:
+  GenerateSphereCoordsImpl(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111)
+  : m_Eulers(eulers)
+  , m_xyz001(xyz001)
+  , m_xyz011(xyz011)
+  , m_xyz111(xyz111)
   {
-    class GenerateSphereCoordsImpl
+  }
+  virtual ~GenerateSphereCoordsImpl() = default;
+
+  void generate(size_t start, size_t end) const
+  {
+    double g[3][3];
+    double gTranpose[3][3];
+    double direction[3] = {0.0, 0.0, 0.0};
+
+    for(size_t i = start; i < end; ++i)
     {
-        FloatArrayType* m_Eulers;
-        FloatArrayType* m_xyz001;
-        FloatArrayType* m_xyz011;
-        FloatArrayType* m_xyz111;
+      OrientationType eu(m_Eulers->getValue(i * 3), m_Eulers->getValue(i * 3 + 1), m_Eulers->getValue(i * 3 + 2));
+      OrientationTransformation::eu2om<OrientationType, OrientationType>(eu).toGMatrix(g);
 
-      public:
-        GenerateSphereCoordsImpl(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) :
-          m_Eulers(eulers),
-          m_xyz001(xyz001),
-          m_xyz011(xyz011),
-          m_xyz111(xyz111)
-        {}
-        virtual ~GenerateSphereCoordsImpl() = default;
+      MatrixMath::Transpose3x3(g, gTranpose);
 
-        void generate(size_t start, size_t end) const
-        {
-          double g[3][3];
-          double gTranpose[3][3];
-          double direction[3] = {0.0, 0.0, 0.0};
+      // -----------------------------------------------------------------------------
+      // 001 Family
+      direction[0] = 1.0;
+      direction[1] = 0.0;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18));
+      MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18), m_xyz001->getPointer(i * 18 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 3), -1.0f);
+      direction[0] = 0.0;
+      direction[1] = 1.0;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18 + 6));
+      MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18 + 6), m_xyz001->getPointer(i * 18 + 9));
+      MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 9), -1.0f);
+      direction[0] = 0.0;
+      direction[1] = 0.0;
+      direction[2] = 1.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18 + 12));
+      MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18 + 12), m_xyz001->getPointer(i * 18 + 15));
+      MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 15), -1.0f);
 
-          for(size_t i = start; i < end; ++i)
-          {
-            OrientationType eu(m_Eulers->getValue(i * 3), m_Eulers->getValue(i * 3 + 1), m_Eulers->getValue(i * 3 + 2));
-            OrientationTransformation::eu2om<OrientationType, OrientationType>(eu).toGMatrix(g);
+      // -----------------------------------------------------------------------------
+      // 011 Family
+      direction[0] = SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36), m_xyz011->getPointer(i * 36 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 3), -1.0f);
+      direction[0] = SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = 0.0;
+      direction[2] = SIMPLib::Constants::k_1OverRoot2;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 6));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 6), m_xyz011->getPointer(i * 36 + 9));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 9), -1.0f);
+      direction[0] = 0.0;
+      direction[1] = SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = SIMPLib::Constants::k_1OverRoot2;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 12));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 12), m_xyz011->getPointer(i * 36 + 15));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 15), -1.0f);
+      direction[0] = -SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 18));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 18), m_xyz011->getPointer(i * 36 + 21));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 21), -1.0f);
+      direction[0] = -SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = 0.0;
+      direction[2] = SIMPLib::Constants::k_1OverRoot2;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 24));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 24), m_xyz011->getPointer(i * 36 + 27));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 27), -1.0f);
+      direction[0] = 0.0;
+      direction[1] = -SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = SIMPLib::Constants::k_1OverRoot2;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 30));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 30), m_xyz011->getPointer(i * 36 + 33));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 33), -1.0f);
 
-            MatrixMath::Transpose3x3(g, gTranpose);
-
-            // -----------------------------------------------------------------------------
-            // 001 Family
-            direction[0] = 1.0;
-            direction[1] = 0.0;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18));
-            MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18), m_xyz001->getPointer(i * 18 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 3), -1.0f);
-            direction[0] = 0.0;
-            direction[1] = 1.0;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18 + 6));
-            MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18 + 6), m_xyz001->getPointer(i * 18 + 9));
-            MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 9), -1.0f);
-            direction[0] = 0.0;
-            direction[1] = 0.0;
-            direction[2] = 1.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 18 + 12));
-            MatrixMath::Copy3x1(m_xyz001->getPointer(i * 18 + 12), m_xyz001->getPointer(i * 18 + 15));
-            MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 18 + 15), -1.0f);
-
-            // -----------------------------------------------------------------------------
-            // 011 Family
-            direction[0] = SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36), m_xyz011->getPointer(i * 36 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 3), -1.0f);
-            direction[0] = SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = 0.0;
-            direction[2] = SIMPLib::Constants::k_1OverRoot2;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 6));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 6), m_xyz011->getPointer(i * 36 + 9));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 9), -1.0f);
-            direction[0] = 0.0;
-            direction[1] = SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = SIMPLib::Constants::k_1OverRoot2;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 12));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 12), m_xyz011->getPointer(i * 36 + 15));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 15), -1.0f);
-            direction[0] = -SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 18));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 18), m_xyz011->getPointer(i * 36 + 21));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 21), -1.0f);
-            direction[0] = -SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = 0.0;
-            direction[2] = SIMPLib::Constants::k_1OverRoot2;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 24));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 24), m_xyz011->getPointer(i * 36 + 27));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 27), -1.0f);
-            direction[0] = 0.0;
-            direction[1] = -SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = SIMPLib::Constants::k_1OverRoot2;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 36 + 30));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 36 + 30), m_xyz011->getPointer(i * 36 + 33));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 36 + 33), -1.0f);
-
-            // -----------------------------------------------------------------------------
-            // 111 Family
-            direction[0] = SIMPLib::Constants::k_1OverRoot3;
-            direction[1] = SIMPLib::Constants::k_1OverRoot3;
-            direction[2] = SIMPLib::Constants::k_1OverRoot3;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24), m_xyz111->getPointer(i * 24 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 3), -1.0f);
-            direction[0] = -SIMPLib::Constants::k_1OverRoot3;
-            direction[1] = SIMPLib::Constants::k_1OverRoot3;
-            direction[2] = SIMPLib::Constants::k_1OverRoot3;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 6));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 6), m_xyz111->getPointer(i * 24 + 9));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 9), -1.0f);
-            direction[0] = SIMPLib::Constants::k_1OverRoot3;
-            direction[1] = -SIMPLib::Constants::k_1OverRoot3;
-            direction[2] = SIMPLib::Constants::k_1OverRoot3;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 12));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 12), m_xyz111->getPointer(i * 24 + 15));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 15), -1.0f);
-            direction[0] = SIMPLib::Constants::k_1OverRoot3;
-            direction[1] = SIMPLib::Constants::k_1OverRoot3;
-            direction[2] = -SIMPLib::Constants::k_1OverRoot3;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 18));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 18), m_xyz111->getPointer(i * 24 + 21));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 21), -1.0f);
-          }
-
-        }
+      // -----------------------------------------------------------------------------
+      // 111 Family
+      direction[0] = SIMPLib::Constants::k_1OverRoot3;
+      direction[1] = SIMPLib::Constants::k_1OverRoot3;
+      direction[2] = SIMPLib::Constants::k_1OverRoot3;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24), m_xyz111->getPointer(i * 24 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 3), -1.0f);
+      direction[0] = -SIMPLib::Constants::k_1OverRoot3;
+      direction[1] = SIMPLib::Constants::k_1OverRoot3;
+      direction[2] = SIMPLib::Constants::k_1OverRoot3;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 6));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 6), m_xyz111->getPointer(i * 24 + 9));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 9), -1.0f);
+      direction[0] = SIMPLib::Constants::k_1OverRoot3;
+      direction[1] = -SIMPLib::Constants::k_1OverRoot3;
+      direction[2] = SIMPLib::Constants::k_1OverRoot3;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 12));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 12), m_xyz111->getPointer(i * 24 + 15));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 15), -1.0f);
+      direction[0] = SIMPLib::Constants::k_1OverRoot3;
+      direction[1] = SIMPLib::Constants::k_1OverRoot3;
+      direction[2] = -SIMPLib::Constants::k_1OverRoot3;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 24 + 18));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 24 + 18), m_xyz111->getPointer(i * 24 + 21));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 24 + 21), -1.0f);
+    }
+  }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
         void operator()(const tbb::blocked_range<size_t>& r) const
@@ -1387,9 +1393,8 @@ namespace Detail
           generate(r.begin(), r.end());
         }
 #endif
-    };
-  }
-}
+};
+} // namespace CubicHigh
 
 // -----------------------------------------------------------------------------
 //
@@ -1399,17 +1404,17 @@ void CubicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArray
   size_t nOrientations = eulers->getNumberOfTuples();
 
   // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::CubicHigh::symSize0)
+  if(xyz001->getNumberOfTuples() < nOrientations * CubicHigh::symSize0)
   {
-    xyz001->resizeTuples(nOrientations * Detail::CubicHigh::symSize0 * 3);
+    xyz001->resizeTuples(nOrientations * CubicHigh::symSize0 * 3);
   }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::CubicHigh::symSize1)
+  if(xyz011->getNumberOfTuples() < nOrientations * CubicHigh::symSize1)
   {
-    xyz011->resizeTuples(nOrientations * Detail::CubicHigh::symSize1 * 3);
+    xyz011->resizeTuples(nOrientations * CubicHigh::symSize1 * 3);
   }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::CubicHigh::symSize2)
+  if(xyz111->getNumberOfTuples() < nOrientations * CubicHigh::symSize2)
   {
-    xyz111->resizeTuples(nOrientations * Detail::CubicHigh::symSize2 * 3);
+    xyz111->resizeTuples(nOrientations * CubicHigh::symSize2 * 3);
   }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -1420,13 +1425,12 @@ void CubicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArray
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::CubicHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), CubicHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::CubicHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    CubicHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
 
@@ -1618,7 +1622,7 @@ SIMPL::Rgb CubicOps::generateIPFColor(double phi1, double phi, double phi2, doub
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < CubicHigh::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -1692,9 +1696,9 @@ SIMPL::Rgb CubicOps::generateIPFColor(double phi1, double phi, double phi2, doub
 // -----------------------------------------------------------------------------
 SIMPL::Rgb CubicOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * CubicDim1InitValue;
-  double range2 = 2.0f * CubicDim2InitValue;
-  double range3 = 2.0f * CubicDim3InitValue;
+  double range1 = 2.0f * CubicHigh::OdfDimInitValue[0];
+  double range2 = 2.0f * CubicHigh::OdfDimInitValue[1];
+  double range3 = 2.0f * CubicHigh::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -1725,11 +1729,11 @@ QVector<UInt8ArrayType::Pointer> CubicOps::generatePoleFigure(PoleFigureConfigur
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::CubicHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * CubicHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::CubicHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * CubicHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::CubicHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * CubicHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/CubicOps.cpp
+++ b/Source/OrientationLib/LaueOps/CubicOps.cpp
@@ -258,7 +258,7 @@ OrientationF CubicOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationD CubicOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
+OrientationD CubicOps::calculateMisorientationInternal(const QuatType* quatsym, size_t numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
   QuatType qco;
@@ -477,7 +477,6 @@ OrientationD CubicOps::calculateMisorientationInternal(const QuatType quatsym[24
   double n1 = 0.0;
   double n2 = 0.0;
   double n3 = 0.0;
-  double w = 0.0;
   if(type == 1)
   {
     n1 = qco.x() / sin_wmin_over_2;
@@ -510,7 +509,7 @@ OrientationD CubicOps::calculateMisorientationInternal(const QuatType quatsym[24
   }
   wmin = 2.0f * wmin;
 
-  OrientationD axisAngle(n1, n2, n3, w);
+  OrientationD axisAngle(n1, n2, n3, wmin);
   return axisAngle;
 }
 

--- a/Source/OrientationLib/LaueOps/CubicOps.h
+++ b/Source/OrientationLib/LaueOps/CubicOps.h
@@ -231,7 +231,7 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
      * @param q2
      * @return
      */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
+    OrientationD calculateMisorientationInternal(const QuatType* quatsym, size_t numsym, const QuatType& q1, const QuatType& q2) const override;
 
     /**
      * @brief area preserving projection of volume preserving transformation (for C. Shuch and S. Patala coloring legend generation)
@@ -248,7 +248,6 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
     CubicOps& operator=(const CubicOps&) = delete; // Copy Assignment Not Implemented
     CubicOps& operator=(CubicOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 };
 
 

--- a/Source/OrientationLib/LaueOps/CubicOps.h
+++ b/Source/OrientationLib/LaueOps/CubicOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
     CubicOps();
     ~CubicOps() override;
 
-    static const int k_OdfSize = 5832;
-    static const int k_MdfSize = 5832;
-    static const int k_NumSymQuats = 24;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +106,12 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -128,9 +130,9 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
     QuatType getFZQuat(const QuatType& qr) const override;
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/CubicOps.h
+++ b/Source/OrientationLib/LaueOps/CubicOps.h
@@ -112,8 +112,21 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -210,7 +223,15 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
     UInt8ArrayType::Pointer generateMisorientationTriangleLegend(double, int, int, int) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[12], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
     /**
      * @brief area preserving projection of volume preserving transformation (for C. Shuch and S. Patala coloring legend generation)

--- a/Source/OrientationLib/LaueOps/CubicOps.h
+++ b/Source/OrientationLib/LaueOps/CubicOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT CubicOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
@@ -156,61 +156,6 @@ QString HexagonalLowOps::getSymmetryName() const
   return "Hexagonal 6/m";;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD HexagonalLowOps::calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for(int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0.0 || wmin == 0.0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD HexagonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(HexagonalLow::QuatSym, HexagonalLow::k_NumSymQuats, q1, q2);

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
@@ -33,9 +33,10 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "HexagonalLowOps.h"
+
 #include <memory>
 
-#include "HexagonalLowOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -1266,7 +1267,7 @@ SIMPL::Rgb HexagonalLowOps::generateRodriguesColor(double r1, double r2, double 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> HexagonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> HexagonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<0001>");
   QString label1 = QString("<11-20>");
@@ -1379,7 +1380,7 @@ QVector<UInt8ArrayType::Pointer> HexagonalLowOps::generatePoleFigure(PoleFigureC
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.cpp
@@ -159,85 +159,71 @@ QString HexagonalLowOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double HexagonalLowOps::_calcMisoQuat(const QuatType QuatSym[12], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD HexagonalLowOps::calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const
 {
-  double wmin = 9999999.0; //,na,nb,nc;
-  double w = 0.0;
-  double n1min = 0.0;
-  double n2min = 0.0;
-  double n3min = 0.0;
-  QuatType qc;
+  double wmin = 9999999.0f; //,na,nb,nc;
+  double n1min = 0.0f;
+  double n2min = 0.0f;
+  double n3min = 0.0f;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
-  for (int i = 0; i < numsym; i++)
+  for(int i = 0; i < numsym; i++)
   {
-    qc = HexagonalLow::QuatSym[i] * qr;
+    qc = quatsym[i] * qr;
 
     if(qc.w() < -1)
     {
-      qc.w() = -1.0;
+      qc.w() = -1;
     }
     else if(qc.w() > 1)
     {
-      qc.w() = 1.0;
+      qc.w() = 1;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0.0 || wmin == 0.0)
   {
-    n1 = 0.0;
-    n2 = 0.0;
-    n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0;
-    n2 = 0.0;
-    n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double HexagonalLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD HexagonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(HexagonalLow::QuatSym, HexagonalLow::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(HexagonalLow::QuatSym, HexagonalLow::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float HexagonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF HexagonalLowOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(HexagonalLow::QuatSym, HexagonalLow::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(HexagonalLow::QuatSym, HexagonalLow::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType HexagonalLowOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.h
@@ -112,8 +112,21 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -200,7 +213,15 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[12], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     HexagonalLowOps(const HexagonalLowOps&) = delete; // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.h
@@ -213,15 +213,6 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     HexagonalLowOps(const HexagonalLowOps&) = delete; // Copy Constructor Not Implemented
@@ -229,7 +220,6 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
     HexagonalLowOps& operator=(const HexagonalLowOps&) = delete; // Copy Assignment Not Implemented
     HexagonalLowOps& operator=(HexagonalLowOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/HexagonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalLowOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
     HexagonalLowOps();
     ~HexagonalLowOps() override;
 
-    static const int k_OdfSize;// = 62208;
-    static const int k_MdfSize;// = 62208;
-    static const int k_NumSymQuats;// = 6;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +106,12 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -128,9 +130,9 @@ class OrientationLib_EXPORT HexagonalLowOps : public LaueOps
     QuatType getFZQuat(const QuatType& qr) const override;
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/HexagonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.cpp
@@ -177,61 +177,6 @@ QString HexagonalOps::getSymmetryName() const
 }
 
 // -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD HexagonalOps::calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for(int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
-// -----------------------------------------------------------------------------
 OrientationD HexagonalOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
@@ -239,7 +184,6 @@ OrientationD HexagonalOps::calculateMisorientation(const QuatType& q1, const Qua
 
 // -----------------------------------------------------------------------------
 OrientationF HexagonalOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
-
 {
   QuatType q1 = q1f;
   QuatType q2 = q2f;

--- a/Source/OrientationLib/LaueOps/HexagonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.cpp
@@ -1,39 +1,40 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <memory>
+#include <array>
 
 #include "HexagonalOps.h"
 
@@ -56,68 +57,68 @@
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 #include "OrientationLib/Utilities/PoleFigureUtilities.h"
 
-namespace Detail
-{
-
-static const double HexDim1InitValue = std::pow((0.75f * (((SIMPLib::Constants::k_PiOver2)) - sinf(((SIMPLib::Constants::k_PiOver2))))), (1.0f / 3.0));
-static const double HexDim2InitValue = std::pow((0.75f * (((SIMPLib::Constants::k_PiOver2)) - sinf(((SIMPLib::Constants::k_PiOver2))))), (1.0f / 3.0));
-static const double HexDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi / 6.0) - sinf(SIMPLib::Constants::k_Pi / 6.0))), (1.0f / 3.0));
-static const double HexDim1StepValue = HexDim1InitValue / 18.0f;
-static const double HexDim2StepValue = HexDim2InitValue / 18.0f;
-static const double HexDim3StepValue = HexDim3InitValue / 6.0f;
-
 namespace HexagonalHigh
 {
+static const std::array<size_t, 3> OdfNumBins = {36, 36, 12}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * (((SIMPLib::Constants::k_PiOver2)) - sinf(((SIMPLib::Constants::k_PiOver2))))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (((SIMPLib::Constants::k_PiOver2)) - sinf(((SIMPLib::Constants::k_PiOver2))))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_Pi / 6.0) - sinf(SIMPLib::Constants::k_Pi / 6.0))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 2;
 static const int symSize1 = 6;
 static const int symSize2 = 6;
-} // namespace HexagonalHigh
-}
 
-static const QuatType HexQuatSym[12] = {
+static const int k_OdfSize = 15552;
+static const int k_MdfSize = 15552;
+static const int k_NumSymQuats = 12;
+
+static const QuatType QuatSym[12] = {
     QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 0.500000000, 0.866025400), QuatType(0.000000000, 0.000000000, 0.866025400, 0.500000000),
     QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000), QuatType(0.000000000, 0.000000000, 0.866025400, -0.50000000), QuatType(0.000000000, 0.000000000, 0.500000000, -0.86602540),
     QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000), QuatType(0.866025400, 0.500000000, 0.000000000, 0.000000000), QuatType(0.500000000, 0.866025400, 0.000000000, 0.000000000),
     QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000), QuatType(-0.50000000, 0.866025400, 0.000000000, 0.000000000), QuatType(-0.86602540, 0.500000000, 0.000000000, 0.000000000)};
 
-static const double HexRodSym[12][3] = {{0.0, 0.0, 0.0},
-                                        {0.0, 0.0, 0.57735},
-                                        {0.0, 0.0, 1.73205},
-                                        {0.0, 0.0, 1000000000000.0},
-                                        {0.0, 0.0, -1.73205},
-                                        {0.0, 0.0, -0.57735},
-                                        {1000000000000.0, 0.0, 0.0},
-                                        {8660254000000.0, 5000000000000.0, 0.0},
-                                        {5000000000000.0, 8660254000000.0, 0.0},
-                                        {0.0, 1000000000000.0, 0.0},
-                                        {-5000000000000.0, 8660254000000.0, 0.0},
-                                        {-8660254000000.0, 5000000000000.0, 0.0}};
-static const double HexMatSym[12][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+static const double RodSym[12][3] = {{0.0, 0.0, 0.0},
+                                     {0.0, 0.0, 0.57735},
+                                     {0.0, 0.0, 1.73205},
+                                     {0.0, 0.0, 1000000000000.0},
+                                     {0.0, 0.0, -1.73205},
+                                     {0.0, 0.0, -0.57735},
+                                     {1000000000000.0, 0.0, 0.0},
+                                     {8660254000000.0, 5000000000000.0, 0.0},
+                                     {5000000000000.0, 8660254000000.0, 0.0},
+                                     {0.0, 1000000000000.0, 0.0},
+                                     {-5000000000000.0, 8660254000000.0, 0.0},
+                                     {-8660254000000.0, 5000000000000.0, 0.0}};
+static const double MatSym[12][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                        {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                        {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                        {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+                                        {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                        {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
+                                        {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                        {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
+                                        {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
+                                        {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                        {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
+                                        {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
 
 // Use a namespace for some detail that only this class needs
-using namespace Detail;
+} // namespace HexagonalHigh
 
 // -----------------------------------------------------------------------------
 //
@@ -142,7 +143,7 @@ bool HexagonalOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int HexagonalOps::getODFSize() const
 {
-  return k_OdfSize;
+  return HexagonalHigh::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -150,7 +151,7 @@ int HexagonalOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int HexagonalOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return HexagonalHigh::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -158,7 +159,13 @@ int HexagonalOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int HexagonalOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return HexagonalHigh::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> HexagonalOps::getOdfNumBins() const
+{
+  return HexagonalHigh::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -233,7 +240,7 @@ double HexagonalOps::_calcMisoQuat(const QuatType quatsym[12], int numsym, QuatT
 double HexagonalOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
 
-  return _calcMisoQuat(HexQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -244,7 +251,7 @@ float HexagonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, 
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(HexQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -253,44 +260,44 @@ float HexagonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, 
 
 QuatType HexagonalOps::getQuatSymOp(int32_t i) const
 {
-  return HexQuatSym[i];
-  //  q.x = HexQuatSym[i][0];
-  //  q.y = HexQuatSym[i][1];
-  //  q.z = HexQuatSym[i][2];
-  //  q.w = HexQuatSym[i][3];
+  return HexagonalHigh::QuatSym[i];
+  //  q.x = HexagonalHigh::QuatSym[i][0];
+  //  q.y = HexagonalHigh::QuatSym[i][1];
+  //  q.z = HexagonalHigh::QuatSym[i][2];
+  //  q.w = HexagonalHigh::QuatSym[i][3];
 }
 
 void HexagonalOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = HexRodSym[i][0];
-  r[1] = HexRodSym[i][1];
-  r[2] = HexRodSym[i][2];
+  r[0] = HexagonalHigh::RodSym[i][0];
+  r[1] = HexagonalHigh::RodSym[i][1];
+  r[2] = HexagonalHigh::RodSym[i][2];
 }
 
 void HexagonalOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = HexMatSym[i][0][0];
-  g[0][1] = HexMatSym[i][0][1];
-  g[0][2] = HexMatSym[i][0][2];
-  g[1][0] = HexMatSym[i][1][0];
-  g[1][1] = HexMatSym[i][1][1];
-  g[1][2] = HexMatSym[i][1][2];
-  g[2][0] = HexMatSym[i][2][0];
-  g[2][1] = HexMatSym[i][2][1];
-  g[2][2] = HexMatSym[i][2][2];
+  g[0][0] = HexagonalHigh::MatSym[i][0][0];
+  g[0][1] = HexagonalHigh::MatSym[i][0][1];
+  g[0][2] = HexagonalHigh::MatSym[i][0][2];
+  g[1][0] = HexagonalHigh::MatSym[i][1][0];
+  g[1][1] = HexagonalHigh::MatSym[i][1][1];
+  g[1][2] = HexagonalHigh::MatSym[i][1][2];
+  g[2][0] = HexagonalHigh::MatSym[i][2][0];
+  g[2][1] = HexagonalHigh::MatSym[i][2][1];
+  g[2][2] = HexagonalHigh::MatSym[i][2][2];
 }
 
 void HexagonalOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = HexMatSym[i][0][0];
-  g[0][1] = HexMatSym[i][0][1];
-  g[0][2] = HexMatSym[i][0][2];
-  g[1][0] = HexMatSym[i][1][0];
-  g[1][1] = HexMatSym[i][1][1];
-  g[1][2] = HexMatSym[i][1][2];
-  g[2][0] = HexMatSym[i][2][0];
-  g[2][1] = HexMatSym[i][2][1];
-  g[2][2] = HexMatSym[i][2][2];
+  g[0][0] = HexagonalHigh::MatSym[i][0][0];
+  g[0][1] = HexagonalHigh::MatSym[i][0][1];
+  g[0][2] = HexagonalHigh::MatSym[i][0][2];
+  g[1][0] = HexagonalHigh::MatSym[i][1][0];
+  g[1][1] = HexagonalHigh::MatSym[i][1][1];
+  g[1][2] = HexagonalHigh::MatSym[i][1][2];
+  g[2][0] = HexagonalHigh::MatSym[i][2][0];
+  g[2][1] = HexagonalHigh::MatSym[i][2][1];
+  g[2][2] = HexagonalHigh::MatSym[i][2][2];
 }
 // -----------------------------------------------------------------------------
 //
@@ -298,7 +305,7 @@ void HexagonalOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType HexagonalOps::getODFFZRod(const OrientationType& rod) const
 {
   int numsym = 12;
-  return _calcRodNearestOrigin(HexRodSym, numsym, rod);
+  return _calcRodNearestOrigin(HexagonalHigh::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -310,7 +317,7 @@ OrientationType HexagonalOps::getMDFFZRod(const OrientationType& inRod) const
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
   double n1n2mag;
 
-  OrientationType rod = _calcRodNearestOrigin(HexRodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(HexagonalHigh::RodSym, 12, inRod);
 
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
@@ -359,14 +366,14 @@ OrientationType HexagonalOps::getMDFFZRod(const OrientationType& inRod) const
 
 QuatType HexagonalOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(HexQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
 }
 
 QuatF HexagonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(HexQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -376,7 +383,7 @@ QuatF HexagonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 // -----------------------------------------------------------------------------
 QuatType HexagonalOps::getFZQuat(const QuatType& qr) const
 {
-  return _calcQuatNearestOrigin(HexQuatSym, k_NumSymQuats, qr);
+  return _calcQuatNearestOrigin(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, qr);
 }
 
 // -----------------------------------------------------------------------------
@@ -390,15 +397,15 @@ int HexagonalOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = HexDim1InitValue;
-  dim[1] = HexDim2InitValue;
-  dim[2] = HexDim3InitValue;
-  step[0] = HexDim1StepValue;
-  step[1] = HexDim2StepValue;
-  step[2] = HexDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 12.0f;
+  dim[0] = HexagonalHigh::OdfDimInitValue[0];
+  dim[1] = HexagonalHigh::OdfDimInitValue[1];
+  dim[2] = HexagonalHigh::OdfDimInitValue[2];
+  step[0] = HexagonalHigh::OdfDimStepValue[0];
+  step[1] = HexagonalHigh::OdfDimStepValue[1];
+  step[2] = HexagonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(HexagonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(HexagonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(HexagonalHigh::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -406,24 +413,24 @@ int HexagonalOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType HexagonalOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType HexagonalOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = HexDim1InitValue;
-  init[1] = HexDim2InitValue;
-  init[2] = HexDim3InitValue;
-  step[0] = HexDim1StepValue;
-  step[1] = HexDim2StepValue;
-  step[2] = HexDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = HexagonalHigh::OdfDimInitValue[0];
+  init[1] = HexagonalHigh::OdfDimInitValue[1];
+  init[2] = HexagonalHigh::OdfDimInitValue[2];
+  step[0] = HexagonalHigh::OdfDimStepValue[0];
+  step[1] = HexagonalHigh::OdfDimStepValue[1];
+  step[2] = HexagonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % HexagonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / HexagonalHigh::OdfNumBins[0]) % HexagonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (HexagonalHigh::OdfNumBins[0] * HexagonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -437,33 +444,33 @@ OrientationType HexagonalOps::determineEulerAngles(uint64_t seed, int choose) co
 // -----------------------------------------------------------------------------
 OrientationType HexagonalOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(HexagonalHigh::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = HexQuatSym[symOp] * quat;
+  QuatType qc = HexagonalHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType HexagonalOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType HexagonalOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = HexDim1InitValue;
-  init[1] = HexDim2InitValue;
-  init[2] = HexDim3InitValue;
-  step[0] = HexDim1StepValue;
-  step[1] = HexDim2StepValue;
-  step[2] = HexDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = HexagonalHigh::OdfDimInitValue[0];
+  init[1] = HexagonalHigh::OdfDimInitValue[1];
+  init[2] = HexagonalHigh::OdfDimInitValue[2];
+  step[0] = HexagonalHigh::OdfDimStepValue[0];
+  step[1] = HexagonalHigh::OdfDimStepValue[1];
+  step[2] = HexagonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % HexagonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / HexagonalHigh::OdfNumBins[0]) % HexagonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (HexagonalHigh::OdfNumBins[0] * HexagonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -481,37 +488,17 @@ int HexagonalOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = HexDim1InitValue;
-  dim[1] = HexDim2InitValue;
-  dim[2] = HexDim3InitValue;
-  step[0] = HexDim1StepValue;
-  step[1] = HexDim2StepValue;
-  step[2] = HexDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 12.0f;
+  dim[0] = HexagonalHigh::OdfDimInitValue[0];
+  dim[1] = HexagonalHigh::OdfDimInitValue[1];
+  dim[2] = HexagonalHigh::OdfDimInitValue[2];
+  step[0] = HexagonalHigh::OdfDimStepValue[0];
+  step[1] = HexagonalHigh::OdfDimStepValue[1];
+  step[2] = HexagonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(HexagonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(HexagonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(HexagonalHigh::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void HexagonalOps::getInitializedODFBinDimensions(double dims[3])
-{
-  dims[0] = HexDim1InitValue;
-  dims[1] = HexDim2InitValue;
-  dims[2] = HexDim3InitValue;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void HexagonalOps::getOdfBinStepSize(double step[3])
-{
-  step[0] = HexDim1StepValue;
-  step[1] = HexDim2StepValue;
-  step[2] = HexDim3StepValue;
 }
 
 void HexagonalOps::getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const
@@ -841,18 +828,18 @@ void HexagonalOps::getSchmidFactorAndSS(double load[3], double plane[3], double 
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = HexMatSym[i][2][0] * plane[0] + HexMatSym[i][2][1] * plane[1] + HexMatSym[i][2][2] * plane[2];
+    slipPlane[2] = HexagonalHigh::MatSym[i][2][0] * plane[0] + HexagonalHigh::MatSym[i][2][1] * plane[1] + HexagonalHigh::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = HexMatSym[i][0][0] * plane[0] + HexMatSym[i][0][1] * plane[1] + HexMatSym[i][0][2] * plane[2];
-      slipPlane[1] = HexMatSym[i][1][0] * plane[0] + HexMatSym[i][1][1] * plane[1] + HexMatSym[i][1][2] * plane[2];
+      slipPlane[0] = HexagonalHigh::MatSym[i][0][0] * plane[0] + HexagonalHigh::MatSym[i][0][1] * plane[1] + HexagonalHigh::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = HexagonalHigh::MatSym[i][1][0] * plane[0] + HexagonalHigh::MatSym[i][1][1] * plane[1] + HexagonalHigh::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = HexMatSym[i][0][0] * direction[0] + HexMatSym[i][0][1] * direction[1] + HexMatSym[i][0][2] * direction[2];
-      slipDirection[1] = HexMatSym[i][1][0] * direction[0] + HexMatSym[i][1][1] * direction[1] + HexMatSym[i][1][2] * direction[2];
-      slipDirection[2] = HexMatSym[i][2][0] * direction[0] + HexMatSym[i][2][1] * direction[1] + HexMatSym[i][2][2] * direction[2];
+      slipDirection[0] = HexagonalHigh::MatSym[i][0][0] * direction[0] + HexagonalHigh::MatSym[i][0][1] * direction[1] + HexagonalHigh::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = HexagonalHigh::MatSym[i][1][0] * direction[0] + HexagonalHigh::MatSym[i][1][1] * direction[1] + HexagonalHigh::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = HexagonalHigh::MatSym[i][2][0] * direction[0] + HexagonalHigh::MatSym[i][2][1] * direction[1] + HexagonalHigh::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -1241,17 +1228,17 @@ void HexagonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatA
 
 
   // Sanity Check the size of the arrays
-  if (xyz0001->getNumberOfTuples() < nOrientations * Detail::HexagonalHigh::symSize0)
+  if(xyz0001->getNumberOfTuples() < nOrientations * HexagonalHigh::symSize0)
   {
-    xyz0001->resizeTuples(nOrientations * Detail::HexagonalHigh::symSize0 * 3);
+    xyz0001->resizeTuples(nOrientations * HexagonalHigh::symSize0 * 3);
   }
-  if (xyz1010->getNumberOfTuples() < nOrientations * Detail::HexagonalHigh::symSize1)
+  if(xyz1010->getNumberOfTuples() < nOrientations * HexagonalHigh::symSize1)
   {
-    xyz1010->resizeTuples(nOrientations * Detail::HexagonalHigh::symSize1 * 3);
+    xyz1010->resizeTuples(nOrientations * HexagonalHigh::symSize1 * 3);
   }
-  if (xyz1120->getNumberOfTuples() < nOrientations * Detail::HexagonalHigh::symSize2)
+  if(xyz1120->getNumberOfTuples() < nOrientations * HexagonalHigh::symSize2)
   {
-    xyz1120->resizeTuples(nOrientations * Detail::HexagonalHigh::symSize2 * 3);
+    xyz1120->resizeTuples(nOrientations * HexagonalHigh::symSize2 * 3);
   }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -1262,8 +1249,7 @@ void HexagonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatA
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::HexagonalHigh::GenerateSphereCoordsImpl(eulers, xyz0001, xyz1010, xyz1120), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), Detail::HexagonalHigh::GenerateSphereCoordsImpl(eulers, xyz0001, xyz1010, xyz1120), tbb::auto_partitioner());
   }
   else
 #endif
@@ -1312,7 +1298,7 @@ SIMPL::Rgb HexagonalOps::generateIPFColor(double phi1, double phi, double phi2, 
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < HexagonalHigh::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -1378,9 +1364,9 @@ SIMPL::Rgb HexagonalOps::generateIPFColor(double phi1, double phi, double phi2, 
 // -----------------------------------------------------------------------------
 SIMPL::Rgb HexagonalOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * HexDim1InitValue;
-  double range2 = 2.0f * HexDim2InitValue;
-  double range3 = 2.0f * HexDim3InitValue;
+  double range1 = 2.0f * HexagonalHigh::OdfDimInitValue[0];
+  double range2 = 2.0f * HexagonalHigh::OdfDimInitValue[1];
+  double range3 = 2.0f * HexagonalHigh::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -1416,11 +1402,11 @@ QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConf
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::HexagonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * HexagonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::HexagonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * HexagonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::HexagonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * HexagonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/HexagonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.cpp
@@ -1318,7 +1318,7 @@ SIMPL::Rgb HexagonalOps::generateRodriguesColor(double r1, double r2, double r3)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<0001>");
   QString label1 = QString("<10-10>");
@@ -1431,7 +1431,7 @@ QVector<UInt8ArrayType::Pointer> HexagonalOps::generatePoleFigure(PoleFigureConf
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/HexagonalOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.h
@@ -212,15 +212,6 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     HexagonalOps(const HexagonalOps&) = delete;   // Copy Constructor Not Implemented
@@ -228,7 +219,6 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
     HexagonalOps& operator=(const HexagonalOps&) = delete; // Copy Assignment Not Implemented
     HexagonalOps& operator=(HexagonalOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 };
 
 

--- a/Source/OrientationLib/LaueOps/HexagonalOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.h
@@ -111,8 +111,21 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -199,7 +212,15 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[12], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[12], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     HexagonalOps(const HexagonalOps&) = delete;   // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/HexagonalOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.h
@@ -203,7 +203,7 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/HexagonalOps.h
+++ b/Source/OrientationLib/LaueOps/HexagonalOps.h
@@ -75,10 +75,6 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
     HexagonalOps();
     ~HexagonalOps() override;
 
-    static const int k_OdfSize = 15552;
-    static const int k_MdfSize = 15552;
-    static const int k_NumSymQuats = 12;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -109,8 +105,11 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
-    virtual void getInitializedODFBinDimensions(double dims[3]);
-    virtual void getOdfBinStepSize(double step[3]);
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
 
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
@@ -130,9 +129,9 @@ class OrientationLib_EXPORT HexagonalOps : public LaueOps
     QuatType getFZQuat(const QuatType& qr) const override;
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/LaueOps.cpp
+++ b/Source/OrientationLib/LaueOps/LaueOps.cpp
@@ -96,21 +96,19 @@ QuatType LaueOps::getFZQuat(const QuatType& qr) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double LaueOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD LaueOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
 
+  OrientationD axisAngle;
   QuatType qc;
+  QuatType qr = q1 * (q2.conjugate());
 
-  QuatType q2inv = q2.conjugate();
-  QuatType qr = q1 * q2inv;
   for(int i = 0; i < numsym; i++)
   {
-
     qc = quatsym[i] * qr;
 
     if(qc.w() < -1)
@@ -122,33 +120,32 @@ double LaueOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, const Quat
       qc.w() = 1;
     }
 
-    OrientationTransformation::qu2ax<QuatType, OrientationType>(qc).toAxisAngle(n1, n2, n3, w);
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if(w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if(w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/OrientationLib/LaueOps/LaueOps.cpp
+++ b/Source/OrientationLib/LaueOps/LaueOps.cpp
@@ -285,17 +285,11 @@ int LaueOps::_calcMisoBin(double dim[3], double bins[3], double step[3], const O
   return (static_cast<int>((bins[0] * bins[1] * miso3bin) + (bins[0] * miso2bin) + miso1bin));
 }
 
-void LaueOps::_calcDetermineHomochoricValues(uint64_t seed, double init[3], double step[3], int32_t phi[3], int choose, double& r1, double& r2, double& r3) const
+void LaueOps::_calcDetermineHomochoricValues(double random[3], double init[3], double step[3], int32_t phi[3], double& r1, double& r2, double& r3) const
 {
-  double random;
-
-  SIMPL_RANDOMNG_NEW_SEEDED(seed)
-  random = static_cast<double>(rg.genrand_res53());
-  r1 = (step[0] * phi[0]) + (step[0] * random) - (init[0]);
-  random = static_cast<double>(rg.genrand_res53());
-  r2 = (step[1] * phi[1]) + (step[1] * random) - (init[1]);
-  random = static_cast<double>(rg.genrand_res53());
-  r3 = (step[2] * phi[2]) + (step[2] * random) - (init[2]);
+  r1 = (step[0] * phi[0]) + (step[0] * random[0]) - (init[0]);
+  r2 = (step[1] * phi[1]) + (step[1] * random[1]) - (init[1]);
+  r3 = (step[2] * phi[2]) + (step[2] * random[2]) - (init[2]);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/OrientationLib/LaueOps/LaueOps.cpp
+++ b/Source/OrientationLib/LaueOps/LaueOps.cpp
@@ -96,56 +96,47 @@ QuatType LaueOps::getFZQuat(const QuatType& qr) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationD LaueOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
+OrientationD LaueOps::calculateMisorientationInternal(const QuatType* quatsym, size_t numsym, const QuatType& q1, const QuatType& q2) const
 {
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
+  OrientationD axisAngleMin(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
   QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
-  for(int i = 0; i < numsym; i++)
+  for(size_t i = 0; i < numsym; i++)
   {
     qc = quatsym[i] * qr;
 
     if(qc.w() < -1)
     {
-      qc.w() = -1;
+      qc.w() = -1.0;
     }
     else if(qc.w() > 1)
     {
-      qc.w() = 1;
+      qc.w() = 1.0;
     }
 
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
+    OrientationD axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
     if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
       axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if(axisAngle[3] < wmin)
+    if(axisAngle[3] < axisAngleMin[3])
     {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
+      axisAngleMin = axisAngle;
     }
   }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
+  double denom = sqrt((axisAngleMin[0] * axisAngleMin[0] + axisAngleMin[1] * axisAngleMin[1] + axisAngleMin[2] * axisAngleMin[2]));
+  axisAngleMin[0] = axisAngleMin[0] / denom;
+  axisAngleMin[1] = axisAngleMin[1] / denom;
+  axisAngleMin[2] = axisAngleMin[2] / denom;
+  if(denom == 0.0 || axisAngleMin[3] == 0.0)
   {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
+    axisAngleMin[0] = 0.0;
+    axisAngleMin[1] = 0.0;
+    axisAngleMin[2] = 1.0;
   }
 
-  return axisAngle;
+  return axisAngleMin;
 }
 
 // -----------------------------------------------------------------------------
@@ -332,35 +323,7 @@ int LaueOps::_calcODFBin(double dim[3], double bins[3], double step[3], const Or
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<LaueOps::Pointer> LaueOps::getOrientationOpsQVector()
-{
-  QVector<LaueOps::Pointer> m_OrientationOps;
-  m_OrientationOps.push_back(HexagonalOps::New());
-
-  m_OrientationOps.push_back(CubicOps::New());
-
-  m_OrientationOps.push_back(HexagonalLowOps::New()); // Hex Low
-  m_OrientationOps.push_back(CubicLowOps::New());     // Cubic Low
-  m_OrientationOps.push_back(TriclinicOps::New());    // Triclinic
-  m_OrientationOps.push_back(MonoclinicOps::New());   // Monoclinic
-
-  m_OrientationOps.push_back(OrthoRhombicOps::New()); // OrthoRhombic
-
-  m_OrientationOps.push_back(TetragonalLowOps::New()); // Tetragonal-low
-  m_OrientationOps.push_back(TetragonalOps::New());    // Tetragonal-high
-
-  m_OrientationOps.push_back(TrigonalLowOps::New()); // Trigonal-low
-  m_OrientationOps.push_back(TrigonalOps::New());    // Trigonal-High
-
-  m_OrientationOps.push_back(OrthoRhombicOps::New()); // Axis OrthorhombicOps
-
-  return m_OrientationOps;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-std::vector<LaueOps::Pointer> LaueOps::getOrientationOpsVector()
+std::vector<LaueOps::Pointer> LaueOps::GetAllOrientationOps()
 {
   std::vector<LaueOps::Pointer> m_OrientationOps;
   m_OrientationOps.push_back(HexagonalOps::New());
@@ -386,7 +349,7 @@ std::vector<LaueOps::Pointer> LaueOps::getOrientationOpsVector()
 }
 
 // -----------------------------------------------------------------------------
-LaueOps::Pointer LaueOps::getOrientationOpsFromSpaceGroupNumber(size_t sgNumber)
+LaueOps::Pointer LaueOps::GetOrientationOpsFromSpaceGroupNumber(size_t sgNumber)
 {
   std::array<size_t, 32> sgpg = {1, 2, 3, 6, 10, 16, 25, 47, 75, 81, 83, 89, 99, 111, 123, 143, 147, 149, 156, 162, 168, 174, 175, 177, 183, 187, 191, 195, 200, 207, 215, 221};
   std::array<size_t, 32> pgLaue = {1, 1, 2, 2, 2, 22, 22, 22, 4, 4, 4, 42, 42, 42, 42, 3, 3, 32, 32, 32, 6, 6, 6, 62, 62, 62, 62, 23, 23, 43, 43, 43};
@@ -438,7 +401,7 @@ std::vector<QString> LaueOps::GetLaueNames()
 {
   std::vector<QString> names;
 
-  std::vector<LaueOps::Pointer> ops = getOrientationOpsVector();
+  std::vector<LaueOps::Pointer> ops = GetAllOrientationOps();
   names.reserve(ops.size());
   for(const auto& op : ops)
   {

--- a/Source/OrientationLib/LaueOps/LaueOps.h
+++ b/Source/OrientationLib/LaueOps/LaueOps.h
@@ -142,16 +142,20 @@ class OrientationLib_EXPORT LaueOps
     virtual std::array<size_t, 3> getOdfNumBins() const = 0;
 
     /**
-     * @brief getMisoQuat Finds the misorientation
-     * @param q1
-     * @param q2
-     * @param n1
-     * @param n2
-     * @param n3
-     * @return
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
      */
-    virtual double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const = 0;
-    virtual float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const = 0;
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const = 0;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const = 0;
 
     /**
      * @brief getQuatSymOp Copies the symmetry operator at index i into q
@@ -253,10 +257,12 @@ class OrientationLib_EXPORT LaueOps
   protected:
     LaueOps();
 
-    double _calcMisoQuat(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2, double& n1, double& n2, double& n3) const;
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
 
     OrientationType _calcRodNearestOrigin(const double rodsym[24][3], int numsym, const OrientationType& rod) const;
+
     QuatType _calcNearestQuat(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
+
     QuatType _calcQuatNearestOrigin(const QuatType quatsym[24], int numsym, const QuatType& qr) const;
 
     int _calcMisoBin(double dim[3], double bins[3], double step[3], const OrientationType& homochoric) const;

--- a/Source/OrientationLib/LaueOps/LaueOps.h
+++ b/Source/OrientationLib/LaueOps/LaueOps.h
@@ -136,6 +136,12 @@ class OrientationLib_EXPORT LaueOps
     virtual QString getSymmetryName() const = 0;
 
     /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    virtual std::array<size_t, 3> getOdfNumBins() const = 0;
+
+    /**
      * @brief getMisoQuat Finds the misorientation
      * @param q1
      * @param q2
@@ -170,13 +176,13 @@ class OrientationLib_EXPORT LaueOps
 
     virtual bool inUnitTriangle(double eta, double chi) const = 0;
 
-    virtual OrientationType determineEulerAngles(uint64_t seed, int choose) const = 0;
+    virtual OrientationType determineEulerAngles(double random[3], int choose) const = 0;
 
     virtual OrientationType randomizeEulerAngles(const OrientationType& euler) const = 0;
 
     virtual size_t getRandomSymmetryOperatorIndex(int numSymOps) const;
 
-    virtual OrientationType determineRodriguesVector(uint64_t seed, int choose) const = 0;
+    virtual OrientationType determineRodriguesVector(double random[3], int choose) const = 0;
 
     virtual int getOdfBin(const OrientationType& rod) const = 0;
 
@@ -254,7 +260,7 @@ class OrientationLib_EXPORT LaueOps
     QuatType _calcQuatNearestOrigin(const QuatType quatsym[24], int numsym, const QuatType& qr) const;
 
     int _calcMisoBin(double dim[3], double bins[3], double step[3], const OrientationType& homochoric) const;
-    void _calcDetermineHomochoricValues(uint64_t seed, double init[3], double step[3], int32_t phi[3], int choose, double& r1, double& r2, double& r3) const;
+    void _calcDetermineHomochoricValues(double random[3], double init[3], double step[3], int32_t phi[3], double& r1, double& r2, double& r3) const;
     int _calcODFBin(double dim[3], double bins[3], double step[3], const OrientationType& homochoric) const;
 
   public:

--- a/Source/OrientationLib/LaueOps/LaueOps.h
+++ b/Source/OrientationLib/LaueOps/LaueOps.h
@@ -35,13 +35,10 @@
 #pragma once
 
 #include <memory>
-
 #include <vector>
 
-
-#include <QtCore/QVector>
 #include <QtCore/QString>
-
+#include <QtCore/QVector>
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
@@ -77,27 +74,19 @@ class OrientationLib_EXPORT LaueOps
 
     virtual ~LaueOps();
 
-
     /**
-     * @brief getOrientationOpsVector This method returns a vector of each type of LaueOps placed such that the
+     * @brief GetAllOrientationOps This method returns a vector of each type of LaueOps placed such that the
      * index into the vector is the value of the constant at EBSD::CrystalStructure::***
      * @return Vector of LaueOps subclasses.
      */
-    static QVector<LaueOps::Pointer> getOrientationOpsQVector();
+    static std::vector<LaueOps::Pointer> GetAllOrientationOps();
 
     /**
-     * @brief getOrientationOpsVector This method returns a vector of each type of LaueOps placed such that the
-     * index into the vector is the value of the constant at EBSD::CrystalStructure::***
-     * @return Vector of LaueOps subclasses.
-     */
-    static std::vector<LaueOps::Pointer> getOrientationOpsVector();
-
-    /**
-     * @brief getOrientationOpsFromSpaceGroupNumber
+     * @brief GetOrientationOpsFromSpaceGroupNumber
      * @param sgNumber
      * @return
      */
-    static Pointer getOrientationOpsFromSpaceGroupNumber(size_t sgNumber);
+    static Pointer GetOrientationOpsFromSpaceGroupNumber(size_t sgNumber);
 
     /**
      * @brief GetLaueNames Returns the names of the Laue Classes
@@ -158,24 +147,51 @@ class OrientationLib_EXPORT LaueOps
     virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const = 0;
 
     /**
-     * @brief getQuatSymOp Copies the symmetry operator at index i into q
+     * @brief getQuatSymOp Returns the symmetry operator at index i
      * @param i The index into the Symmetry operators array
-     * @param q [output] The quaternion to store the value into
+     * @return The quaternion symmetry operator
      */
     virtual QuatType getQuatSymOp(int i) const = 0;
+
+    /**
+     * @brief getRodSymOp Returns a Rodrigues vector based on the symmetry operator at index i
+     * @param i Index of the symmetry operator
+     * @param r Pointer to store the Rodrigues vector into.
+     */
     virtual void getRodSymOp(int i, double* r) const = 0;
 
     virtual void getMatSymOp(int i, double g[3][3]) const = 0;
     virtual void getMatSymOp(int i, float g[3][3]) const = 0;
 
+    /**
+     * @brief getODFFZRod
+     * @param rod
+     * @return
+     */
     virtual OrientationType getODFFZRod(const OrientationType& rod) const = 0;
+
+    /**
+     * @brief getMDFFZRod
+     * @param rod
+     * @return
+     */
     virtual OrientationType getMDFFZRod(const OrientationType& rod) const = 0;
 
     virtual QuatType getNearestQuat(const QuatType& q1, const QuatType& q2) const = 0;
     virtual QuatF getNearestQuat(const QuatF& q1f, const QuatF& q2f) const = 0;
 
+    /**
+     * @brief getFZQuat Returns a Quaternioni that lies in the Fundemental Zone (FZ)
+     * @param qr Input Quaternion
+     * @return
+     */
     virtual QuatType getFZQuat(const QuatType& qr) const;
 
+    /**
+     * @brief getMisoBin Returns the misorientation bin that the input Rodregues vector lies in.
+     * @param rod
+     * @return
+     */
     virtual int getMisoBin(const OrientationType& rod) const = 0;
 
     virtual bool inUnitTriangle(double eta, double chi) const = 0;
@@ -257,7 +273,15 @@ class OrientationLib_EXPORT LaueOps
   protected:
     LaueOps();
 
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym The Symmetry Quarternions from the specific Laue class
+     * @param numsym The number of Symmetry Quaternions
+     * @param q1 Input Quaternion 1
+     * @param q2 Input Quaternion 2
+     * @return Returns Axis-Angle <XYZ>W form.
+     */
+    virtual OrientationD calculateMisorientationInternal(const QuatType* quatsym, size_t numsym, const QuatType& q1, const QuatType& q2) const;
 
     OrientationType _calcRodNearestOrigin(const double rodsym[24][3], int numsym, const OrientationType& rod) const;
 
@@ -275,7 +299,6 @@ class OrientationLib_EXPORT LaueOps
     LaueOps& operator=(const LaueOps&) = delete; // Copy Assignment Not Implemented
     LaueOps& operator=(LaueOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 };
 
 

--- a/Source/OrientationLib/LaueOps/LaueOps.h
+++ b/Source/OrientationLib/LaueOps/LaueOps.h
@@ -38,7 +38,6 @@
 #include <vector>
 
 #include <QtCore/QString>
-#include <QtCore/QVector>
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
@@ -265,10 +264,10 @@ class OrientationLib_EXPORT LaueOps
      * @param eulers The Euler Angles to generate the pole figure from.
      * @param imageSize The size in Pixels of the final RGB Image.
      * @param numColors The number of colors to use in the RGB Image. Less colors can give the effect of contouring.
-     * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
+     * @return A std::vector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    virtual QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const = 0;
+    virtual std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const = 0;
 
   protected:
     LaueOps();

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
@@ -143,83 +143,73 @@ QString MonoclinicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double MonoclinicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD MonoclinicOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float MonoclinicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF MonoclinicOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double MonoclinicOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD MonoclinicOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
-  for (int i = 0; i < numsym; i++)
+  for(int i = 0; i < numsym; i++)
   {
     qc = quatsym[i] * qr;
 
     if(qc.w() < -1)
     {
-      qc.w() = -1.0;
+      qc.w() = -1;
     }
     else if(qc.w() > 1)
     {
-      qc.w() = 1.0;
+      qc.w() = 1;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
 QuatType MonoclinicOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
@@ -55,32 +55,34 @@
 
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 
-
-namespace Detail
-{
-static const double MonoclinicDim1InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0));
-static const double MonoclinicDim2InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double MonoclinicDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0));
-static const double MonoclinicDim1StepValue = MonoclinicDim1InitValue / 36.0f;
-static const double MonoclinicDim2StepValue = MonoclinicDim2InitValue / 18.0f;
-static const double MonoclinicDim3StepValue = MonoclinicDim3InitValue / 36.0f;
 namespace Monoclinic
 {
+
+static const std::array<size_t, 3> OdfNumBins = {72, 36, 72}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 2;
 static const int symSize1 = 2;
 static const int symSize2 = 2;
+
+static const int k_OdfSize = 186624;
+static const int k_MdfSize = 186624;
+static const int k_NumSymQuats = 2;
+
+static const QuatType QuatSym[2] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000)};
+
+static const double RodSym[2][3] = {{0.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}};
+
+static const double MatSym[2][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}}};
+
 } // namespace Monoclinic
-} // namespace Detail
-
-static const QuatType MonoclinicQuatSym[2] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000)};
-
-static const double MonoclinicRodSym[2][3] = {{0.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}};
-
-static const double MonoclinicMatSym[2][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                                 {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}}};
-
-using namespace Detail;
 
 // -----------------------------------------------------------------------------
 //
@@ -105,7 +107,7 @@ bool MonoclinicOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int MonoclinicOps::getODFSize() const
 {
-  return k_OdfSize;
+  return Monoclinic::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -113,7 +115,7 @@ int MonoclinicOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int MonoclinicOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return Monoclinic::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -121,7 +123,13 @@ int MonoclinicOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int MonoclinicOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return Monoclinic::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> MonoclinicOps::getOdfNumBins() const
+{
+  return Monoclinic::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -137,7 +145,7 @@ QString MonoclinicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 double MonoclinicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(MonoclinicQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -148,7 +156,7 @@ float MonoclinicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f,
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(MonoclinicQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -216,40 +224,40 @@ double MonoclinicOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, Quat
 
 QuatType MonoclinicOps::getQuatSymOp(int32_t i) const
 {
-  return MonoclinicQuatSym[i];
+  return Monoclinic::QuatSym[i];
 }
 
 void MonoclinicOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = MonoclinicRodSym[i][0];
-  r[1] = MonoclinicRodSym[i][1];
-  r[2] = MonoclinicRodSym[i][2];
+  r[0] = Monoclinic::RodSym[i][0];
+  r[1] = Monoclinic::RodSym[i][1];
+  r[2] = Monoclinic::RodSym[i][2];
 }
 
 void MonoclinicOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = MonoclinicMatSym[i][0][0];
-  g[0][1] = MonoclinicMatSym[i][0][1];
-  g[0][2] = MonoclinicMatSym[i][0][2];
-  g[1][0] = MonoclinicMatSym[i][1][0];
-  g[1][1] = MonoclinicMatSym[i][1][1];
-  g[1][2] = MonoclinicMatSym[i][1][2];
-  g[2][0] = MonoclinicMatSym[i][2][0];
-  g[2][1] = MonoclinicMatSym[i][2][1];
-  g[2][2] = MonoclinicMatSym[i][2][2];
+  g[0][0] = Monoclinic::MatSym[i][0][0];
+  g[0][1] = Monoclinic::MatSym[i][0][1];
+  g[0][2] = Monoclinic::MatSym[i][0][2];
+  g[1][0] = Monoclinic::MatSym[i][1][0];
+  g[1][1] = Monoclinic::MatSym[i][1][1];
+  g[1][2] = Monoclinic::MatSym[i][1][2];
+  g[2][0] = Monoclinic::MatSym[i][2][0];
+  g[2][1] = Monoclinic::MatSym[i][2][1];
+  g[2][2] = Monoclinic::MatSym[i][2][2];
 }
 
 void MonoclinicOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = MonoclinicMatSym[i][0][0];
-  g[0][1] = MonoclinicMatSym[i][0][1];
-  g[0][2] = MonoclinicMatSym[i][0][2];
-  g[1][0] = MonoclinicMatSym[i][1][0];
-  g[1][1] = MonoclinicMatSym[i][1][1];
-  g[1][2] = MonoclinicMatSym[i][1][2];
-  g[2][0] = MonoclinicMatSym[i][2][0];
-  g[2][1] = MonoclinicMatSym[i][2][1];
-  g[2][2] = MonoclinicMatSym[i][2][2];
+  g[0][0] = Monoclinic::MatSym[i][0][0];
+  g[0][1] = Monoclinic::MatSym[i][0][1];
+  g[0][2] = Monoclinic::MatSym[i][0][2];
+  g[1][0] = Monoclinic::MatSym[i][1][0];
+  g[1][1] = Monoclinic::MatSym[i][1][1];
+  g[1][2] = Monoclinic::MatSym[i][1][2];
+  g[2][0] = Monoclinic::MatSym[i][2][0];
+  g[2][1] = Monoclinic::MatSym[i][2][1];
+  g[2][2] = Monoclinic::MatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -258,7 +266,7 @@ void MonoclinicOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType MonoclinicOps::getODFFZRod(const OrientationType& rod) const
 {
   int numsym = 2;
-  return _calcRodNearestOrigin(MonoclinicRodSym, numsym, rod);
+  return _calcRodNearestOrigin(Monoclinic::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -269,7 +277,7 @@ OrientationType MonoclinicOps::getMDFFZRod(const OrientationType& inRod) const
   double w = 0.0, n1 = 0.0, n2 = 0.0, n3 = 0.0;
   double FZw = 0.0, FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0;
 
-  OrientationType rod = LaueOps::_calcRodNearestOrigin(MonoclinicRodSym, 24, inRod);
+  OrientationType rod = LaueOps::_calcRodNearestOrigin(Monoclinic::RodSym, 24, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
   n1 = ax[0];
   n2 = ax[1], n3 = ax[2], w = ax[3];
@@ -284,14 +292,14 @@ OrientationType MonoclinicOps::getMDFFZRod(const OrientationType& inRod) const
 // -----------------------------------------------------------------------------
 QuatType MonoclinicOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(MonoclinicQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2);
 }
 
 QuatF MonoclinicOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(MonoclinicQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -307,15 +315,15 @@ int MonoclinicOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::MonoclinicDim1InitValue;
-  dim[1] = Detail::MonoclinicDim2InitValue;
-  dim[2] = Detail::MonoclinicDim3InitValue;
-  step[0] = Detail::MonoclinicDim1StepValue;
-  step[1] = Detail::MonoclinicDim2StepValue;
-  step[2] = Detail::MonoclinicDim3StepValue;
-  bins[0] = 72.0f;
-  bins[1] = 36.0f;
-  bins[2] = 72.0f;
+  dim[0] = Monoclinic::OdfDimInitValue[0];
+  dim[1] = Monoclinic::OdfDimInitValue[1];
+  dim[2] = Monoclinic::OdfDimInitValue[2];
+  step[0] = Monoclinic::OdfDimStepValue[0];
+  step[1] = Monoclinic::OdfDimStepValue[1];
+  step[2] = Monoclinic::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(Monoclinic::OdfNumBins[0]);
+  bins[1] = static_cast<double>(Monoclinic::OdfNumBins[1]);
+  bins[2] = static_cast<double>(Monoclinic::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -323,24 +331,25 @@ int MonoclinicOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType MonoclinicOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType MonoclinicOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::MonoclinicDim1InitValue;
-  init[1] = Detail::MonoclinicDim2InitValue;
-  init[2] = Detail::MonoclinicDim3InitValue;
-  step[0] = Detail::MonoclinicDim1StepValue;
-  step[1] = Detail::MonoclinicDim2StepValue;
-  step[2] = Detail::MonoclinicDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 36);
-  phi[2] = static_cast<int32_t>(choose / (72 * 36));
+  init[0] = Monoclinic::OdfDimInitValue[0];
+  init[1] = Monoclinic::OdfDimInitValue[1];
+  init[2] = Monoclinic::OdfDimInitValue[2];
+  step[0] = Monoclinic::OdfDimStepValue[0];
+  step[1] = Monoclinic::OdfDimStepValue[1];
+  step[2] = Monoclinic::OdfDimStepValue[2];
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  phi[0] = static_cast<int32_t>(choose % Monoclinic::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / Monoclinic::OdfNumBins[0]) % Monoclinic::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (Monoclinic::OdfNumBins[0] * Monoclinic::OdfNumBins[1]));
+
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -354,9 +363,9 @@ OrientationType MonoclinicOps::determineEulerAngles(uint64_t seed, int choose) c
 // -----------------------------------------------------------------------------
 OrientationType MonoclinicOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(Monoclinic::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = MonoclinicQuatSym[symOp] * quat;
+  QuatType qc = Monoclinic::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
@@ -364,24 +373,24 @@ OrientationType MonoclinicOps::randomizeEulerAngles(const OrientationType& synea
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType MonoclinicOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType MonoclinicOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::MonoclinicDim1InitValue;
-  init[1] = Detail::MonoclinicDim2InitValue;
-  init[2] = Detail::MonoclinicDim3InitValue;
-  step[0] = Detail::MonoclinicDim1StepValue;
-  step[1] = Detail::MonoclinicDim2StepValue;
-  step[2] = Detail::MonoclinicDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 36);
-  phi[2] = static_cast<int32_t>(choose / (72 * 36));
+  init[0] = Monoclinic::OdfDimInitValue[0];
+  init[1] = Monoclinic::OdfDimInitValue[1];
+  init[2] = Monoclinic::OdfDimInitValue[2];
+  step[0] = Monoclinic::OdfDimStepValue[0];
+  step[1] = Monoclinic::OdfDimStepValue[1];
+  step[2] = Monoclinic::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % Monoclinic::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / Monoclinic::OdfNumBins[0]) % Monoclinic::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (Monoclinic::OdfNumBins[0] * Monoclinic::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -399,15 +408,15 @@ int MonoclinicOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::MonoclinicDim1InitValue;
-  dim[1] = Detail::MonoclinicDim2InitValue;
-  dim[2] = Detail::MonoclinicDim3InitValue;
-  step[0] = Detail::MonoclinicDim1StepValue;
-  step[1] = Detail::MonoclinicDim2StepValue;
-  step[2] = Detail::MonoclinicDim3StepValue;
-  bins[0] = 72.0f;
-  bins[1] = 36.0f;
-  bins[2] = 72.0f;
+  dim[0] = Monoclinic::OdfDimInitValue[0];
+  dim[1] = Monoclinic::OdfDimInitValue[1];
+  dim[2] = Monoclinic::OdfDimInitValue[2];
+  step[0] = Monoclinic::OdfDimStepValue[0];
+  step[1] = Monoclinic::OdfDimStepValue[1];
+  step[2] = Monoclinic::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(Monoclinic::OdfNumBins[0]);
+  bins[1] = static_cast<double>(Monoclinic::OdfNumBins[1]);
+  bins[2] = static_cast<double>(Monoclinic::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -433,22 +442,22 @@ void MonoclinicOps::getSchmidFactorAndSS(double load[3], double plane[3], double
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < Monoclinic::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = MonoclinicMatSym[i][2][0] * plane[0] + MonoclinicMatSym[i][2][1] * plane[1] + MonoclinicMatSym[i][2][2] * plane[2];
+    slipPlane[2] = Monoclinic::MatSym[i][2][0] * plane[0] + Monoclinic::MatSym[i][2][1] * plane[1] + Monoclinic::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = MonoclinicMatSym[i][0][0] * plane[0] + MonoclinicMatSym[i][0][1] * plane[1] + MonoclinicMatSym[i][0][2] * plane[2];
-      slipPlane[1] = MonoclinicMatSym[i][1][0] * plane[0] + MonoclinicMatSym[i][1][1] * plane[1] + MonoclinicMatSym[i][1][2] * plane[2];
+      slipPlane[0] = Monoclinic::MatSym[i][0][0] * plane[0] + Monoclinic::MatSym[i][0][1] * plane[1] + Monoclinic::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = Monoclinic::MatSym[i][1][0] * plane[0] + Monoclinic::MatSym[i][1][1] * plane[1] + Monoclinic::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = MonoclinicMatSym[i][0][0] * direction[0] + MonoclinicMatSym[i][0][1] * direction[1] + MonoclinicMatSym[i][0][2] * direction[2];
-      slipDirection[1] = MonoclinicMatSym[i][1][0] * direction[0] + MonoclinicMatSym[i][1][1] * direction[1] + MonoclinicMatSym[i][1][2] * direction[2];
-      slipDirection[2] = MonoclinicMatSym[i][2][0] * direction[0] + MonoclinicMatSym[i][2][1] * direction[1] + MonoclinicMatSym[i][2][2] * direction[2];
+      slipDirection[0] = Monoclinic::MatSym[i][0][0] * direction[0] + Monoclinic::MatSym[i][0][1] * direction[1] + Monoclinic::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = Monoclinic::MatSym[i][1][0] * direction[0] + Monoclinic::MatSym[i][1][1] * direction[1] + Monoclinic::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = Monoclinic::MatSym[i][2][0] * direction[0] + Monoclinic::MatSym[i][2][1] * direction[1] + Monoclinic::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -488,8 +497,7 @@ double MonoclinicOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3]
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
-{
+
   namespace Monoclinic
   {
     class GenerateSphereCoordsImpl
@@ -558,30 +566,28 @@ namespace Detail
         }
 #endif
     };
-  }
-}
+    } // namespace Monoclinic
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void MonoclinicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
-{
-  size_t nOrientations = eulers->getNumberOfTuples();
+    // -----------------------------------------------------------------------------
+    //
+    // -----------------------------------------------------------------------------
+    void MonoclinicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
+    {
+      size_t nOrientations = eulers->getNumberOfTuples();
 
-
-  // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::Monoclinic::symSize0)
-  {
-    xyz001->resizeTuples(nOrientations * Detail::Monoclinic::symSize0 * 3);
-  }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::Monoclinic::symSize1)
-  {
-    xyz011->resizeTuples(nOrientations * Detail::Monoclinic::symSize1 * 3);
-  }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::Monoclinic::symSize2)
-  {
-    xyz111->resizeTuples(nOrientations * Detail::Monoclinic::symSize2 * 3);
-  }
+      // Sanity Check the size of the arrays
+      if(xyz001->getNumberOfTuples() < nOrientations * Monoclinic::symSize0)
+      {
+        xyz001->resizeTuples(nOrientations * Monoclinic::symSize0 * 3);
+      }
+      if(xyz011->getNumberOfTuples() < nOrientations * Monoclinic::symSize1)
+      {
+        xyz011->resizeTuples(nOrientations * Monoclinic::symSize1 * 3);
+      }
+      if(xyz111->getNumberOfTuples() < nOrientations * Monoclinic::symSize2)
+      {
+        xyz111->resizeTuples(nOrientations * Monoclinic::symSize2 * 3);
+      }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   tbb::task_scheduler_init init;
@@ -591,17 +597,15 @@ void MonoclinicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Float
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::Monoclinic::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), Monoclinic::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::Monoclinic::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    Monoclinic::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
-
-}
+    }
 
 // -----------------------------------------------------------------------------
 //
@@ -641,7 +645,7 @@ SIMPL::Rgb MonoclinicOps::generateIPFColor(double phi1, double phi, double phi2,
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < Monoclinic::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -707,9 +711,9 @@ SIMPL::Rgb MonoclinicOps::generateIPFColor(double phi1, double phi, double phi2,
 // -----------------------------------------------------------------------------
 SIMPL::Rgb MonoclinicOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * MonoclinicDim1InitValue;
-  double range2 = 2.0f * MonoclinicDim2InitValue;
-  double range3 = 2.0f * MonoclinicDim3InitValue;
+  double range1 = 2.0f * Monoclinic::OdfDimInitValue[0];
+  double range2 = 2.0f * Monoclinic::OdfDimInitValue[1];
+  double range3 = 2.0f * Monoclinic::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -746,11 +750,11 @@ QVector<UInt8ArrayType::Pointer> MonoclinicOps::generatePoleFigure(PoleFigureCon
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::Monoclinic::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Monoclinic::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::Monoclinic::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Monoclinic::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::Monoclinic::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Monoclinic::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
@@ -33,9 +33,10 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "MonoclinicOps.h"
+
 #include <memory>
 
-#include "MonoclinicOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -669,7 +670,7 @@ SIMPL::Rgb MonoclinicOps::generateRodriguesColor(double r1, double r2, double r3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> MonoclinicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> MonoclinicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<100>");
@@ -782,7 +783,7 @@ QVector<UInt8ArrayType::Pointer> MonoclinicOps::generatePoleFigure(PoleFigureCon
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.cpp
@@ -157,60 +157,6 @@ OrientationF MonoclinicOps::calculateMisorientation(const QuatF& q1f, const Quat
   OrientationD axisAngle = calculateMisorientationInternal(Monoclinic::QuatSym, Monoclinic::k_NumSymQuats, q1, q2);
   return axisAngle;
 }
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD MonoclinicOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for(int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
 
 QuatType MonoclinicOps::getQuatSymOp(int32_t i) const
 {

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.h
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.h
@@ -212,15 +212,6 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     MonoclinicOps(const MonoclinicOps&) = delete;  // Copy Constructor Not Implemented
@@ -228,7 +219,6 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
     MonoclinicOps& operator=(const MonoclinicOps&) = delete; // Copy Assignment Not Implemented
     MonoclinicOps& operator=(MonoclinicOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.h
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
     MonoclinicOps();
     ~MonoclinicOps() override;
 
-    static const int k_OdfSize = 186624;
-    static const int k_MdfSize = 186624;
-    static const int k_NumSymQuats = 2;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +106,12 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -127,9 +129,9 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.h
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.h
@@ -203,7 +203,7 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/MonoclinicOps.h
+++ b/Source/OrientationLib/LaueOps/MonoclinicOps.h
@@ -112,8 +112,21 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -199,7 +212,15 @@ class OrientationLib_EXPORT MonoclinicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     MonoclinicOps(const MonoclinicOps&) = delete;  // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
@@ -150,83 +150,71 @@ QString OrthoRhombicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double OrthoRhombicOps::_calcMisoQuat(const QuatType quatsym[4], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD OrthoRhombicOps::calculateMisorientationInternal(const QuatType quatsym[4], int numsym, const QuatType& q1, const QuatType& q2) const
 {
-  double wmin = 9999999.0; //,na,nb,nc;
-  double w = 0;
-  double n1min = 0.0;
-  double n2min = 0.0;
-  double n3min = 0.0;
-  QuatType qc;
+  double wmin = 9999999.0f; //,na,nb,nc;
+  double n1min = 0.0f;
+  double n2min = 0.0f;
+  double n3min = 0.0f;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
-  for (int i = 0; i < numsym; i++)
+  for(int i = 0; i < numsym; i++)
   {
-
     qc = quatsym[i] * qr;
 
-    //MULT_QUAT(qr, quatsym[i], qc)
     if(qc.w() < -1)
     {
-      qc.w() = -1.0;
+      qc.w() = -1;
     }
     else if(qc.w() > 1)
     {
-      qc.w() = 1.0;
+      qc.w() = 1;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double OrthoRhombicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD OrthoRhombicOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float OrthoRhombicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF OrthoRhombicOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType OrthoRhombicOps::getQuatSymOp(int32_t i) const
@@ -977,9 +965,8 @@ UInt8ArrayType::Pointer OrthoRhombicOps::generateIPFTriangleLegend(int imageDim)
 // -----------------------------------------------------------------------------
 SIMPL::Rgb OrthoRhombicOps::generateMisorientationColor(const QuatType& q, const QuatType& refFrame) const
 {
-  Q_ASSERT(false);
+  throw std::out_of_range("OrthoRhombicOps::generateMisorientationColor NOT Implemented");
 
-  double n1, n2, n3, w;
   double x, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11;
   double y, y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11;
   double z, z1, z2, z3, z4, z5, z6, z7, z8, z9, z10, z11;
@@ -989,16 +976,16 @@ SIMPL::Rgb OrthoRhombicOps::generateMisorientationColor(const QuatType& q, const
   QuatType q2 = refFrame;
 
   // get disorientation
-  w = getMisoQuat(q1, q2, n1, n2, n3);
-  n1 = fabs(n1);
-  n2 = fabs(n2);
-  n3 = fabs(n3);
+  OrientationD axisAngle = calculateMisorientation(q1, q2);
+  axisAngle[0] = fabs(axisAngle[0]);
+  axisAngle[1] = fabs(axisAngle[1]);
+  axisAngle[2] = fabs(axisAngle[2]);
 
   //eq c1.1
-  k = tan(w / 2.0);
-  x = n1;
-  y = n2;
-  z = n3;
+  k = tan(axisAngle[3] / 2.0);
+  x = axisAngle[0];
+  y = axisAngle[1];
+  z = axisAngle[2];
 
   OrientationType rod(x, y, z, k);
   rod = getMDFFZRod(rod);

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
@@ -147,61 +147,6 @@ QString OrthoRhombicOps::getSymmetryName() const
   ;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD OrthoRhombicOps::calculateMisorientationInternal(const QuatType quatsym[4], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for(int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD OrthoRhombicOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2);

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
@@ -57,38 +57,38 @@
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 #include "OrientationLib/Utilities/PoleFigureUtilities.h"
 
-namespace Detail
+namespace OrthoRhombic
 {
+static const std::array<size_t, 3> OdfNumBins = {36, 36, 36}; // Represents a 5Deg bin
 
-static const double OrthoDim1InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double OrthoDim2InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double OrthoDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double OrthoDim1StepValue = OrthoDim1InitValue / 18.0;
-static const double OrthoDim2StepValue = OrthoDim2InitValue / 18.0;
-static const double OrthoDim3StepValue = OrthoDim3InitValue / 18.0;
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
 
-namespace Orthorhombic
-{
 static const int symSize0 = 2;
 static const int symSize1 = 2;
 static const int symSize2 = 2;
-} // namespace Orthorhombic
-}
 
-static const QuatType OrthoQuatSym[4] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
-                                         QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000), QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000)};
+static const int k_OdfSize = 46656;
+static const int k_MdfSize = 46656;
+static const int k_NumSymQuats = 4;
 
-static const double OrthoRodSym[4][3] = {{0.0, 0.0, 0.0}, {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}, {0.0, 0.0, 10000000000.0}};
+static const QuatType QuatSym[4] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
+                                    QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000), QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000)};
 
-static const double OrthoMatSym[4][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+static const double RodSym[4][3] = {{0.0, 0.0, 0.0}, {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0}, {0.0, 0.0, 10000000000.0}};
 
-                                            {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+static const double MatSym[4][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                            {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                       {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                            {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}}};
+                                       {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-using namespace Detail;
+                                       {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}}};
+
+} // namespace OrthoRhombic
 
 // -----------------------------------------------------------------------------
 //
@@ -113,7 +113,7 @@ bool OrthoRhombicOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int OrthoRhombicOps::getODFSize() const
 {
-  return k_OdfSize;
+  return OrthoRhombic::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -121,7 +121,7 @@ int OrthoRhombicOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int OrthoRhombicOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return OrthoRhombic::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -129,7 +129,13 @@ int OrthoRhombicOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int OrthoRhombicOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return OrthoRhombic::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> OrthoRhombicOps::getOdfNumBins() const
+{
+  return OrthoRhombic::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -137,7 +143,7 @@ int OrthoRhombicOps::getNumSymOps() const
 // -----------------------------------------------------------------------------
 QString OrthoRhombicOps::getSymmetryName() const
 {
-  return "Orthorhombic mmm";
+  return "OrthoRhombic mmm";
   ;
 }
 
@@ -205,7 +211,7 @@ double OrthoRhombicOps::_calcMisoQuat(const QuatType quatsym[4], int numsym, Qua
 
 double OrthoRhombicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(OrthoQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -216,7 +222,7 @@ float OrthoRhombicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(OrthoQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -225,40 +231,40 @@ float OrthoRhombicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2
 
 QuatType OrthoRhombicOps::getQuatSymOp(int32_t i) const
 {
-  return OrthoQuatSym[i];
+  return OrthoRhombic::QuatSym[i];
 }
 
 void OrthoRhombicOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = OrthoRodSym[i][0];
-  r[1] = OrthoRodSym[i][1];
-  r[2] = OrthoRodSym[i][2];
+  r[0] = OrthoRhombic::RodSym[i][0];
+  r[1] = OrthoRhombic::RodSym[i][1];
+  r[2] = OrthoRhombic::RodSym[i][2];
 }
 
 void OrthoRhombicOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = OrthoMatSym[i][0][0];
-  g[0][1] = OrthoMatSym[i][0][1];
-  g[0][2] = OrthoMatSym[i][0][2];
-  g[1][0] = OrthoMatSym[i][1][0];
-  g[1][1] = OrthoMatSym[i][1][1];
-  g[1][2] = OrthoMatSym[i][1][2];
-  g[2][0] = OrthoMatSym[i][2][0];
-  g[2][1] = OrthoMatSym[i][2][1];
-  g[2][2] = OrthoMatSym[i][2][2];
+  g[0][0] = OrthoRhombic::MatSym[i][0][0];
+  g[0][1] = OrthoRhombic::MatSym[i][0][1];
+  g[0][2] = OrthoRhombic::MatSym[i][0][2];
+  g[1][0] = OrthoRhombic::MatSym[i][1][0];
+  g[1][1] = OrthoRhombic::MatSym[i][1][1];
+  g[1][2] = OrthoRhombic::MatSym[i][1][2];
+  g[2][0] = OrthoRhombic::MatSym[i][2][0];
+  g[2][1] = OrthoRhombic::MatSym[i][2][1];
+  g[2][2] = OrthoRhombic::MatSym[i][2][2];
 }
 
 void OrthoRhombicOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = OrthoMatSym[i][0][0];
-  g[0][1] = OrthoMatSym[i][0][1];
-  g[0][2] = OrthoMatSym[i][0][2];
-  g[1][0] = OrthoMatSym[i][1][0];
-  g[1][1] = OrthoMatSym[i][1][1];
-  g[1][2] = OrthoMatSym[i][1][2];
-  g[2][0] = OrthoMatSym[i][2][0];
-  g[2][1] = OrthoMatSym[i][2][1];
-  g[2][2] = OrthoMatSym[i][2][2];
+  g[0][0] = OrthoRhombic::MatSym[i][0][0];
+  g[0][1] = OrthoRhombic::MatSym[i][0][1];
+  g[0][2] = OrthoRhombic::MatSym[i][0][2];
+  g[1][0] = OrthoRhombic::MatSym[i][1][0];
+  g[1][1] = OrthoRhombic::MatSym[i][1][1];
+  g[1][2] = OrthoRhombic::MatSym[i][1][2];
+  g[2][0] = OrthoRhombic::MatSym[i][2][0];
+  g[2][1] = OrthoRhombic::MatSym[i][2][1];
+  g[2][2] = OrthoRhombic::MatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -267,7 +273,7 @@ void OrthoRhombicOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType OrthoRhombicOps::getODFFZRod(const OrientationType& rod) const
 {
   int  numsym = 4;
-  return _calcRodNearestOrigin(OrthoRodSym, numsym, rod);
+  return _calcRodNearestOrigin(OrthoRhombic::RodSym, numsym, rod);
 }
 
 
@@ -279,12 +285,12 @@ OrientationType OrthoRhombicOps::getMDFFZRod(const OrientationType& inRod) const
   double w, n1, n2, n3;
   double FZn1 = 0.0f, FZn2 = 0.0f, FZn3 = 0.0f, FZw = 0.0f;
 
-  OrientationType rod = _calcRodNearestOrigin(OrthoRodSym, 4, inRod);
+  OrientationType rod = _calcRodNearestOrigin(OrthoRhombic::RodSym, 4, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
   n1 = ax[0];
   n2 = ax[1], n3 = ax[2], w = ax[3];
 
-  /// FIXME: Are we missing code for Orthorhombic MDF FZ Rodrigues calculation?
+  /// FIXME: Are we missing code for OrthoRhombic MDF FZ Rodrigues calculation?
 
   return OrientationTransformation::ax2ro<OrientationType, OrientationType>(OrientationType(FZn1, FZn2, FZn3, FZw));
 }
@@ -294,21 +300,21 @@ OrientationType OrthoRhombicOps::getMDFFZRod(const OrientationType& inRod) const
 // -----------------------------------------------------------------------------
 QuatType OrthoRhombicOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(OrthoQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2);
 }
 
 QuatF OrthoRhombicOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(OrthoQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
 
 QuatType OrthoRhombicOps::getFZQuat(const QuatType& qr) const
 {
-  return _calcQuatNearestOrigin(OrthoQuatSym, k_NumSymQuats, qr);
+  return _calcQuatNearestOrigin(OrthoRhombic::QuatSym, OrthoRhombic::k_NumSymQuats, qr);
 }
 
 // -----------------------------------------------------------------------------
@@ -321,15 +327,15 @@ int OrthoRhombicOps::getMisoBin(const OrientationType& rod) const
   double step[3];
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = OrthoDim1InitValue;
-  dim[1] = OrthoDim2InitValue;
-  dim[2] = OrthoDim3InitValue;
-  step[0] = OrthoDim1StepValue;
-  step[1] = OrthoDim2StepValue;
-  step[2] = OrthoDim3StepValue;
-  bins[0] = 36.0;
-  bins[1] = 36.0;
-  bins[2] = 36.0;
+  dim[0] = OrthoRhombic::OdfDimInitValue[0];
+  dim[1] = OrthoRhombic::OdfDimInitValue[1];
+  dim[2] = OrthoRhombic::OdfDimInitValue[2];
+  step[0] = OrthoRhombic::OdfDimStepValue[0];
+  step[1] = OrthoRhombic::OdfDimStepValue[1];
+  step[2] = OrthoRhombic::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(OrthoRhombic::OdfNumBins[0]);
+  bins[1] = static_cast<double>(OrthoRhombic::OdfNumBins[1]);
+  bins[2] = static_cast<double>(OrthoRhombic::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -337,24 +343,24 @@ int OrthoRhombicOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType OrthoRhombicOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType OrthoRhombicOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = OrthoDim1InitValue;
-  init[1] = OrthoDim2InitValue;
-  init[2] = OrthoDim3InitValue;
-  step[0] = OrthoDim1StepValue;
-  step[1] = OrthoDim2StepValue;
-  step[2] = OrthoDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = OrthoRhombic::OdfDimInitValue[0];
+  init[1] = OrthoRhombic::OdfDimInitValue[1];
+  init[2] = OrthoRhombic::OdfDimInitValue[2];
+  step[0] = OrthoRhombic::OdfDimStepValue[0];
+  step[1] = OrthoRhombic::OdfDimStepValue[1];
+  step[2] = OrthoRhombic::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % OrthoRhombic::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / OrthoRhombic::OdfNumBins[0]) % OrthoRhombic::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (OrthoRhombic::OdfNumBins[0] * OrthoRhombic::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -368,33 +374,33 @@ OrientationType OrthoRhombicOps::determineEulerAngles(uint64_t seed, int choose)
 // -----------------------------------------------------------------------------
 OrientationType OrthoRhombicOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(OrthoRhombic::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = OrthoQuatSym[symOp] * quat;
+  QuatType qc = OrthoRhombic::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType OrthoRhombicOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType OrthoRhombicOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = OrthoDim1InitValue;
-  init[1] = OrthoDim2InitValue;
-  init[2] = OrthoDim3InitValue;
-  step[0] = OrthoDim1StepValue;
-  step[1] = OrthoDim2StepValue;
-  step[2] = OrthoDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = OrthoRhombic::OdfDimInitValue[0];
+  init[1] = OrthoRhombic::OdfDimInitValue[1];
+  init[2] = OrthoRhombic::OdfDimInitValue[2];
+  step[0] = OrthoRhombic::OdfDimStepValue[0];
+  step[1] = OrthoRhombic::OdfDimStepValue[1];
+  step[2] = OrthoRhombic::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % OrthoRhombic::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / OrthoRhombic::OdfNumBins[0]) % OrthoRhombic::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (OrthoRhombic::OdfNumBins[0] * OrthoRhombic::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -412,15 +418,15 @@ int OrthoRhombicOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = OrthoDim1InitValue;
-  dim[1] = OrthoDim2InitValue;
-  dim[2] = OrthoDim3InitValue;
-  step[0] = OrthoDim1StepValue;
-  step[1] = OrthoDim2StepValue;
-  step[2] = OrthoDim3StepValue;
-  bins[0] = 36.0;
-  bins[1] = 36.0;
-  bins[2] = 36.0;
+  dim[0] = OrthoRhombic::OdfDimInitValue[0];
+  dim[1] = OrthoRhombic::OdfDimInitValue[1];
+  dim[2] = OrthoRhombic::OdfDimInitValue[2];
+  step[0] = OrthoRhombic::OdfDimStepValue[0];
+  step[1] = OrthoRhombic::OdfDimStepValue[1];
+  step[2] = OrthoRhombic::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(OrthoRhombic::OdfNumBins[0]);
+  bins[1] = static_cast<double>(OrthoRhombic::OdfNumBins[1]);
+  bins[2] = static_cast<double>(OrthoRhombic::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -446,22 +452,22 @@ void OrthoRhombicOps::getSchmidFactorAndSS(double load[3], double plane[3], doub
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < OrthoRhombic::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = OrthoMatSym[i][2][0] * plane[0] + OrthoMatSym[i][2][1] * plane[1] + OrthoMatSym[i][2][2] * plane[2];
+    slipPlane[2] = OrthoRhombic::MatSym[i][2][0] * plane[0] + OrthoRhombic::MatSym[i][2][1] * plane[1] + OrthoRhombic::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = OrthoMatSym[i][0][0] * plane[0] + OrthoMatSym[i][0][1] * plane[1] + OrthoMatSym[i][0][2] * plane[2];
-      slipPlane[1] = OrthoMatSym[i][1][0] * plane[0] + OrthoMatSym[i][1][1] * plane[1] + OrthoMatSym[i][1][2] * plane[2];
+      slipPlane[0] = OrthoRhombic::MatSym[i][0][0] * plane[0] + OrthoRhombic::MatSym[i][0][1] * plane[1] + OrthoRhombic::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = OrthoRhombic::MatSym[i][1][0] * plane[0] + OrthoRhombic::MatSym[i][1][1] * plane[1] + OrthoRhombic::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = OrthoMatSym[i][0][0] * direction[0] + OrthoMatSym[i][0][1] * direction[1] + OrthoMatSym[i][0][2] * direction[2];
-      slipDirection[1] = OrthoMatSym[i][1][0] * direction[0] + OrthoMatSym[i][1][1] * direction[1] + OrthoMatSym[i][1][2] * direction[2];
-      slipDirection[2] = OrthoMatSym[i][2][0] * direction[0] + OrthoMatSym[i][2][1] * direction[1] + OrthoMatSym[i][2][2] * direction[2];
+      slipDirection[0] = OrthoRhombic::MatSym[i][0][0] * direction[0] + OrthoRhombic::MatSym[i][0][1] * direction[1] + OrthoRhombic::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = OrthoRhombic::MatSym[i][1][0] * direction[0] + OrthoRhombic::MatSym[i][1][1] * direction[1] + OrthoRhombic::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = OrthoRhombic::MatSym[i][2][0] * direction[0] + OrthoRhombic::MatSym[i][2][1] * direction[1] + OrthoRhombic::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -500,8 +506,7 @@ double OrthoRhombicOps::getF7(const QuatType& q1, const QuatType& q2, double LD[
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
-{
+
   namespace OrthoRhombic
   {
     class GenerateSphereCoordsImpl
@@ -569,29 +574,28 @@ namespace Detail
         }
 #endif
     };
-  }
-}
+    } // namespace OrthoRhombic
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void OrthoRhombicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
-{
-  size_t nOrientations = eulers->getNumberOfTuples();
+    // -----------------------------------------------------------------------------
+    //
+    // -----------------------------------------------------------------------------
+    void OrthoRhombicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
+    {
+      size_t nOrientations = eulers->getNumberOfTuples();
 
-  // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::Orthorhombic::symSize0)
-  {
-    xyz001->resizeTuples(nOrientations * Detail::Orthorhombic::symSize0 * 3);
-  }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::Orthorhombic::symSize1)
-  {
-    xyz011->resizeTuples(nOrientations * Detail::Orthorhombic::symSize1 * 3);
-  }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::Orthorhombic::symSize2)
-  {
-    xyz111->resizeTuples(nOrientations * Detail::Orthorhombic::symSize2 * 3);
-  }
+      // Sanity Check the size of the arrays
+      if(xyz001->getNumberOfTuples() < nOrientations * OrthoRhombic::symSize0)
+      {
+        xyz001->resizeTuples(nOrientations * OrthoRhombic::symSize0 * 3);
+      }
+      if(xyz011->getNumberOfTuples() < nOrientations * OrthoRhombic::symSize1)
+      {
+        xyz011->resizeTuples(nOrientations * OrthoRhombic::symSize1 * 3);
+      }
+      if(xyz111->getNumberOfTuples() < nOrientations * OrthoRhombic::symSize2)
+      {
+        xyz111->resizeTuples(nOrientations * OrthoRhombic::symSize2 * 3);
+      }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   tbb::task_scheduler_init init;
@@ -601,16 +605,15 @@ void OrthoRhombicOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Flo
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::OrthoRhombic::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), OrthoRhombic::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::OrthoRhombic::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    OrthoRhombic::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
-}
+    }
 
 // -----------------------------------------------------------------------------
 //
@@ -650,7 +653,7 @@ SIMPL::Rgb OrthoRhombicOps::generateIPFColor(double phi1, double phi, double phi
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < OrthoRhombic::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -717,9 +720,9 @@ SIMPL::Rgb OrthoRhombicOps::generateIPFColor(double phi1, double phi, double phi
 // -----------------------------------------------------------------------------
 SIMPL::Rgb OrthoRhombicOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * OrthoDim1InitValue;
-  double range2 = 2.0f * OrthoDim2InitValue;
-  double range3 = 2.0f * OrthoDim3InitValue;
+  double range1 = 2.0f * OrthoRhombic::OdfDimInitValue[0];
+  double range2 = 2.0f * OrthoRhombic::OdfDimInitValue[1];
+  double range3 = 2.0f * OrthoRhombic::OdfDimInitValue[2];
   double max1 = range1 / 2.0;
   double max2 = range2 / 2.0;
   double max3 = range3 / 2.0;
@@ -757,9 +760,9 @@ QVector<UInt8ArrayType::Pointer> OrthoRhombicOps::generatePoleFigure(PoleFigureC
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   std::vector<size_t> dims(1, 3);
   std::vector<FloatArrayType::Pointer> coords(3);
-  coords[0] = FloatArrayType::CreateArray(numOrientations * Detail::Orthorhombic::symSize0, dims, label0 + QString("001_Coords"), true);
-  coords[1] = FloatArrayType::CreateArray(numOrientations * Detail::Orthorhombic::symSize1, dims, label1 + QString("100_Coords"), true);
-  coords[2] = FloatArrayType::CreateArray(numOrientations * Detail::Orthorhombic::symSize2, dims, label2 + QString("010_Coords"), true);
+  coords[0] = FloatArrayType::CreateArray(numOrientations * OrthoRhombic::symSize0, dims, label0 + QString("001_Coords"), true);
+  coords[1] = FloatArrayType::CreateArray(numOrientations * OrthoRhombic::symSize1, dims, label1 + QString("100_Coords"), true);
+  coords[2] = FloatArrayType::CreateArray(numOrientations * OrthoRhombic::symSize2, dims, label2 + QString("010_Coords"), true);
 
   config.sphereRadius = 1.0;
 

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.cpp
@@ -34,9 +34,10 @@
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 
+#include "OrthoRhombicOps.h"
+
 #include <memory>
 
-#include "OrthoRhombicOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -675,7 +676,7 @@ SIMPL::Rgb OrthoRhombicOps::generateRodriguesColor(double r1, double r2, double 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> OrthoRhombicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> OrthoRhombicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
 
   QString label0 = QString("<001>");
@@ -787,7 +788,7 @@ QVector<UInt8ArrayType::Pointer> OrthoRhombicOps::generatePoleFigure(PoleFigureC
   UInt8ArrayType::Pointer image100 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image010 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
     OrthoRhombicOps();
     ~OrthoRhombicOps() override;
 
-    static const int k_OdfSize = 46656;
-    static const int k_MdfSize = 46656;
-    static const int k_NumSymQuats = 4;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +106,12 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -128,9 +130,9 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
     QuatType getFZQuat(const QuatType& qr) const override;
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
@@ -213,23 +213,12 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[4], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     OrthoRhombicOps(const OrthoRhombicOps&) = delete; // Copy Constructor Not Implemented
     OrthoRhombicOps(OrthoRhombicOps&&) = delete;      // Move Constructor Not Implemented
     OrthoRhombicOps& operator=(const OrthoRhombicOps&) = delete; // Copy Assignment Not Implemented
     OrthoRhombicOps& operator=(OrthoRhombicOps&&) = delete;      // Move Assignment Not Implemented
-
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/OrientationLib/LaueOps/OrthoRhombicOps.h
@@ -112,8 +112,21 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -200,7 +213,15 @@ class OrientationLib_EXPORT OrthoRhombicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[4], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[4], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     OrthoRhombicOps(const OrthoRhombicOps&) = delete; // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
@@ -57,39 +57,39 @@
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 #include "OrientationLib/Utilities/PoleFigureUtilities.h"
 
-namespace Detail
-{
-
-static const double TetraDim1InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0));
-static const double TetraDim2InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0));
-static const double TetraDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver4)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double TetraDim1StepValue = TetraDim1InitValue / 36.0f;
-static const double TetraDim2StepValue = TetraDim2InitValue / 36.0f;
-static const double TetraDim3StepValue = TetraDim3InitValue / 9.0f;
 namespace TetragonalLow
 {
+static const std::array<size_t, 3> OdfNumBins = {72, 72, 18}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_Pi)-sinf((SIMPLib::Constants::k_Pi)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver4)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 2;
 static const int symSize1 = 2;
 static const int symSize2 = 2;
+
+static const int k_OdfSize = 93312;
+static const int k_MdfSize = 93312;
+static const int k_NumSymQuats = 4;
+
+static const QuatType QuatSym[4] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
+                                    QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, -SIMPLib::Constants::k_1OverRoot2),
+                                    QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2)};
+
+static const double RodSym[4][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 10000000000.0}, {0.0, 0.0, -1.0}, {0.0, 0.0, 1.0}};
+
+static const double MatSym[4][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}}};
+
 } // namespace TetragonalLow
-} // namespace Detail
-static const QuatType TetraQuatSym[4] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
-                                         QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, -SIMPLib::Constants::k_1OverRoot2),
-                                         QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2)};
-
-static const double TetraRodSym[4][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 10000000000.0}, {0.0, 0.0, -1.0}, {0.0, 0.0, 1.0}};
-
-static const double TetraMatSym[4][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}}};
-
-// const static double m_OnePointThree = 1.33333333333f;
-
-using namespace Detail;
 
 // -----------------------------------------------------------------------------
 //
@@ -114,7 +114,7 @@ bool TetragonalLowOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int TetragonalLowOps::getODFSize() const
 {
-  return k_OdfSize;
+  return TetragonalLow::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -122,7 +122,7 @@ int TetragonalLowOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int TetragonalLowOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return TetragonalLow::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -130,7 +130,13 @@ int TetragonalLowOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int TetragonalLowOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return TetragonalLow::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> TetragonalLowOps::getOdfNumBins() const
+{
+  return TetragonalLow::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -203,7 +209,7 @@ double TetragonalLowOps::_calcMisoQuat(const QuatType quatsym[8], int numsym, Qu
 
 double TetragonalLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(TetraQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -214,7 +220,7 @@ float TetragonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TetraQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -223,40 +229,40 @@ float TetragonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n
 
 QuatType TetragonalLowOps::getQuatSymOp(int32_t i) const
 {
-  return TetraQuatSym[i];
+  return TetragonalLow::QuatSym[i];
 }
 
 void TetragonalLowOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = TetraRodSym[i][0];
-  r[1] = TetraRodSym[i][1];
-  r[2] = TetraRodSym[i][2];
+  r[0] = TetragonalLow::RodSym[i][0];
+  r[1] = TetragonalLow::RodSym[i][1];
+  r[2] = TetragonalLow::RodSym[i][2];
 }
 
 void TetragonalLowOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = TetraMatSym[i][0][0];
-  g[0][1] = TetraMatSym[i][0][1];
-  g[0][2] = TetraMatSym[i][0][2];
-  g[1][0] = TetraMatSym[i][1][0];
-  g[1][1] = TetraMatSym[i][1][1];
-  g[1][2] = TetraMatSym[i][1][2];
-  g[2][0] = TetraMatSym[i][2][0];
-  g[2][1] = TetraMatSym[i][2][1];
-  g[2][2] = TetraMatSym[i][2][2];
+  g[0][0] = TetragonalLow::MatSym[i][0][0];
+  g[0][1] = TetragonalLow::MatSym[i][0][1];
+  g[0][2] = TetragonalLow::MatSym[i][0][2];
+  g[1][0] = TetragonalLow::MatSym[i][1][0];
+  g[1][1] = TetragonalLow::MatSym[i][1][1];
+  g[1][2] = TetragonalLow::MatSym[i][1][2];
+  g[2][0] = TetragonalLow::MatSym[i][2][0];
+  g[2][1] = TetragonalLow::MatSym[i][2][1];
+  g[2][2] = TetragonalLow::MatSym[i][2][2];
 }
 
 void TetragonalLowOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = TetraMatSym[i][0][0];
-  g[0][1] = TetraMatSym[i][0][1];
-  g[0][2] = TetraMatSym[i][0][2];
-  g[1][0] = TetraMatSym[i][1][0];
-  g[1][1] = TetraMatSym[i][1][1];
-  g[1][2] = TetraMatSym[i][1][2];
-  g[2][0] = TetraMatSym[i][2][0];
-  g[2][1] = TetraMatSym[i][2][1];
-  g[2][2] = TetraMatSym[i][2][2];
+  g[0][0] = TetragonalLow::MatSym[i][0][0];
+  g[0][1] = TetragonalLow::MatSym[i][0][1];
+  g[0][2] = TetragonalLow::MatSym[i][0][2];
+  g[1][0] = TetragonalLow::MatSym[i][1][0];
+  g[1][1] = TetragonalLow::MatSym[i][1][1];
+  g[1][2] = TetragonalLow::MatSym[i][1][2];
+  g[2][0] = TetragonalLow::MatSym[i][2][0];
+  g[2][1] = TetragonalLow::MatSym[i][2][1];
+  g[2][2] = TetragonalLow::MatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -265,7 +271,7 @@ void TetragonalLowOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType TetragonalLowOps::getODFFZRod(const OrientationType& rod) const
 {
   int  numsym = 4;
-  return _calcRodNearestOrigin(TetraRodSym, numsym, rod);
+  return _calcRodNearestOrigin(TetragonalLow::RodSym, numsym, rod);
 }
 // -----------------------------------------------------------------------------
 //
@@ -274,7 +280,7 @@ OrientationType TetragonalLowOps::getMDFFZRod(const OrientationType& inRod) cons
 {
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
 
-  OrientationType rod = _calcRodNearestOrigin(TetraRodSym, 4, inRod);
+  OrientationType rod = _calcRodNearestOrigin(TetragonalLow::RodSym, 4, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
   FZn1 = std::fabs(ax[0]);
@@ -290,13 +296,13 @@ OrientationType TetragonalLowOps::getMDFFZRod(const OrientationType& inRod) cons
 // -----------------------------------------------------------------------------
 QuatType TetragonalLowOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(TetraQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2);
 }
 QuatF TetragonalLowOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(TetraQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -312,15 +318,15 @@ int TetragonalLowOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::TetraDim1InitValue;
-  dim[1] = Detail::TetraDim2InitValue;
-  dim[2] = Detail::TetraDim3InitValue;
-  step[0] = Detail::TetraDim1StepValue;
-  step[1] = Detail::TetraDim2StepValue;
-  step[2] = Detail::TetraDim3StepValue;
-  bins[0] = 72.0;
-  bins[1] = 72.0;
-  bins[2] = 18.0;
+  dim[0] = TetragonalLow::OdfDimInitValue[0];
+  dim[1] = TetragonalLow::OdfDimInitValue[1];
+  dim[2] = TetragonalLow::OdfDimInitValue[2];
+  step[0] = TetragonalLow::OdfDimStepValue[0];
+  step[1] = TetragonalLow::OdfDimStepValue[1];
+  step[2] = TetragonalLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TetragonalLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TetragonalLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TetragonalLow::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -328,25 +334,24 @@ int TetragonalLowOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TetragonalLowOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType TetragonalLowOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::TetraDim1InitValue;
-  init[1] = Detail::TetraDim2InitValue;
-  init[2] = Detail::TetraDim3InitValue;
-  step[0] = Detail::TetraDim1StepValue;
-  step[1] = Detail::TetraDim2StepValue;
-  step[2] = Detail::TetraDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 72);
-  phi[2] = static_cast<int32_t>(choose / (72 * 72));
+  init[0] = TetragonalLow::OdfDimInitValue[0];
+  init[1] = TetragonalLow::OdfDimInitValue[1];
+  init[2] = TetragonalLow::OdfDimInitValue[2];
+  step[0] = TetragonalLow::OdfDimStepValue[0];
+  step[1] = TetragonalLow::OdfDimStepValue[1];
+  step[2] = TetragonalLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TetragonalLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TetragonalLow::OdfNumBins[0]) % TetragonalLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TetragonalLow::OdfNumBins[0] * TetragonalLow::OdfNumBins[1]));
 
-
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -360,33 +365,33 @@ OrientationType TetragonalLowOps::determineEulerAngles(uint64_t seed, int choose
 // -----------------------------------------------------------------------------
 OrientationType TetragonalLowOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(TetragonalLow::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = TetraQuatSym[symOp] * quat;
+  QuatType qc = TetragonalLow::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TetragonalLowOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType TetragonalLowOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = Detail::TetraDim1InitValue;
-  init[1] = Detail::TetraDim2InitValue;
-  init[2] = Detail::TetraDim3InitValue;
-  step[0] = Detail::TetraDim1StepValue;
-  step[1] = Detail::TetraDim2StepValue;
-  step[2] = Detail::TetraDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 72);
-  phi[2] = static_cast<int32_t>(choose / (72 * 72));
+  init[0] = TetragonalLow::OdfDimInitValue[0];
+  init[1] = TetragonalLow::OdfDimInitValue[1];
+  init[2] = TetragonalLow::OdfDimInitValue[2];
+  step[0] = TetragonalLow::OdfDimStepValue[0];
+  step[1] = TetragonalLow::OdfDimStepValue[1];
+  step[2] = TetragonalLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TetragonalLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TetragonalLow::OdfNumBins[0]) % TetragonalLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TetragonalLow::OdfNumBins[0] * TetragonalLow::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -404,15 +409,15 @@ int TetragonalLowOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = Detail::TetraDim1InitValue;
-  dim[1] = Detail::TetraDim2InitValue;
-  dim[2] = Detail::TetraDim3InitValue;
-  step[0] = Detail::TetraDim1StepValue;
-  step[1] = Detail::TetraDim2StepValue;
-  step[2] = Detail::TetraDim3StepValue;
-  bins[0] = 72.0f;
-  bins[1] = 72.0f;
-  bins[2] = 18.0f;
+  dim[0] = TetragonalLow::OdfDimInitValue[0];
+  dim[1] = TetragonalLow::OdfDimInitValue[1];
+  dim[2] = TetragonalLow::OdfDimInitValue[2];
+  step[0] = TetragonalLow::OdfDimStepValue[0];
+  step[1] = TetragonalLow::OdfDimStepValue[1];
+  step[2] = TetragonalLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TetragonalLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TetragonalLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TetragonalLow::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -438,22 +443,22 @@ void TetragonalLowOps::getSchmidFactorAndSS(double load[3], double plane[3], dou
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < TetragonalLow::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = TetraMatSym[i][2][0] * plane[0] + TetraMatSym[i][2][1] * plane[1] + TetraMatSym[i][2][2] * plane[2];
+    slipPlane[2] = TetragonalLow::MatSym[i][2][0] * plane[0] + TetragonalLow::MatSym[i][2][1] * plane[1] + TetragonalLow::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = TetraMatSym[i][0][0] * plane[0] + TetraMatSym[i][0][1] * plane[1] + TetraMatSym[i][0][2] * plane[2];
-      slipPlane[1] = TetraMatSym[i][1][0] * plane[0] + TetraMatSym[i][1][1] * plane[1] + TetraMatSym[i][1][2] * plane[2];
+      slipPlane[0] = TetragonalLow::MatSym[i][0][0] * plane[0] + TetragonalLow::MatSym[i][0][1] * plane[1] + TetragonalLow::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = TetragonalLow::MatSym[i][1][0] * plane[0] + TetragonalLow::MatSym[i][1][1] * plane[1] + TetragonalLow::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = TetraMatSym[i][0][0] * direction[0] + TetraMatSym[i][0][1] * direction[1] + TetraMatSym[i][0][2] * direction[2];
-      slipDirection[1] = TetraMatSym[i][1][0] * direction[0] + TetraMatSym[i][1][1] * direction[1] + TetraMatSym[i][1][2] * direction[2];
-      slipDirection[2] = TetraMatSym[i][2][0] * direction[0] + TetraMatSym[i][2][1] * direction[1] + TetraMatSym[i][2][2] * direction[2];
+      slipDirection[0] = TetragonalLow::MatSym[i][0][0] * direction[0] + TetragonalLow::MatSym[i][0][1] * direction[1] + TetragonalLow::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = TetragonalLow::MatSym[i][1][0] * direction[0] + TetragonalLow::MatSym[i][1][1] * direction[1] + TetragonalLow::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = TetragonalLow::MatSym[i][2][0] * direction[0] + TetragonalLow::MatSym[i][2][1] * direction[1] + TetragonalLow::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -493,8 +498,7 @@ double TetragonalLowOps::getF7(const QuatType& q1, const QuatType& q2, double LD
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
-{
+
   namespace TetragonalLow
   {
     class GenerateSphereCoordsImpl
@@ -562,29 +566,28 @@ namespace Detail
         }
 #endif
     };
-  }
-}
+    } // namespace TetragonalLow
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void TetragonalLowOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
-{
-  size_t nOrientations = eulers->getNumberOfTuples();
+    // -----------------------------------------------------------------------------
+    //
+    // -----------------------------------------------------------------------------
+    void TetragonalLowOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatArrayType* xyz001, FloatArrayType* xyz011, FloatArrayType* xyz111) const
+    {
+      size_t nOrientations = eulers->getNumberOfTuples();
 
-  // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::TetragonalLow::symSize0)
-  {
-    xyz001->resizeTuples(nOrientations * Detail::TetragonalLow::symSize0 * 3);
-  }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::TetragonalLow::symSize1)
-  {
-    xyz011->resizeTuples(nOrientations * Detail::TetragonalLow::symSize1 * 3);
-  }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::TetragonalLow::symSize2)
-  {
-    xyz111->resizeTuples(nOrientations * Detail::TetragonalLow::symSize2 * 3);
-  }
+      // Sanity Check the size of the arrays
+      if(xyz001->getNumberOfTuples() < nOrientations * TetragonalLow::symSize0)
+      {
+        xyz001->resizeTuples(nOrientations * TetragonalLow::symSize0 * 3);
+      }
+      if(xyz011->getNumberOfTuples() < nOrientations * TetragonalLow::symSize1)
+      {
+        xyz011->resizeTuples(nOrientations * TetragonalLow::symSize1 * 3);
+      }
+      if(xyz111->getNumberOfTuples() < nOrientations * TetragonalLow::symSize2)
+      {
+        xyz111->resizeTuples(nOrientations * TetragonalLow::symSize2 * 3);
+      }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   tbb::task_scheduler_init init;
@@ -594,17 +597,15 @@ void TetragonalLowOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Fl
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::TetragonalLow::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), TetragonalLow::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::TetragonalLow::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    TetragonalLow::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
-
-}
+    }
 
 // -----------------------------------------------------------------------------
 //
@@ -644,7 +645,7 @@ SIMPL::Rgb TetragonalLowOps::generateIPFColor(double phi1, double phi, double ph
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < TetragonalLow::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -711,9 +712,9 @@ SIMPL::Rgb TetragonalLowOps::generateIPFColor(double phi1, double phi, double ph
 // -----------------------------------------------------------------------------
 SIMPL::Rgb TetragonalLowOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * TetraDim1InitValue;
-  double range2 = 2.0f * TetraDim2InitValue;
-  double range3 = 2.0f * TetraDim3InitValue;
+  double range1 = 2.0f * TetragonalLow::OdfDimInitValue[0];
+  double range2 = 2.0f * TetragonalLow::OdfDimInitValue[1];
+  double range3 = 2.0f * TetragonalLow::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -750,11 +751,11 @@ QVector<UInt8ArrayType::Pointer> TetragonalLowOps::generatePoleFigure(PoleFigure
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalLow::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * TetragonalLow::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalLow::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * TetragonalLow::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalLow::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * TetragonalLow::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
@@ -147,60 +147,6 @@ QString TetragonalLowOps::getSymmetryName() const
   return "Tetragonal 4/m";;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD TetragonalLowOps::calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-  QuatType qc;
-
-  QuatType qr = q1 * (q2.conjugate());
-  OrientationType axisAngle;
-  for (int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1.0;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1.0;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD TetragonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2);

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
@@ -150,17 +150,16 @@ QString TetragonalLowOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TetragonalLowOps::_calcMisoQuat(const QuatType quatsym[8], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TetragonalLowOps::calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
   QuatType qc;
 
   QuatType qr = q1 * (q2.conjugate());
-
+  OrientationType axisAngle;
   for (int i = 0; i < numsym; i++)
   {
     qc = quatsym[i] * qr;
@@ -174,57 +173,46 @@ double TetragonalLowOps::_calcMisoQuat(const QuatType quatsym[8], int numsym, Qu
       qc.w() = 1.0;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double TetragonalLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TetragonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float TetragonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF TetragonalLowOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(TetragonalLow::QuatSym, TetragonalLow::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType TetragonalLowOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.cpp
@@ -34,9 +34,10 @@
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 
+#include "TetragonalLowOps.h"
+
 #include <memory>
 
-#include "TetragonalLowOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -668,7 +669,7 @@ SIMPL::Rgb TetragonalLowOps::generateRodriguesColor(double r1, double r2, double
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> TetragonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> TetragonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<100>");
@@ -781,7 +782,7 @@ QVector<UInt8ArrayType::Pointer> TetragonalLowOps::generatePoleFigure(PoleFigure
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
     TetragonalLowOps();
     ~TetragonalLowOps() override;
 
-    static const int k_OdfSize = 93312;
-    static const int k_MdfSize = 93312;
-    static const int k_NumSymQuats = 4;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -110,6 +106,12 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -127,9 +129,9 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.h
@@ -112,8 +112,21 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -199,7 +212,15 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[8], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TetragonalLowOps(const TetragonalLowOps&) = delete; // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.h
@@ -212,15 +212,6 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TetragonalLowOps(const TetragonalLowOps&) = delete; // Copy Constructor Not Implemented
@@ -228,7 +219,6 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
     TetragonalLowOps& operator=(const TetragonalLowOps&) = delete; // Copy Assignment Not Implemented
     TetragonalLowOps& operator=(TetragonalLowOps&&) = delete;      // Move Assignment Not Implemented
 
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/TetragonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalLowOps.h
@@ -203,7 +203,7 @@ class OrientationLib_EXPORT TetragonalLowOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/TetragonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.cpp
@@ -161,64 +161,11 @@ QString TetragonalOps::getSymmetryName() const
 }
 
 // -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD TetragonalOps::calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for(int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD TetragonalOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2);
 }
+
 // -----------------------------------------------------------------------------
 OrientationF TetragonalOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
 
@@ -232,10 +179,6 @@ OrientationF TetragonalOps::calculateMisorientation(const QuatF& q1f, const Quat
 QuatType TetragonalOps::getQuatSymOp(int32_t i) const
 {
   return TetragonalHigh::QuatSym[i];
-  //  q.x = TetragonalHigh::QuatSym[i][0];
-  //  q.y = TetragonalHigh::QuatSym[i][1];
-  //  q.z = TetragonalHigh::QuatSym[i][2];
-  //  q.w = TetragonalHigh::QuatSym[i][3];
 }
 
 void TetragonalOps::getRodSymOp(int i, double* r) const

--- a/Source/OrientationLib/LaueOps/TetragonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.cpp
@@ -57,53 +57,53 @@
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 #include "OrientationLib/Utilities/PoleFigureUtilities.h"
 
-namespace Detail
-{
-
-static const double TetraDim1InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double TetraDim2InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0));
-static const double TetraDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_PiOver4)-sinf((SIMPLib::Constants::k_PiOver4)))), (1.0f / 3.0));
-static const double TetraDim1StepValue = TetraDim1InitValue / 18.0f;
-static const double TetraDim2StepValue = TetraDim2InitValue / 18.0f;
-static const double TetraDim3StepValue = TetraDim3InitValue / 9.0f;
-
-static const double TetraRodSym[8][3] = {{0.0, 0.0, 0.0},  {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0},           {0.0, 0.0, 10000000000.0},
-                                         {0.0, 0.0, -1.0}, {0.0, 0.0, 1.0},           {10000000000.0, 10000000000.0, 0.0}, {-10000000000.0, 10000000000.0, 0.0}};
-
 namespace TetragonalHigh
 {
+static const std::array<size_t, 3> OdfNumBins = {36, 36, 18}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver2)-sinf((SIMPLib::Constants::k_PiOver2)))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_PiOver4)-sinf((SIMPLib::Constants::k_PiOver4)))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
+static const double RodSym[8][3] = {{0.0, 0.0, 0.0},  {10000000000.0, 0.0, 0.0}, {0.0, 10000000000.0, 0.0},           {0.0, 0.0, 10000000000.0},
+                                    {0.0, 0.0, -1.0}, {0.0, 0.0, 1.0},           {10000000000.0, 10000000000.0, 0.0}, {-10000000000.0, 10000000000.0, 0.0}};
+
 static const int symSize0 = 2;
 static const int symSize1 = 4;
 static const int symSize2 = 4;
+
+static const int k_OdfSize = 23328;
+static const int k_MdfSize = 23328;
+static const int k_NumSymQuats = 8;
+
+static const QuatType QuatSym[8] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),
+                                    QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
+                                    QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
+                                    QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
+                                    QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, -SIMPLib::Constants::k_1OverRoot2),
+                                    QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
+                                    QuatType(SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
+                                    QuatType(-SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000)};
+
+static const double MatSym[8][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                       {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                       {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
+
+                                       {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
+
 } // namespace TetragonalHigh
-} // namespace Detail
-
-static const QuatType TetraQuatSym[8] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000),
-                                         QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
-                                         QuatType(0.000000000, 1.000000000, 0.000000000, 0.000000000),
-                                         QuatType(0.000000000, 0.000000000, 1.000000000, 0.000000000),
-                                         QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, -SIMPLib::Constants::k_1OverRoot2),
-                                         QuatType(0.000000000, 0.000000000, SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2),
-                                         QuatType(SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
-                                         QuatType(-SIMPLib::Constants::k_1OverRoot2, SIMPLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000)};
-
-static const double TetraMatSym[8][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                            {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                            {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                            {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
-
-                                            {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
-
-using namespace Detail;
 
 // -----------------------------------------------------------------------------
 //
@@ -128,7 +128,7 @@ bool TetragonalOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int TetragonalOps::getODFSize() const
 {
-  return k_OdfSize;
+  return TetragonalHigh::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -136,7 +136,7 @@ int TetragonalOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int TetragonalOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return TetragonalHigh::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -144,7 +144,13 @@ int TetragonalOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int TetragonalOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return TetragonalHigh::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> TetragonalOps::getOdfNumBins() const
+{
+  return TetragonalHigh::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -217,7 +223,7 @@ double TetragonalOps::_calcMisoQuat(const QuatType quatsym[8], int numsym, QuatT
 
 double TetragonalOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(TetraQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 // -----------------------------------------------------------------------------
 float TetragonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
@@ -227,7 +233,7 @@ float TetragonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f,
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TetraQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -236,44 +242,44 @@ float TetragonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f,
 
 QuatType TetragonalOps::getQuatSymOp(int32_t i) const
 {
-  return TetraQuatSym[i];
-  //  q.x = TetraQuatSym[i][0];
-  //  q.y = TetraQuatSym[i][1];
-  //  q.z = TetraQuatSym[i][2];
-  //  q.w = TetraQuatSym[i][3];
+  return TetragonalHigh::QuatSym[i];
+  //  q.x = TetragonalHigh::QuatSym[i][0];
+  //  q.y = TetragonalHigh::QuatSym[i][1];
+  //  q.z = TetragonalHigh::QuatSym[i][2];
+  //  q.w = TetragonalHigh::QuatSym[i][3];
 }
 
 void TetragonalOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = TetraRodSym[i][0];
-  r[1] = TetraRodSym[i][1];
-  r[2] = TetraRodSym[i][2];
+  r[0] = TetragonalHigh::RodSym[i][0];
+  r[1] = TetragonalHigh::RodSym[i][1];
+  r[2] = TetragonalHigh::RodSym[i][2];
 }
 
 void TetragonalOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = TetraMatSym[i][0][0];
-  g[0][1] = TetraMatSym[i][0][1];
-  g[0][2] = TetraMatSym[i][0][2];
-  g[1][0] = TetraMatSym[i][1][0];
-  g[1][1] = TetraMatSym[i][1][1];
-  g[1][2] = TetraMatSym[i][1][2];
-  g[2][0] = TetraMatSym[i][2][0];
-  g[2][1] = TetraMatSym[i][2][1];
-  g[2][2] = TetraMatSym[i][2][2];
+  g[0][0] = TetragonalHigh::MatSym[i][0][0];
+  g[0][1] = TetragonalHigh::MatSym[i][0][1];
+  g[0][2] = TetragonalHigh::MatSym[i][0][2];
+  g[1][0] = TetragonalHigh::MatSym[i][1][0];
+  g[1][1] = TetragonalHigh::MatSym[i][1][1];
+  g[1][2] = TetragonalHigh::MatSym[i][1][2];
+  g[2][0] = TetragonalHigh::MatSym[i][2][0];
+  g[2][1] = TetragonalHigh::MatSym[i][2][1];
+  g[2][2] = TetragonalHigh::MatSym[i][2][2];
 }
 
 void TetragonalOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = TetraMatSym[i][0][0];
-  g[0][1] = TetraMatSym[i][0][1];
-  g[0][2] = TetraMatSym[i][0][2];
-  g[1][0] = TetraMatSym[i][1][0];
-  g[1][1] = TetraMatSym[i][1][1];
-  g[1][2] = TetraMatSym[i][1][2];
-  g[2][0] = TetraMatSym[i][2][0];
-  g[2][1] = TetraMatSym[i][2][1];
-  g[2][2] = TetraMatSym[i][2][2];
+  g[0][0] = TetragonalHigh::MatSym[i][0][0];
+  g[0][1] = TetragonalHigh::MatSym[i][0][1];
+  g[0][2] = TetragonalHigh::MatSym[i][0][2];
+  g[1][0] = TetragonalHigh::MatSym[i][1][0];
+  g[1][1] = TetragonalHigh::MatSym[i][1][1];
+  g[1][2] = TetragonalHigh::MatSym[i][1][2];
+  g[2][0] = TetragonalHigh::MatSym[i][2][0];
+  g[2][1] = TetragonalHigh::MatSym[i][2][1];
+  g[2][2] = TetragonalHigh::MatSym[i][2][2];
 }
 
 // -----------------------------------------------------------------------------
@@ -283,7 +289,7 @@ OrientationType TetragonalOps::getODFFZRod(const OrientationType& rod) const
 {
   int  numsym = 8;
 
-  return _calcRodNearestOrigin(TetraRodSym, numsym, rod);
+  return _calcRodNearestOrigin(TetragonalHigh::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -293,7 +299,7 @@ OrientationType TetragonalOps::getMDFFZRod(const OrientationType& inRod) const
 {
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
 
-  OrientationType rod = _calcRodNearestOrigin(TetraRodSym, 8, inRod);
+  OrientationType rod = _calcRodNearestOrigin(TetragonalHigh::RodSym, 8, inRod);
 
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
@@ -310,13 +316,13 @@ OrientationType TetragonalOps::getMDFFZRod(const OrientationType& inRod) const
 // -----------------------------------------------------------------------------
 QuatType TetragonalOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(TetraQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2);
 }
 QuatF TetragonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(TetraQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -332,15 +338,15 @@ int TetragonalOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TetraDim1InitValue;
-  dim[1] = TetraDim2InitValue;
-  dim[2] = TetraDim3InitValue;
-  step[0] = TetraDim1StepValue;
-  step[1] = TetraDim2StepValue;
-  step[2] = TetraDim3StepValue;
-  bins[0] = 36.0;
-  bins[1] = 36.0;
-  bins[2] = 18.0;
+  dim[0] = TetragonalHigh::OdfDimInitValue[0];
+  dim[1] = TetragonalHigh::OdfDimInitValue[1];
+  dim[2] = TetragonalHigh::OdfDimInitValue[2];
+  step[0] = TetragonalHigh::OdfDimStepValue[0];
+  step[1] = TetragonalHigh::OdfDimStepValue[1];
+  step[2] = TetragonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TetragonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TetragonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TetragonalHigh::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -348,24 +354,24 @@ int TetragonalOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TetragonalOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType TetragonalOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TetraDim1InitValue;
-  init[1] = TetraDim2InitValue;
-  init[2] = TetraDim3InitValue;
-  step[0] = TetraDim1StepValue;
-  step[1] = TetraDim2StepValue;
-  step[2] = TetraDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = TetragonalHigh::OdfDimInitValue[0];
+  init[1] = TetragonalHigh::OdfDimInitValue[1];
+  init[2] = TetragonalHigh::OdfDimInitValue[2];
+  step[0] = TetragonalHigh::OdfDimStepValue[0];
+  step[1] = TetragonalHigh::OdfDimStepValue[1];
+  step[2] = TetragonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TetragonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TetragonalHigh::OdfNumBins[0]) % TetragonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TetragonalHigh::OdfNumBins[0] * TetragonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -380,33 +386,33 @@ OrientationType TetragonalOps::determineEulerAngles(uint64_t seed, int choose) c
 // -----------------------------------------------------------------------------
 OrientationType TetragonalOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(TetragonalHigh::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = TetraQuatSym[symOp] * quat;
+  QuatType qc = TetragonalHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TetragonalOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType TetragonalOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TetraDim1InitValue;
-  init[1] = TetraDim2InitValue;
-  init[2] = TetraDim3InitValue;
-  step[0] = TetraDim1StepValue;
-  step[1] = TetraDim2StepValue;
-  step[2] = TetraDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = TetragonalHigh::OdfDimInitValue[0];
+  init[1] = TetragonalHigh::OdfDimInitValue[1];
+  init[2] = TetragonalHigh::OdfDimInitValue[2];
+  step[0] = TetragonalHigh::OdfDimStepValue[0];
+  step[1] = TetragonalHigh::OdfDimStepValue[1];
+  step[2] = TetragonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TetragonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TetragonalHigh::OdfNumBins[0]) % TetragonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TetragonalHigh::OdfNumBins[0] * TetragonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -424,15 +430,15 @@ int TetragonalOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TetraDim1InitValue;
-  dim[1] = TetraDim2InitValue;
-  dim[2] = TetraDim3InitValue;
-  step[0] = TetraDim1StepValue;
-  step[1] = TetraDim2StepValue;
-  step[2] = TetraDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 18.0f;
+  dim[0] = TetragonalHigh::OdfDimInitValue[0];
+  dim[1] = TetragonalHigh::OdfDimInitValue[1];
+  dim[2] = TetragonalHigh::OdfDimInitValue[2];
+  step[0] = TetragonalHigh::OdfDimStepValue[0];
+  step[1] = TetragonalHigh::OdfDimStepValue[1];
+  step[2] = TetragonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TetragonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TetragonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TetragonalHigh::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -458,22 +464,22 @@ void TetragonalOps::getSchmidFactorAndSS(double load[3], double plane[3], double
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < TetragonalHigh::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = TetraMatSym[i][2][0] * plane[0] + TetraMatSym[i][2][1] * plane[1] + TetraMatSym[i][2][2] * plane[2];
+    slipPlane[2] = TetragonalHigh::MatSym[i][2][0] * plane[0] + TetragonalHigh::MatSym[i][2][1] * plane[1] + TetragonalHigh::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = TetraMatSym[i][0][0] * plane[0] + TetraMatSym[i][0][1] * plane[1] + TetraMatSym[i][0][2] * plane[2];
-      slipPlane[1] = TetraMatSym[i][1][0] * plane[0] + TetraMatSym[i][1][1] * plane[1] + TetraMatSym[i][1][2] * plane[2];
+      slipPlane[0] = TetragonalHigh::MatSym[i][0][0] * plane[0] + TetragonalHigh::MatSym[i][0][1] * plane[1] + TetragonalHigh::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = TetragonalHigh::MatSym[i][1][0] * plane[0] + TetragonalHigh::MatSym[i][1][1] * plane[1] + TetragonalHigh::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = TetraMatSym[i][0][0] * direction[0] + TetraMatSym[i][0][1] * direction[1] + TetraMatSym[i][0][2] * direction[2];
-      slipDirection[1] = TetraMatSym[i][1][0] * direction[0] + TetraMatSym[i][1][1] * direction[1] + TetraMatSym[i][1][2] * direction[2];
-      slipDirection[2] = TetraMatSym[i][2][0] * direction[0] + TetraMatSym[i][2][1] * direction[1] + TetraMatSym[i][2][2] * direction[2];
+      slipDirection[0] = TetragonalHigh::MatSym[i][0][0] * direction[0] + TetragonalHigh::MatSym[i][0][1] * direction[1] + TetragonalHigh::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = TetragonalHigh::MatSym[i][1][0] * direction[0] + TetragonalHigh::MatSym[i][1][1] * direction[1] + TetragonalHigh::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = TetragonalHigh::MatSym[i][2][0] * direction[0] + TetragonalHigh::MatSym[i][2][1] * direction[1] + TetragonalHigh::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -512,81 +518,79 @@ double TetragonalOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3]
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
+namespace TetragonalHigh
 {
-  namespace TetragonalHigh
+class GenerateSphereCoordsImpl
+{
+  FloatArrayType* m_Eulers;
+  FloatArrayType* m_xyz001;
+  FloatArrayType* m_xyz011;
+  FloatArrayType* m_xyz111;
+
+public:
+  GenerateSphereCoordsImpl(FloatArrayType* eulerAngles, FloatArrayType* xyz001Coords, FloatArrayType* xyz011Coords, FloatArrayType* xyz111Coords)
+  : m_Eulers(eulerAngles)
+  , m_xyz001(xyz001Coords)
+  , m_xyz011(xyz011Coords)
+  , m_xyz111(xyz111Coords)
   {
-    class GenerateSphereCoordsImpl
+  }
+  virtual ~GenerateSphereCoordsImpl() = default;
+
+  void generate(size_t start, size_t end) const
+  {
+    double g[3][3];
+    double gTranpose[3][3];
+    double direction[3] = {0.0, 0.0, 0.0};
+
+    // Geneate all the Coordinates
+    for(size_t i = start; i < end; ++i)
     {
-        FloatArrayType* m_Eulers;
-        FloatArrayType* m_xyz001;
-        FloatArrayType* m_xyz011;
-        FloatArrayType* m_xyz111;
+      OrientationType eu(m_Eulers->getValue(i * 3), m_Eulers->getValue(i * 3 + 1), m_Eulers->getValue(i * 3 + 2));
+      OrientationTransformation::eu2om<OrientationType, OrientationType>(eu).toGMatrix(g);
 
-      public:
-        GenerateSphereCoordsImpl(FloatArrayType* eulerAngles, FloatArrayType* xyz001Coords, FloatArrayType* xyz011Coords, FloatArrayType* xyz111Coords) :
-          m_Eulers(eulerAngles),
-          m_xyz001(xyz001Coords),
-          m_xyz011(xyz011Coords),
-          m_xyz111(xyz111Coords)
-        {}
-        virtual ~GenerateSphereCoordsImpl() = default;
+      MatrixMath::Transpose3x3(g, gTranpose);
 
-        void generate(size_t start, size_t end) const
-        {
-          double g[3][3];
-          double gTranpose[3][3];
-          double direction[3] = {0.0, 0.0, 0.0};
+      // -----------------------------------------------------------------------------
+      // 001 Family
+      direction[0] = 0.0;
+      direction[1] = 0.0;
+      direction[2] = 1.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 6));
+      MatrixMath::Copy3x1(m_xyz001->getPointer(i * 6), m_xyz001->getPointer(i * 6 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 6 + 3), -1.0f);
 
-          // Geneate all the Coordinates
-          for(size_t i = start; i < end; ++i)
-          {
-            OrientationType eu(m_Eulers->getValue(i * 3), m_Eulers->getValue(i * 3 + 1), m_Eulers->getValue(i * 3 + 2));
-            OrientationTransformation::eu2om<OrientationType, OrientationType>(eu).toGMatrix(g);
+      // -----------------------------------------------------------------------------
+      // 011 Family
+      direction[0] = 1.0;
+      direction[1] = 0.0;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 12));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 12), m_xyz011->getPointer(i * 12 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 12 + 3), -1.0f);
+      direction[0] = 0.0;
+      direction[1] = 1.0;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 12 + 6));
+      MatrixMath::Copy3x1(m_xyz011->getPointer(i * 12 + 6), m_xyz011->getPointer(i * 12 + 9));
+      MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 12 + 9), -1.0f);
 
-            MatrixMath::Transpose3x3(g, gTranpose);
-
-            // -----------------------------------------------------------------------------
-            // 001 Family
-            direction[0] = 0.0;
-            direction[1] = 0.0;
-            direction[2] = 1.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz001->getPointer(i * 6));
-            MatrixMath::Copy3x1(m_xyz001->getPointer(i * 6), m_xyz001->getPointer(i * 6 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz001->getPointer(i * 6 + 3), -1.0f);
-
-            // -----------------------------------------------------------------------------
-            // 011 Family
-            direction[0] = 1.0;
-            direction[1] = 0.0;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 12));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 12), m_xyz011->getPointer(i * 12 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 12 + 3), -1.0f);
-            direction[0] = 0.0;
-            direction[1] = 1.0;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz011->getPointer(i * 12 + 6));
-            MatrixMath::Copy3x1(m_xyz011->getPointer(i * 12 + 6), m_xyz011->getPointer(i * 12 + 9));
-            MatrixMath::Multiply3x1withConstant(m_xyz011->getPointer(i * 12 + 9), -1.0f);
-
-            // -----------------------------------------------------------------------------
-            // 111 Family
-            direction[0] = SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = 0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 12));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 12), m_xyz111->getPointer(i * 12 + 3));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 12 + 3), -1.0f);
-            direction[0] = -SIMPLib::Constants::k_1OverRoot2;
-            direction[1] = SIMPLib::Constants::k_1OverRoot2;
-            direction[2] = 0.0;
-            MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 12 + 6));
-            MatrixMath::Copy3x1(m_xyz111->getPointer(i * 12 + 6), m_xyz111->getPointer(i * 12 + 9));
-            MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 12 + 9), -1.0f);
-          }
-
-        }
+      // -----------------------------------------------------------------------------
+      // 111 Family
+      direction[0] = SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = 0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 12));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 12), m_xyz111->getPointer(i * 12 + 3));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 12 + 3), -1.0f);
+      direction[0] = -SIMPLib::Constants::k_1OverRoot2;
+      direction[1] = SIMPLib::Constants::k_1OverRoot2;
+      direction[2] = 0.0;
+      MatrixMath::Multiply3x3with3x1(gTranpose, direction, m_xyz111->getPointer(i * 12 + 6));
+      MatrixMath::Copy3x1(m_xyz111->getPointer(i * 12 + 6), m_xyz111->getPointer(i * 12 + 9));
+      MatrixMath::Multiply3x1withConstant(m_xyz111->getPointer(i * 12 + 9), -1.0f);
+    }
+  }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
         void operator()(const tbb::blocked_range<size_t>& r) const
@@ -594,9 +598,8 @@ namespace Detail
           generate(r.begin(), r.end());
         }
 #endif
-    };
-  }
-}
+};
+} // namespace TetragonalHigh
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -605,17 +608,17 @@ void TetragonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Float
   size_t nOrientations = eulers->getNumberOfTuples();
 
   // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::TetragonalHigh::symSize0)
+  if(xyz001->getNumberOfTuples() < nOrientations * TetragonalHigh::symSize0)
   {
-    xyz001->resizeTuples(nOrientations * Detail::TetragonalHigh::symSize0 * 3);
+    xyz001->resizeTuples(nOrientations * TetragonalHigh::symSize0 * 3);
   }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::TetragonalHigh::symSize1)
+  if(xyz011->getNumberOfTuples() < nOrientations * TetragonalHigh::symSize1)
   {
-    xyz011->resizeTuples(nOrientations * Detail::TetragonalHigh::symSize1 * 3);
+    xyz011->resizeTuples(nOrientations * TetragonalHigh::symSize1 * 3);
   }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::TetragonalHigh::symSize2)
+  if(xyz111->getNumberOfTuples() < nOrientations * TetragonalHigh::symSize2)
   {
-    xyz111->resizeTuples(nOrientations * Detail::TetragonalHigh::symSize2 * 3);
+    xyz111->resizeTuples(nOrientations * TetragonalHigh::symSize2 * 3);
   }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -626,13 +629,12 @@ void TetragonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Float
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::TetragonalHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), TetragonalHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::TetragonalHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    TetragonalHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
 
@@ -676,7 +678,7 @@ SIMPL::Rgb TetragonalOps::generateIPFColor(double phi1, double phi, double phi2,
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < TetragonalHigh::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -743,9 +745,9 @@ SIMPL::Rgb TetragonalOps::generateIPFColor(double phi1, double phi, double phi2,
 // -----------------------------------------------------------------------------
 SIMPL::Rgb TetragonalOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * TetraDim1InitValue;
-  double range2 = 2.0f * TetraDim2InitValue;
-  double range3 = 2.0f * TetraDim3InitValue;
+  double range1 = 2.0f * TetragonalHigh::OdfDimInitValue[0];
+  double range2 = 2.0f * TetragonalHigh::OdfDimInitValue[1];
+  double range3 = 2.0f * TetragonalHigh::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -782,11 +784,11 @@ QVector<UInt8ArrayType::Pointer> TetragonalOps::generatePoleFigure(PoleFigureCon
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * TetragonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * TetragonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::TetragonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * TetragonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/TetragonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.cpp
@@ -33,9 +33,10 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "TetragonalOps.h"
+
 #include <memory>
 
-#include "TetragonalOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -699,7 +700,7 @@ SIMPL::Rgb TetragonalOps::generateRodriguesColor(double r1, double r2, double r3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> TetragonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> TetragonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<100>");
@@ -812,7 +813,7 @@ QVector<UInt8ArrayType::Pointer> TetragonalOps::generatePoleFigure(PoleFigureCon
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/TetragonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.cpp
@@ -1,38 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <memory>
 
@@ -164,80 +163,70 @@ QString TetragonalOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TetragonalOps::_calcMisoQuat(const QuatType quatsym[8], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TetragonalOps::calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
-  for (int i = 0; i < numsym; i++)
+  for(int i = 0; i < numsym; i++)
   {
     qc = quatsym[i] * qr;
 
     if(qc.w() < -1)
     {
-      qc.w() = -1.0;
+      qc.w() = -1;
     }
     else if(qc.w() > 1)
     {
-      qc.w() = 1.0;
+      qc.w() = 1;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double TetragonalOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TetragonalOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2);
 }
 // -----------------------------------------------------------------------------
-float TetragonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF TetragonalOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(TetragonalHigh::QuatSym, TetragonalHigh::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType TetragonalOps::getQuatSymOp(int32_t i) const
@@ -1005,9 +994,9 @@ UInt8ArrayType::Pointer TetragonalOps::generateIPFTriangleLegend(int imageDim) c
 // -----------------------------------------------------------------------------
 SIMPL::Rgb TetragonalOps::generateMisorientationColor(const QuatType& q, const QuatType& refFrame) const
 {
-  Q_ASSERT(false);
+  throw std::out_of_range("TetragonalOps::generateMisorientationColor NOT Implemented");
 
-  double n1, n2, n3, w;
+  // double n1, n2, n3, w;
   double xo, xo1, xo2, xo3, x, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11;
   double yo, yo1, yo2, yo3, y, y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11;
   double zo, zo1, zo2, zo3, z, z1, z2, z3, z4, z5, z6, z7, z8, z9, z10, z11;
@@ -1017,16 +1006,17 @@ SIMPL::Rgb TetragonalOps::generateMisorientationColor(const QuatType& q, const Q
   QuatType q2 = refFrame;
 
   //get misorientation
-  w = getMisoQuat(q1, q2, n1, n2, n3);
-  n1 = fabs(n1);
-  n2 = fabs(n2);
-  n3 = fabs(n3);
+  OrientationD axisAngle = calculateMisorientation(q1, q2);
+
+  axisAngle[0] = fabs(axisAngle[0]);
+  axisAngle[1] = fabs(axisAngle[1]);
+  axisAngle[2] = fabs(axisAngle[2]);
 
   //eq c5.1
-  k = tan(w / 2.0);
-  xo = n1;
-  yo = n2;
-  zo = n3;
+  k = tan(axisAngle[3] / 2.0);
+  xo = axisAngle[0];
+  yo = axisAngle[1];
+  zo = axisAngle[2];
 
   OrientationType rod(xo, yo, zo, k);
   rod = getMDFFZRod(rod);

--- a/Source/OrientationLib/LaueOps/TetragonalOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.h
@@ -110,8 +110,21 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -197,7 +210,15 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[8], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TetragonalOps(const TetragonalOps&) = delete;  // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TetragonalOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.h
@@ -210,23 +210,12 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[8], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TetragonalOps(const TetragonalOps&) = delete;  // Copy Constructor Not Implemented
     TetragonalOps(TetragonalOps&&) = delete;       // Move Constructor Not Implemented
     TetragonalOps& operator=(const TetragonalOps&) = delete; // Copy Assignment Not Implemented
     TetragonalOps& operator=(TetragonalOps&&) = delete;      // Move Assignment Not Implemented
-
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/TetragonalOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.h
@@ -71,14 +71,8 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
 
     static Pointer New();
 
-
-
     TetragonalOps();
     ~TetragonalOps() override;
-
-    static const int k_OdfSize = 23328;
-    static const int k_MdfSize = 23328;
-    static const int k_NumSymQuats = 8;
 
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
@@ -110,6 +104,12 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -127,9 +127,9 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/TetragonalOps.h
+++ b/Source/OrientationLib/LaueOps/TetragonalOps.h
@@ -201,7 +201,7 @@ class OrientationLib_EXPORT TetragonalOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/TriclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.cpp
@@ -156,61 +156,6 @@ OrientationF TriclinicOps::calculateMisorientation(const QuatF& q1f, const QuatF
   return axisAngle;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD TriclinicOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for (int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1.0;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1.0;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 QuatType TriclinicOps::getQuatSymOp(int32_t i) const
 {
   return Triclinic::QuatSym[i];

--- a/Source/OrientationLib/LaueOps/TriclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.cpp
@@ -141,38 +141,33 @@ QString TriclinicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TriclinicOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TriclinicOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(Triclinic::QuatSym, Triclinic::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(Triclinic::QuatSym, Triclinic::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float TriclinicOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF TriclinicOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(Triclinic::QuatSym, Triclinic::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(Triclinic::QuatSym, Triclinic::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TriclinicOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TriclinicOps::calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
   for (int i = 0; i < numsym; i++)
@@ -188,37 +183,32 @@ double TriclinicOps::_calcMisoQuat(const QuatType quatsym[24], int numsym, QuatT
       qc.w() = 1.0;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
 QuatType TriclinicOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/TriclinicOps.cpp
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.cpp
@@ -33,9 +33,10 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "TriclinicOps.h"
+
 #include <memory>
 
-#include "TriclinicOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -658,7 +659,7 @@ SIMPL::Rgb TriclinicOps::generateRodriguesColor(double r1, double r2, double r3)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> TriclinicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> TriclinicOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<001>");
   QString label1 = QString("<100>");
@@ -770,7 +771,7 @@ QVector<UInt8ArrayType::Pointer> TriclinicOps::generatePoleFigure(PoleFigureConf
   UInt8ArrayType::Pointer image001 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label0, true);
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/TriclinicOps.h
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.h
@@ -75,10 +75,6 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
     TriclinicOps();
     ~TriclinicOps() override;
 
-    static const int k_OdfSize = 373248;
-    static const int k_MdfSize = 373248;
-    static const int k_NumSymQuats = 1;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -109,6 +105,12 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -126,9 +128,9 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/TriclinicOps.h
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.h
@@ -211,23 +211,12 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TriclinicOps(const TriclinicOps&) = delete;   // Copy Constructor Not Implemented
     TriclinicOps(TriclinicOps&&) = delete;        // Move Constructor Not Implemented
     TriclinicOps& operator=(const TriclinicOps&) = delete; // Copy Assignment Not Implemented
     TriclinicOps& operator=(TriclinicOps&&) = delete;      // Move Assignment Not Implemented
-
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/TriclinicOps.h
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.h
@@ -202,7 +202,7 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/TriclinicOps.h
+++ b/Source/OrientationLib/LaueOps/TriclinicOps.h
@@ -111,8 +111,21 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -198,7 +211,15 @@ class OrientationLib_EXPORT TriclinicOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[24], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[24], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TriclinicOps(const TriclinicOps&) = delete;   // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
@@ -153,15 +153,15 @@ QString TrigonalLowOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TrigonalLowOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TrigonalLowOps::calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
   for (int i = 0; i < numsym; i++)
@@ -177,57 +177,47 @@ double TrigonalLowOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, Quat
       qc.w() = 1.0;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double TrigonalLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TrigonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float TrigonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF TrigonalLowOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType TrigonalLowOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
@@ -57,44 +57,45 @@
 
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 
-namespace Detail
-{
-
-static const double TrigDim1InitValue = std::pow((0.75f * (SIMPLib::Constants::k_Pi - sinf(SIMPLib::Constants::k_Pi))), (1.0f / 3.0));
-static const double TrigDim2InitValue = std::pow((0.75f * (SIMPLib::Constants::k_Pi - sinf(SIMPLib::Constants::k_Pi))), (1.0f / 3.0));
-static const double TrigDim3InitValue = std::pow((0.75f * ((SIMPLib::Constants::k_Pi / 3.0) - sinf((SIMPLib::Constants::k_Pi / 3.0)))), (1.0f / 3.0));
-static const double TrigDim1StepValue = TrigDim1InitValue / 36.0f;
-static const double TrigDim2StepValue = TrigDim2InitValue / 36.0f;
-static const double TrigDim3StepValue = TrigDim3InitValue / 12.0f;
-
 namespace TrigonalLow
 {
+static const std::array<size_t, 3> OdfNumBins = {72, 72, 24}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * (SIMPLib::Constants::k_Pi - sinf(SIMPLib::Constants::k_Pi))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_Pi - sinf(SIMPLib::Constants::k_Pi))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * ((SIMPLib::Constants::k_Pi / 6.0) - sinf(SIMPLib::Constants::k_Pi / 6.0))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 2;
 static const int symSize1 = 2;
 static const int symSize2 = 2;
+
+static const int k_OdfSize = 124416;
+static const int k_MdfSize = 124416;
+static const int k_NumSymQuats = 3;
+
+static const QuatType QuatSym[3] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 0.866025400, 0.500000000),
+                                    QuatType(0.000000000, 0.000000000, 0.866025400, -0.50000000)};
+
+static const double RodSym[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 1.73205}, {0.0, 0.0, -1.73205}};
+
+static const double MatSym[3][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{-0.5, SIMPLib::Constants::k_Root3Over2, 0.0}, {-SIMPLib::Constants::k_Root3Over2, -0.5, 0.0}, {0.0, 0.0, 1.0}},
+
+                                       {{-0.5, -SIMPLib::Constants::k_Root3Over2, 0.0}, {SIMPLib::Constants::k_Root3Over2, -0.5, 0.0}, {0.0, 0.0, 1.0}}};
+
 } // namespace TrigonalLow
-} // namespace Detail
-static const QuatType TrigQuatSym[3] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 0.866025400, 0.500000000),
-                                        QuatType(0.000000000, 0.000000000, 0.866025400, -0.50000000)};
-
-static const double TrigRodSym[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 1.73205}, {0.0, 0.0, -1.73205}};
-
-static const double TrigMatSym[3][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
-
-                                           {{-0.5, SIMPLib::Constants::k_Root3Over2, 0.0}, {-SIMPLib::Constants::k_Root3Over2, -0.5, 0.0}, {0.0, 0.0, 1.0}},
-
-                                           {{-0.5, -SIMPLib::Constants::k_Root3Over2, 0.0}, {SIMPLib::Constants::k_Root3Over2, -0.5, 0.0}, {0.0, 0.0, 1.0}}};
-
-using namespace Detail;
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
 TrigonalLowOps::TrigonalLowOps()
 {
-  double junk1 = TrigDim1StepValue * 1.0f;
-  double junk2 = junk1 / TrigDim2StepValue;
-  double junk3 = junk2 / TrigDim3StepValue;
+  double junk1 = TrigonalLow::OdfDimStepValue[0] * 1.0f;
+  double junk2 = junk1 / TrigonalLow::OdfDimStepValue[1];
+  double junk3 = junk2 / TrigonalLow::OdfDimStepValue[2];
   junk1 = junk3 / junk2;
 }
 
@@ -116,7 +117,7 @@ bool TrigonalLowOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int TrigonalLowOps::getODFSize() const
 {
-  return k_OdfSize;
+  return TrigonalLow::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -124,7 +125,7 @@ int TrigonalLowOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int TrigonalLowOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return TrigonalLow::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -132,7 +133,13 @@ int TrigonalLowOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int TrigonalLowOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return TrigonalLow::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> TrigonalLowOps::getOdfNumBins() const
+{
+  return TrigonalLow::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -205,7 +212,7 @@ double TrigonalLowOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, Quat
 
 double TrigonalLowOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(TrigQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -216,7 +223,7 @@ float TrigonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TrigQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -225,40 +232,40 @@ float TrigonalLowOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f
 
 QuatType TrigonalLowOps::getQuatSymOp(int32_t i) const
 {
-  return TrigQuatSym[i];
+  return TrigonalLow::QuatSym[i];
 }
 
 void TrigonalLowOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = TrigRodSym[i][0];
-  r[1] = TrigRodSym[i][1];
-  r[2] = TrigRodSym[i][2];
+  r[0] = TrigonalLow::RodSym[i][0];
+  r[1] = TrigonalLow::RodSym[i][1];
+  r[2] = TrigonalLow::RodSym[i][2];
 }
 
 void TrigonalLowOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = TrigMatSym[i][0][0];
-  g[0][1] = TrigMatSym[i][0][1];
-  g[0][2] = TrigMatSym[i][0][2];
-  g[1][0] = TrigMatSym[i][1][0];
-  g[1][1] = TrigMatSym[i][1][1];
-  g[1][2] = TrigMatSym[i][1][2];
-  g[2][0] = TrigMatSym[i][2][0];
-  g[2][1] = TrigMatSym[i][2][1];
-  g[2][2] = TrigMatSym[i][2][2];
+  g[0][0] = TrigonalLow::MatSym[i][0][0];
+  g[0][1] = TrigonalLow::MatSym[i][0][1];
+  g[0][2] = TrigonalLow::MatSym[i][0][2];
+  g[1][0] = TrigonalLow::MatSym[i][1][0];
+  g[1][1] = TrigonalLow::MatSym[i][1][1];
+  g[1][2] = TrigonalLow::MatSym[i][1][2];
+  g[2][0] = TrigonalLow::MatSym[i][2][0];
+  g[2][1] = TrigonalLow::MatSym[i][2][1];
+  g[2][2] = TrigonalLow::MatSym[i][2][2];
 }
 
 void TrigonalLowOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = TrigMatSym[i][0][0];
-  g[0][1] = TrigMatSym[i][0][1];
-  g[0][2] = TrigMatSym[i][0][2];
-  g[1][0] = TrigMatSym[i][1][0];
-  g[1][1] = TrigMatSym[i][1][1];
-  g[1][2] = TrigMatSym[i][1][2];
-  g[2][0] = TrigMatSym[i][2][0];
-  g[2][1] = TrigMatSym[i][2][1];
-  g[2][2] = TrigMatSym[i][2][2];
+  g[0][0] = TrigonalLow::MatSym[i][0][0];
+  g[0][1] = TrigonalLow::MatSym[i][0][1];
+  g[0][2] = TrigonalLow::MatSym[i][0][2];
+  g[1][0] = TrigonalLow::MatSym[i][1][0];
+  g[1][1] = TrigonalLow::MatSym[i][1][1];
+  g[1][2] = TrigonalLow::MatSym[i][1][2];
+  g[2][0] = TrigonalLow::MatSym[i][2][0];
+  g[2][1] = TrigonalLow::MatSym[i][2][1];
+  g[2][2] = TrigonalLow::MatSym[i][2][2];
 }
 // -----------------------------------------------------------------------------
 //
@@ -266,7 +273,7 @@ void TrigonalLowOps::getMatSymOp(int i, float g[3][3]) const
 OrientationType TrigonalLowOps::getODFFZRod(const OrientationType& rod) const
 {
   int numsym = 3;
-  return _calcRodNearestOrigin(TrigRodSym, numsym, rod);
+  return _calcRodNearestOrigin(TrigonalLow::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -277,7 +284,7 @@ OrientationType TrigonalLowOps::getMDFFZRod(const OrientationType& inRod) const
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
   float n1n2mag = 0.0f;
 
-  OrientationType rod = _calcRodNearestOrigin(TrigRodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(TrigonalLow::RodSym, 12, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
   float denom = sqrt(ax[0] * ax[0] + ax[1] * ax[1] + ax[2] * ax[2]);
@@ -324,13 +331,13 @@ OrientationType TrigonalLowOps::getMDFFZRod(const OrientationType& inRod) const
 // -----------------------------------------------------------------------------
 QuatType TrigonalLowOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(TrigQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2);
 }
 QuatF TrigonalLowOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(TrigQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -346,15 +353,15 @@ int TrigonalLowOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TrigDim1InitValue;
-  dim[1] = TrigDim2InitValue;
-  dim[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  bins[0] = 72.0f;
-  bins[1] = 72.0f;
-  bins[2] = 24.0f;
+  dim[0] = TrigonalLow::OdfDimInitValue[0];
+  dim[1] = TrigonalLow::OdfDimInitValue[1];
+  dim[2] = TrigonalLow::OdfDimInitValue[2];
+  step[0] = TrigonalLow::OdfDimStepValue[0];
+  step[1] = TrigonalLow::OdfDimStepValue[1];
+  step[2] = TrigonalLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TrigonalLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TrigonalLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TrigonalLow::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -362,24 +369,24 @@ int TrigonalLowOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TrigonalLowOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType TrigonalLowOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TrigDim1InitValue;
-  init[1] = TrigDim2InitValue;
-  init[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 72);
-  phi[2] = static_cast<int32_t>(choose / (72 * 72));
+  init[0] = TrigonalLow::OdfDimInitValue[0];
+  init[1] = TrigonalLow::OdfDimInitValue[1];
+  init[2] = TrigonalLow::OdfDimInitValue[2];
+  step[0] = TrigonalLow::OdfDimStepValue[0];
+  step[1] = TrigonalLow::OdfDimStepValue[1];
+  step[2] = TrigonalLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TrigonalLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TrigonalLow::OdfNumBins[0]) % TrigonalLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TrigonalLow::OdfNumBins[0] * TrigonalLow::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -393,33 +400,33 @@ OrientationType TrigonalLowOps::determineEulerAngles(uint64_t seed, int choose) 
 // -----------------------------------------------------------------------------
 OrientationType TrigonalLowOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(TrigonalLow::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = TrigQuatSym[symOp] * quat;
+  QuatType qc = TrigonalLow::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TrigonalLowOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType TrigonalLowOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TrigDim1InitValue;
-  init[1] = TrigDim2InitValue;
-  init[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 72);
-  phi[1] = static_cast<int32_t>((choose / 72) % 72);
-  phi[2] = static_cast<int32_t>(choose / (72 * 72));
+  init[0] = TrigonalLow::OdfDimInitValue[0];
+  init[1] = TrigonalLow::OdfDimInitValue[1];
+  init[2] = TrigonalLow::OdfDimInitValue[2];
+  step[0] = TrigonalLow::OdfDimStepValue[0];
+  step[1] = TrigonalLow::OdfDimStepValue[1];
+  step[2] = TrigonalLow::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TrigonalLow::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TrigonalLow::OdfNumBins[0]) % TrigonalLow::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TrigonalLow::OdfNumBins[0] * TrigonalLow::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -437,15 +444,15 @@ int TrigonalLowOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TrigDim1InitValue;
-  dim[1] = TrigDim2InitValue;
-  dim[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  bins[0] = 72.0f;
-  bins[1] = 72.0f;
-  bins[2] = 24.0f;
+  dim[0] = TrigonalLow::OdfDimInitValue[0];
+  dim[1] = TrigonalLow::OdfDimInitValue[1];
+  dim[2] = TrigonalLow::OdfDimInitValue[2];
+  step[0] = TrigonalLow::OdfDimStepValue[0];
+  step[1] = TrigonalLow::OdfDimStepValue[1];
+  step[2] = TrigonalLow::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TrigonalLow::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TrigonalLow::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TrigonalLow::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -471,22 +478,22 @@ void TrigonalLowOps::getSchmidFactorAndSS(double load[3], double plane[3], doubl
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < TrigonalLow::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = TrigMatSym[i][2][0] * plane[0] + TrigMatSym[i][2][1] * plane[1] + TrigMatSym[i][2][2] * plane[2];
+    slipPlane[2] = TrigonalLow::MatSym[i][2][0] * plane[0] + TrigonalLow::MatSym[i][2][1] * plane[1] + TrigonalLow::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = TrigMatSym[i][0][0] * plane[0] + TrigMatSym[i][0][1] * plane[1] + TrigMatSym[i][0][2] * plane[2];
-      slipPlane[1] = TrigMatSym[i][1][0] * plane[0] + TrigMatSym[i][1][1] * plane[1] + TrigMatSym[i][1][2] * plane[2];
+      slipPlane[0] = TrigonalLow::MatSym[i][0][0] * plane[0] + TrigonalLow::MatSym[i][0][1] * plane[1] + TrigonalLow::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = TrigonalLow::MatSym[i][1][0] * plane[0] + TrigonalLow::MatSym[i][1][1] * plane[1] + TrigonalLow::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = TrigMatSym[i][0][0] * direction[0] + TrigMatSym[i][0][1] * direction[1] + TrigMatSym[i][0][2] * direction[2];
-      slipDirection[1] = TrigMatSym[i][1][0] * direction[0] + TrigMatSym[i][1][1] * direction[1] + TrigMatSym[i][1][2] * direction[2];
-      slipDirection[2] = TrigMatSym[i][2][0] * direction[0] + TrigMatSym[i][2][1] * direction[1] + TrigMatSym[i][2][2] * direction[2];
+      slipDirection[0] = TrigonalLow::MatSym[i][0][0] * direction[0] + TrigonalLow::MatSym[i][0][1] * direction[1] + TrigonalLow::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = TrigonalLow::MatSym[i][1][0] * direction[0] + TrigonalLow::MatSym[i][1][1] * direction[1] + TrigonalLow::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = TrigonalLow::MatSym[i][2][0] * direction[0] + TrigonalLow::MatSym[i][2][1] * direction[1] + TrigonalLow::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -525,8 +532,7 @@ double TrigonalLowOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
-{
+
   namespace TrigonalLow
   {
     class GenerateSphereCoordsImpl
@@ -596,7 +602,7 @@ namespace Detail
 #endif
     };
   }
-}
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -605,17 +611,17 @@ void TrigonalLowOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Floa
   size_t nOrientations = eulers->getNumberOfTuples();
 
   // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::TrigonalLow::symSize0)
+  if(xyz001->getNumberOfTuples() < nOrientations * TrigonalLow::symSize0)
   {
-    xyz001->resizeTuples(nOrientations * Detail::TrigonalLow::symSize0 * 3);
+    xyz001->resizeTuples(nOrientations * TrigonalLow::symSize0 * 3);
   }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::TrigonalLow::symSize1)
+  if(xyz011->getNumberOfTuples() < nOrientations * TrigonalLow::symSize1)
   {
-    xyz011->resizeTuples(nOrientations * Detail::TrigonalLow::symSize1 * 3);
+    xyz011->resizeTuples(nOrientations * TrigonalLow::symSize1 * 3);
   }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::TrigonalLow::symSize2)
+  if(xyz111->getNumberOfTuples() < nOrientations * TrigonalLow::symSize2)
   {
-    xyz111->resizeTuples(nOrientations * Detail::TrigonalLow::symSize2 * 3);
+    xyz111->resizeTuples(nOrientations * TrigonalLow::symSize2 * 3);
   }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -626,13 +632,12 @@ void TrigonalLowOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, Floa
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::TrigonalLow::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), TrigonalLow::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::TrigonalLow::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    TrigonalLow::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
 
@@ -676,7 +681,7 @@ SIMPL::Rgb TrigonalLowOps::generateIPFColor(double phi1, double phi, double phi2
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < TrigonalLow::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -742,9 +747,9 @@ SIMPL::Rgb TrigonalLowOps::generateIPFColor(double phi1, double phi, double phi2
 // -----------------------------------------------------------------------------
 SIMPL::Rgb TrigonalLowOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * TrigDim1InitValue;
-  double range2 = 2.0f * TrigDim2InitValue;
-  double range3 = 2.0f * TrigDim3InitValue;
+  double range1 = 2.0f * TrigonalLow::OdfDimInitValue[0];
+  double range2 = 2.0f * TrigonalLow::OdfDimInitValue[1];
+  double range3 = 2.0f * TrigonalLow::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -780,11 +785,11 @@ QVector<UInt8ArrayType::Pointer> TrigonalLowOps::generatePoleFigure(PoleFigureCo
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalLow::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * TrigonalLow::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalLow::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * TrigonalLow::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalLow::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * TrigonalLow::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
@@ -150,61 +150,6 @@ QString TrigonalLowOps::getSymmetryName() const
   return "Trigonal -3";;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD TrigonalLowOps::calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for (int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1.0;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1.0;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD TrigonalLowOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(TrigonalLow::QuatSym, TrigonalLow::k_NumSymQuats, q1, q2);

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.cpp
@@ -33,9 +33,10 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "TrigonalLowOps.h"
+
 #include <memory>
 
-#include "TrigonalLowOps.h"
 
 #include <cmath>
 
@@ -703,7 +704,7 @@ SIMPL::Rgb TrigonalLowOps::generateRodriguesColor(double r1, double r2, double r
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> TrigonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> TrigonalLowOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<0001>");
   QString label1 = QString("<-1-120>");
@@ -816,7 +817,7 @@ QVector<UInt8ArrayType::Pointer> TrigonalLowOps::generatePoleFigure(PoleFigureCo
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.h
@@ -213,23 +213,12 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TrigonalLowOps(const TrigonalLowOps&) = delete; // Copy Constructor Not Implemented
     TrigonalLowOps(TrigonalLowOps&&) = delete;      // Move Constructor Not Implemented
     TrigonalLowOps& operator=(const TrigonalLowOps&) = delete; // Copy Assignment Not Implemented
     TrigonalLowOps& operator=(TrigonalLowOps&&) = delete;      // Move Assignment Not Implemented
-
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.h
@@ -113,8 +113,21 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -200,7 +213,15 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[6], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TrigonalLowOps(const TrigonalLowOps&) = delete; // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/TrigonalLowOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalLowOps.h
@@ -77,10 +77,6 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
     TrigonalLowOps();
     ~TrigonalLowOps() override;
 
-    static const int k_OdfSize = 124416;
-    static const int k_MdfSize = 124416;
-    static const int k_NumSymQuats = 3;
-
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
      * @return
@@ -111,6 +107,12 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -128,9 +130,9 @@ class OrientationLib_EXPORT TrigonalLowOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/LaueOps/TrigonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.cpp
@@ -33,9 +33,10 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#include "TrigonalOps.h"
+
 #include <memory>
 
-#include "TrigonalOps.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
@@ -710,7 +711,7 @@ SIMPL::Rgb TrigonalOps::generateRodriguesColor(double r1, double r2, double r3) 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<UInt8ArrayType::Pointer> TrigonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
+std::vector<UInt8ArrayType::Pointer> TrigonalOps::generatePoleFigure(PoleFigureConfiguration_t& config) const
 {
   QString label0 = QString("<0001>");
   QString label1 = QString("<0-110>");
@@ -823,7 +824,7 @@ QVector<UInt8ArrayType::Pointer> TrigonalOps::generatePoleFigure(PoleFigureConfi
   UInt8ArrayType::Pointer image011 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label1, true);
   UInt8ArrayType::Pointer image111 = UInt8ArrayType::CreateArray(config.imageDim * config.imageDim, dims, label2, true);
 
-  QVector<UInt8ArrayType::Pointer> poleFigures(3);
+  std::vector<UInt8ArrayType::Pointer> poleFigures(3);
   if(config.order.size() == 3)
   {
     poleFigures[config.order[0]] = image001;

--- a/Source/OrientationLib/LaueOps/TrigonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.cpp
@@ -160,15 +160,15 @@ QString TrigonalOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-double TrigonalOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TrigonalOps::calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
-  double w = 0.0;
   double n1min = 0.0f;
   double n2min = 0.0f;
   double n3min = 0.0f;
-  QuatType qc;
 
+  OrientationD axisAngle;
+  QuatType qc;
   QuatType qr = q1 * (q2.conjugate());
 
   for (int i = 0; i < numsym; i++)
@@ -184,57 +184,47 @@ double TrigonalOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, QuatTyp
       qc.w() = 1.0;
     }
 
-    OrientationType ax = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-    n1 = ax[0];
-    n2 = ax[1];
-    n3 = ax[2];
-    w = ax[3];
+    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
 
-    if (w > SIMPLib::Constants::k_Pi)
+    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
     {
-      w = SIMPLib::Constants::k_2Pi - w;
+      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
     }
-    if (w < wmin)
+    if(axisAngle[3] < wmin)
     {
-      wmin = w;
-      n1min = n1;
-      n2min = n2;
-      n3min = n3;
+      wmin = axisAngle[3];
+      n1min = axisAngle[0];
+      n2min = axisAngle[1];
+      n3min = axisAngle[2];
     }
   }
   double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  n1 = n1min / denom;
-  n2 = n2min / denom;
-  n3 = n3min / denom;
-  if(denom == 0)
+  axisAngle[0] = n1min / denom;
+  axisAngle[1] = n2min / denom;
+  axisAngle[2] = n3min / denom;
+  if(denom == 0 || wmin == 0)
   {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
+    axisAngle[0] = 0.0;
+    axisAngle[1] = 0.0;
+    axisAngle[2] = 1.0;
   }
-  if(wmin == 0)
-  {
-    n1 = 0.0, n2 = 0.0, n3 = 1.0;
-  }
-  return wmin;
+
+  return axisAngle;
 }
 
-double TrigonalOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
+OrientationD TrigonalOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcMisoQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
+  return calculateMisorientationInternal(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
-float TrigonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, float& n3f) const
+OrientationF TrigonalOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2f) const
+
 {
-  QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
-  QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  double n1 = n1f;
-  double n2 = n2f;
-  double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
-  n1f = n1;
-  n2f = n2;
-  n3f = n3;
-  return w;
+  QuatType q1 = q1f;
+  QuatType q2 = q2f;
+  OrientationD axisAngle = calculateMisorientationInternal(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2);
+  return axisAngle;
 }
 
 QuatType TrigonalOps::getQuatSymOp(int32_t i) const

--- a/Source/OrientationLib/LaueOps/TrigonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.cpp
@@ -56,52 +56,53 @@
 #include "OrientationLib/Utilities/ComputeStereographicProjection.h"
 #include "OrientationLib/Utilities/PoleFigureUtilities.h"
 
-namespace Detail
-{
-
-static const double TrigDim1InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0));
-static const double TrigDim2InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0));
-static const double TrigDim3InitValue = std::pow((0.75f * (SIMPLib::Constants::k_PiOver3 - sinf(SIMPLib::Constants::k_PiOver3))), (1.0f / 3.0));
-static const double TrigDim1StepValue = TrigDim1InitValue / 18.0f;
-static const double TrigDim2StepValue = TrigDim2InitValue / 18.0f;
-static const double TrigDim3StepValue = TrigDim3InitValue / 12.0f;
 namespace TrigonalHigh
 {
+static const std::array<size_t, 3> OdfNumBins = {36, 36, 24}; // Represents a 5Deg bin
+
+static const std::array<double, 3> OdfDimInitValue = {std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver2 - sinf(SIMPLib::Constants::k_PiOver2))), (1.0f / 3.0)),
+                                                      std::pow((0.75f * (SIMPLib::Constants::k_PiOver3 - sinf(SIMPLib::Constants::k_PiOver3))), (1.0f / 3.0))};
+static const std::array<double, 3> OdfDimStepValue = {OdfDimInitValue[0] / static_cast<double>(OdfNumBins[0] / 2), OdfDimInitValue[1] / static_cast<double>(OdfNumBins[1] / 2),
+                                                      OdfDimInitValue[2] / static_cast<double>(OdfNumBins[2] / 2)};
+
 static const int symSize0 = 2;
 static const int symSize1 = 2;
 static const int symSize2 = 2;
-} // namespace TrigonalHigh
-}
 
-static const QuatType TrigQuatSym[6] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 0.866025400, 0.500000000),
-                                        QuatType(0.000000000, 0.000000000, 0.866025400, -0.50000000), QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
-                                        QuatType(-0.500000000, 0.86602540, 0.000000000, 0.000000000), QuatType(-0.500000000, -0.866025400, 0.000000000, 0.000000000)};
+static const int k_OdfSize = 31104;
+static const int k_MdfSize = 31104;
+static const int k_NumSymQuats = 6;
 
-static const double TrigRodSym[6][3] = {
+static const QuatType QuatSym[6] = {QuatType(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatType(0.000000000, 0.000000000, 0.866025400, 0.500000000),
+                                    QuatType(0.000000000, 0.000000000, 0.866025400, -0.50000000), QuatType(1.000000000, 0.000000000, 0.000000000, 0.000000000),
+                                    QuatType(-0.500000000, 0.86602540, 0.000000000, 0.000000000), QuatType(-0.500000000, -0.866025400, 0.000000000, 0.000000000)};
+
+static const double RodSym[6][3] = {
     {0.0, 0.0, 0.0}, {0.0, 0.0, 1.73205}, {0.0, 0.0, -1.73205}, {8660254000000.0, 5000000000000.0, 0.0}, {0.0, 1000000000000.0, 0.0}, {-8660254000000.0, 5000000000000.0, 0.0}};
 
-static const double TrigMatSym[6][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+static const double MatSym[6][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                       {{-0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+                                       {{-0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                           {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
+                                       {{0.5, static_cast<double>(SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                       {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                           {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
+                                       {{0.5, static_cast<double>(-SIMPLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-SIMPLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
 
-using namespace Detail;
+} // namespace TrigonalHigh
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
 TrigonalOps::TrigonalOps()
 {
-  double junk1 = TrigDim1StepValue * 1.0f;
-  double junk2 = junk1 / TrigDim2StepValue;
-  double junk3 = junk2 / TrigDim3StepValue;
+  double junk1 = TrigonalHigh::OdfDimStepValue[0] * 1.0f;
+  double junk2 = junk1 / TrigonalHigh::OdfDimStepValue[1];
+  double junk3 = junk2 / TrigonalHigh::OdfDimStepValue[2];
   junk1 = junk3 / junk2;
 }
 
@@ -123,7 +124,7 @@ bool TrigonalOps::getHasInversion() const
 // -----------------------------------------------------------------------------
 int TrigonalOps::getODFSize() const
 {
-  return k_OdfSize;
+  return TrigonalHigh::k_OdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -131,7 +132,7 @@ int TrigonalOps::getODFSize() const
 // -----------------------------------------------------------------------------
 int TrigonalOps::getMDFSize() const
 {
-  return k_MdfSize;
+  return TrigonalHigh::k_MdfSize;
 }
 
 // -----------------------------------------------------------------------------
@@ -139,7 +140,13 @@ int TrigonalOps::getMDFSize() const
 // -----------------------------------------------------------------------------
 int TrigonalOps::getNumSymOps() const
 {
-  return k_NumSymQuats;
+  return TrigonalHigh::k_NumSymQuats;
+}
+
+// -----------------------------------------------------------------------------
+std::array<size_t, 3> TrigonalOps::getOdfNumBins() const
+{
+  return TrigonalHigh::OdfNumBins;
 }
 
 // -----------------------------------------------------------------------------
@@ -212,7 +219,7 @@ double TrigonalOps::_calcMisoQuat(const QuatType quatsym[6], int numsym, QuatTyp
 
 double TrigonalOps::getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const
 {
-  return _calcMisoQuat(TrigQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3);
+  return _calcMisoQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3);
 }
 
 // -----------------------------------------------------------------------------
@@ -223,7 +230,7 @@ float TrigonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, f
   double n1 = n1f;
   double n2 = n2f;
   double n3 = n3f;
-  float w = static_cast<float>(_calcMisoQuat(TrigQuatSym, k_NumSymQuats, q1, q2, n1, n2, n3));
+  float w = static_cast<float>(_calcMisoQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2, n1, n2, n3));
   n1f = n1;
   n2f = n2;
   n3f = n3;
@@ -232,40 +239,40 @@ float TrigonalOps::getMisoQuat(QuatF& q1f, QuatF& q2f, float& n1f, float& n2f, f
 
 QuatType TrigonalOps::getQuatSymOp(int32_t i) const
 {
-  return TrigQuatSym[i];
+  return TrigonalHigh::QuatSym[i];
 }
 
 void TrigonalOps::getRodSymOp(int i, double* r) const
 {
-  r[0] = TrigRodSym[i][0];
-  r[1] = TrigRodSym[i][1];
-  r[2] = TrigRodSym[i][2];
+  r[0] = TrigonalHigh::RodSym[i][0];
+  r[1] = TrigonalHigh::RodSym[i][1];
+  r[2] = TrigonalHigh::RodSym[i][2];
 }
 
 void TrigonalOps::getMatSymOp(int i, double g[3][3]) const
 {
-  g[0][0] = TrigMatSym[i][0][0];
-  g[0][1] = TrigMatSym[i][0][1];
-  g[0][2] = TrigMatSym[i][0][2];
-  g[1][0] = TrigMatSym[i][1][0];
-  g[1][1] = TrigMatSym[i][1][1];
-  g[1][2] = TrigMatSym[i][1][2];
-  g[2][0] = TrigMatSym[i][2][0];
-  g[2][1] = TrigMatSym[i][2][1];
-  g[2][2] = TrigMatSym[i][2][2];
+  g[0][0] = TrigonalHigh::MatSym[i][0][0];
+  g[0][1] = TrigonalHigh::MatSym[i][0][1];
+  g[0][2] = TrigonalHigh::MatSym[i][0][2];
+  g[1][0] = TrigonalHigh::MatSym[i][1][0];
+  g[1][1] = TrigonalHigh::MatSym[i][1][1];
+  g[1][2] = TrigonalHigh::MatSym[i][1][2];
+  g[2][0] = TrigonalHigh::MatSym[i][2][0];
+  g[2][1] = TrigonalHigh::MatSym[i][2][1];
+  g[2][2] = TrigonalHigh::MatSym[i][2][2];
 }
 
 void TrigonalOps::getMatSymOp(int i, float g[3][3]) const
 {
-  g[0][0] = TrigMatSym[i][0][0];
-  g[0][1] = TrigMatSym[i][0][1];
-  g[0][2] = TrigMatSym[i][0][2];
-  g[1][0] = TrigMatSym[i][1][0];
-  g[1][1] = TrigMatSym[i][1][1];
-  g[1][2] = TrigMatSym[i][1][2];
-  g[2][0] = TrigMatSym[i][2][0];
-  g[2][1] = TrigMatSym[i][2][1];
-  g[2][2] = TrigMatSym[i][2][2];
+  g[0][0] = TrigonalHigh::MatSym[i][0][0];
+  g[0][1] = TrigonalHigh::MatSym[i][0][1];
+  g[0][2] = TrigonalHigh::MatSym[i][0][2];
+  g[1][0] = TrigonalHigh::MatSym[i][1][0];
+  g[1][1] = TrigonalHigh::MatSym[i][1][1];
+  g[1][2] = TrigonalHigh::MatSym[i][1][2];
+  g[2][0] = TrigonalHigh::MatSym[i][2][0];
+  g[2][1] = TrigonalHigh::MatSym[i][2][1];
+  g[2][2] = TrigonalHigh::MatSym[i][2][2];
 }
 // -----------------------------------------------------------------------------
 //
@@ -274,7 +281,7 @@ OrientationType TrigonalOps::getODFFZRod(const OrientationType& rod) const
 {
   int numsym = 6;
 
-  return _calcRodNearestOrigin(TrigRodSym, numsym, rod);
+  return _calcRodNearestOrigin(TrigonalHigh::RodSym, numsym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -286,7 +293,7 @@ OrientationType TrigonalOps::getMDFFZRod(const OrientationType& inRod) const
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
   double n1n2mag = 0.0f;
 
-  OrientationType rod = _calcRodNearestOrigin(TrigRodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(TrigonalHigh::RodSym, 12, inRod);
 
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
@@ -337,13 +344,13 @@ OrientationType TrigonalOps::getMDFFZRod(const OrientationType& inRod) const
 // -----------------------------------------------------------------------------
 QuatType TrigonalOps::getNearestQuat(const QuatType& q1, const QuatType& q2) const
 {
-  return _calcNearestQuat(TrigQuatSym, k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2);
 }
 QuatF TrigonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatType q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatType q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatType temp = _calcNearestQuat(TrigQuatSym, k_NumSymQuats, q1, q2);
+  QuatType temp = _calcNearestQuat(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -359,15 +366,15 @@ int TrigonalOps::getMisoBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TrigDim1InitValue;
-  dim[1] = TrigDim2InitValue;
-  dim[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 24.0f;
+  dim[0] = TrigonalHigh::OdfDimInitValue[0];
+  dim[1] = TrigonalHigh::OdfDimInitValue[1];
+  dim[2] = TrigonalHigh::OdfDimInitValue[2];
+  step[0] = TrigonalHigh::OdfDimStepValue[0];
+  step[1] = TrigonalHigh::OdfDimStepValue[1];
+  step[2] = TrigonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TrigonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TrigonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TrigonalHigh::OdfNumBins[2]);
 
   return _calcMisoBin(dim, bins, step, ho);
 }
@@ -376,24 +383,24 @@ int TrigonalOps::getMisoBin(const OrientationType& rod) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TrigonalOps::determineEulerAngles(uint64_t seed, int choose) const
+OrientationType TrigonalOps::determineEulerAngles(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TrigDim1InitValue;
-  init[1] = TrigDim2InitValue;
-  init[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = TrigonalHigh::OdfDimInitValue[0];
+  init[1] = TrigonalHigh::OdfDimInitValue[1];
+  init[2] = TrigonalHigh::OdfDimInitValue[2];
+  step[0] = TrigonalHigh::OdfDimStepValue[0];
+  step[1] = TrigonalHigh::OdfDimStepValue[1];
+  step[2] = TrigonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TrigonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TrigonalHigh::OdfNumBins[0]) % TrigonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TrigonalHigh::OdfNumBins[0] * TrigonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
 
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
@@ -407,33 +414,33 @@ OrientationType TrigonalOps::determineEulerAngles(uint64_t seed, int choose) con
 // -----------------------------------------------------------------------------
 OrientationType TrigonalOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(TrigonalHigh::k_NumSymQuats);
   QuatType quat = OrientationTransformation::eu2qu<OrientationType, QuatType>(synea);
-  QuatType qc = TrigQuatSym[symOp] * quat;
+  QuatType qc = TrigonalHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatType, OrientationType>(qc);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType TrigonalOps::determineRodriguesVector(uint64_t seed, int choose) const
+OrientationType TrigonalOps::determineRodriguesVector(double random[3], int choose) const
 {
   double init[3];
   double step[3];
   int32_t phi[3];
   double h1, h2, h3;
 
-  init[0] = TrigDim1InitValue;
-  init[1] = TrigDim2InitValue;
-  init[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  phi[0] = static_cast<int32_t>(choose % 36);
-  phi[1] = static_cast<int32_t>((choose / 36) % 36);
-  phi[2] = static_cast<int32_t>(choose / (36 * 36));
+  init[0] = TrigonalHigh::OdfDimInitValue[0];
+  init[1] = TrigonalHigh::OdfDimInitValue[1];
+  init[2] = TrigonalHigh::OdfDimInitValue[2];
+  step[0] = TrigonalHigh::OdfDimStepValue[0];
+  step[1] = TrigonalHigh::OdfDimStepValue[1];
+  step[2] = TrigonalHigh::OdfDimStepValue[2];
+  phi[0] = static_cast<int32_t>(choose % TrigonalHigh::OdfNumBins[0]);
+  phi[1] = static_cast<int32_t>((choose / TrigonalHigh::OdfNumBins[0]) % TrigonalHigh::OdfNumBins[1]);
+  phi[2] = static_cast<int32_t>(choose / (TrigonalHigh::OdfNumBins[0] * TrigonalHigh::OdfNumBins[1]));
 
-  _calcDetermineHomochoricValues(seed, init, step, phi, choose, h1, h2, h3);
+  _calcDetermineHomochoricValues(random, init, step, phi, h1, h2, h3);
   OrientationType ho(h1, h2, h3);
   OrientationType ro = OrientationTransformation::ho2ro<OrientationType, OrientationType>(ho);
   ro = getMDFFZRod(ro);
@@ -448,15 +455,15 @@ int TrigonalOps::getOdfBin(const OrientationType& rod) const
 
   OrientationType ho = OrientationTransformation::ro2ho<OrientationType, OrientationType>(rod);
 
-  dim[0] = TrigDim1InitValue;
-  dim[1] = TrigDim2InitValue;
-  dim[2] = TrigDim3InitValue;
-  step[0] = TrigDim1StepValue;
-  step[1] = TrigDim2StepValue;
-  step[2] = TrigDim3StepValue;
-  bins[0] = 36.0f;
-  bins[1] = 36.0f;
-  bins[2] = 24.0f;
+  dim[0] = TrigonalHigh::OdfDimInitValue[0];
+  dim[1] = TrigonalHigh::OdfDimInitValue[1];
+  dim[2] = TrigonalHigh::OdfDimInitValue[2];
+  step[0] = TrigonalHigh::OdfDimStepValue[0];
+  step[1] = TrigonalHigh::OdfDimStepValue[1];
+  step[2] = TrigonalHigh::OdfDimStepValue[2];
+  bins[0] = static_cast<double>(TrigonalHigh::OdfNumBins[0]);
+  bins[1] = static_cast<double>(TrigonalHigh::OdfNumBins[1]);
+  bins[2] = static_cast<double>(TrigonalHigh::OdfNumBins[2]);
 
   return _calcODFBin(dim, bins, step, ho);
 }
@@ -482,22 +489,22 @@ void TrigonalOps::getSchmidFactorAndSS(double load[3], double plane[3], double d
   directionMag *= loadMag;
 
   //loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < k_NumSymQuats; i++)
+  for(int i = 0; i < TrigonalHigh::k_NumSymQuats; i++)
   {
     //compute slip system
     double slipPlane[3] = {0};
-    slipPlane[2] = TrigMatSym[i][2][0] * plane[0] + TrigMatSym[i][2][1] * plane[1] + TrigMatSym[i][2][2] * plane[2];
+    slipPlane[2] = TrigonalHigh::MatSym[i][2][0] * plane[0] + TrigonalHigh::MatSym[i][2][1] * plane[1] + TrigonalHigh::MatSym[i][2][2] * plane[2];
 
     //dont consider negative z planes (to avoid duplicates)
     if( slipPlane[2] >= 0)
     {
-      slipPlane[0] = TrigMatSym[i][0][0] * plane[0] + TrigMatSym[i][0][1] * plane[1] + TrigMatSym[i][0][2] * plane[2];
-      slipPlane[1] = TrigMatSym[i][1][0] * plane[0] + TrigMatSym[i][1][1] * plane[1] + TrigMatSym[i][1][2] * plane[2];
+      slipPlane[0] = TrigonalHigh::MatSym[i][0][0] * plane[0] + TrigonalHigh::MatSym[i][0][1] * plane[1] + TrigonalHigh::MatSym[i][0][2] * plane[2];
+      slipPlane[1] = TrigonalHigh::MatSym[i][1][0] * plane[0] + TrigonalHigh::MatSym[i][1][1] * plane[1] + TrigonalHigh::MatSym[i][1][2] * plane[2];
 
       double slipDirection[3] = {0};
-      slipDirection[0] = TrigMatSym[i][0][0] * direction[0] + TrigMatSym[i][0][1] * direction[1] + TrigMatSym[i][0][2] * direction[2];
-      slipDirection[1] = TrigMatSym[i][1][0] * direction[0] + TrigMatSym[i][1][1] * direction[1] + TrigMatSym[i][1][2] * direction[2];
-      slipDirection[2] = TrigMatSym[i][2][0] * direction[0] + TrigMatSym[i][2][1] * direction[1] + TrigMatSym[i][2][2] * direction[2];
+      slipDirection[0] = TrigonalHigh::MatSym[i][0][0] * direction[0] + TrigonalHigh::MatSym[i][0][1] * direction[1] + TrigonalHigh::MatSym[i][0][2] * direction[2];
+      slipDirection[1] = TrigonalHigh::MatSym[i][1][0] * direction[0] + TrigonalHigh::MatSym[i][1][1] * direction[1] + TrigonalHigh::MatSym[i][1][2] * direction[2];
+      slipDirection[2] = TrigonalHigh::MatSym[i][2][0] * direction[0] + TrigonalHigh::MatSym[i][2][1] * direction[1] + TrigonalHigh::MatSym[i][2][2] * direction[2];
 
       double cosPhi = fabs(load[0] * slipPlane[0] + load[1] * slipPlane[1] + load[2] * slipPlane[2]) / planeMag;
       double cosLambda = fabs(load[0] * slipDirection[0] + load[1] * slipDirection[1] + load[2] * slipDirection[2]) / directionMag;
@@ -536,8 +543,7 @@ double TrigonalOps::getF7(const QuatType& q1, const QuatType& q2, double LD[3], 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-namespace Detail
-{
+
   namespace TrigonalHigh
   {
     class GenerateSphereCoordsImpl
@@ -607,7 +613,7 @@ namespace Detail
 #endif
     };
   }
-}
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -616,17 +622,17 @@ void TrigonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatAr
   size_t nOrientations = eulers->getNumberOfTuples();
 
   // Sanity Check the size of the arrays
-  if (xyz001->getNumberOfTuples() < nOrientations * Detail::TrigonalHigh::symSize0)
+  if(xyz001->getNumberOfTuples() < nOrientations * TrigonalHigh::symSize0)
   {
-    xyz001->resizeTuples(nOrientations * Detail::TrigonalHigh::symSize0 * 3);
+    xyz001->resizeTuples(nOrientations * TrigonalHigh::symSize0 * 3);
   }
-  if (xyz011->getNumberOfTuples() < nOrientations * Detail::TrigonalHigh::symSize1)
+  if(xyz011->getNumberOfTuples() < nOrientations * TrigonalHigh::symSize1)
   {
-    xyz011->resizeTuples(nOrientations * Detail::TrigonalHigh::symSize1 * 3);
+    xyz011->resizeTuples(nOrientations * TrigonalHigh::symSize1 * 3);
   }
-  if (xyz111->getNumberOfTuples() < nOrientations * Detail::TrigonalHigh::symSize2)
+  if(xyz111->getNumberOfTuples() < nOrientations * TrigonalHigh::symSize2)
   {
-    xyz111->resizeTuples(nOrientations * Detail::TrigonalHigh::symSize2 * 3);
+    xyz111->resizeTuples(nOrientations * TrigonalHigh::symSize2 * 3);
   }
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -637,13 +643,12 @@ void TrigonalOps::generateSphereCoordsFromEulers(FloatArrayType* eulers, FloatAr
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   if(doParallel)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations),
-                      Detail::TrigonalHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, nOrientations), TrigonalHigh::GenerateSphereCoordsImpl(eulers, xyz001, xyz011, xyz111), tbb::auto_partitioner());
   }
   else
 #endif
   {
-    Detail::TrigonalHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
+    TrigonalHigh::GenerateSphereCoordsImpl serial(eulers, xyz001, xyz011, xyz111);
     serial.generate(0, nOrientations);
   }
 
@@ -687,7 +692,7 @@ SIMPL::Rgb TrigonalOps::generateIPFColor(double phi1, double phi, double phi2, d
   OrientationType om(9); // Reusable for the loop
   QuatType q1 = OrientationTransformation::eu2qu<OrientationType, QuatType>(eu);
 
-  for(int j = 0; j < k_NumSymQuats; j++)
+  for(int j = 0; j < TrigonalHigh::k_NumSymQuats; j++)
   {
     QuatType qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatType, OrientationType>(qu).toGMatrix(g);
@@ -753,9 +758,9 @@ SIMPL::Rgb TrigonalOps::generateIPFColor(double phi1, double phi, double phi2, d
 // -----------------------------------------------------------------------------
 SIMPL::Rgb TrigonalOps::generateRodriguesColor(double r1, double r2, double r3) const
 {
-  double range1 = 2.0f * TrigDim1InitValue;
-  double range2 = 2.0f * TrigDim2InitValue;
-  double range3 = 2.0f * TrigDim3InitValue;
+  double range1 = 2.0f * TrigonalHigh::OdfDimInitValue[0];
+  double range2 = 2.0f * TrigonalHigh::OdfDimInitValue[1];
+  double range3 = 2.0f * TrigonalHigh::OdfDimInitValue[2];
   double max1 = range1 / 2.0f;
   double max2 = range2 / 2.0f;
   double max3 = range3 / 2.0f;
@@ -786,11 +791,11 @@ QVector<UInt8ArrayType::Pointer> TrigonalOps::generatePoleFigure(PoleFigureConfi
   // Create an Array to hold the XYZ Coordinates which are the coords on the sphere.
   // this is size for CUBIC ONLY, <001> Family
   std::vector<size_t> dims(1, 3);
-  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz001 = FloatArrayType::CreateArray(numOrientations * TrigonalHigh::symSize0, dims, label0 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <011> Family
-  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz011 = FloatArrayType::CreateArray(numOrientations * TrigonalHigh::symSize1, dims, label1 + QString("xyzCoords"), true);
   // this is size for CUBIC ONLY, <111> Family
-  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * Detail::TrigonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
+  FloatArrayType::Pointer xyz111 = FloatArrayType::CreateArray(numOrientations * TrigonalHigh::symSize2, dims, label2 + QString("xyzCoords"), true);
 
   config.sphereRadius = 1.0f;
 

--- a/Source/OrientationLib/LaueOps/TrigonalOps.cpp
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.cpp
@@ -157,61 +157,6 @@ QString TrigonalOps::getSymmetryName() const
   return "Trigonal -3m";;
 }
 
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-OrientationD TrigonalOps::calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const
-{
-  double wmin = 9999999.0f; //,na,nb,nc;
-  double n1min = 0.0f;
-  double n2min = 0.0f;
-  double n3min = 0.0f;
-
-  OrientationD axisAngle;
-  QuatType qc;
-  QuatType qr = q1 * (q2.conjugate());
-
-  for (int i = 0; i < numsym; i++)
-  {
-    qc = quatsym[i] * qr;
-
-    if(qc.w() < -1)
-    {
-      qc.w() = -1.0;
-    }
-    else if(qc.w() > 1)
-    {
-      qc.w() = 1.0;
-    }
-
-    axisAngle = OrientationTransformation::qu2ax<QuatType, OrientationType>(qc);
-
-    if(axisAngle[3] > SIMPLib::Constants::k_Pi)
-    {
-      axisAngle[3] = SIMPLib::Constants::k_2Pi - axisAngle[3];
-    }
-    if(axisAngle[3] < wmin)
-    {
-      wmin = axisAngle[3];
-      n1min = axisAngle[0];
-      n2min = axisAngle[1];
-      n3min = axisAngle[2];
-    }
-  }
-  double denom = sqrt((n1min * n1min + n2min * n2min + n3min * n3min));
-  axisAngle[0] = n1min / denom;
-  axisAngle[1] = n2min / denom;
-  axisAngle[2] = n3min / denom;
-  if(denom == 0 || wmin == 0)
-  {
-    axisAngle[0] = 0.0;
-    axisAngle[1] = 0.0;
-    axisAngle[2] = 1.0;
-  }
-
-  return axisAngle;
-}
-
 OrientationD TrigonalOps::calculateMisorientation(const QuatType& q1, const QuatType& q2) const
 {
   return calculateMisorientationInternal(TrigonalHigh::QuatSym, TrigonalHigh::k_NumSymQuats, q1, q2);
@@ -227,6 +172,7 @@ OrientationF TrigonalOps::calculateMisorientation(const QuatF& q1f, const QuatF&
   return axisAngle;
 }
 
+// -----------------------------------------------------------------------------
 QuatType TrigonalOps::getQuatSymOp(int32_t i) const
 {
   return TrigonalHigh::QuatSym[i];

--- a/Source/OrientationLib/LaueOps/TrigonalOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.h
@@ -204,7 +204,7 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
      * @return A QVector of UInt8ArrayType pointers where each one represents a 2D RGB array that can be used to initialize
      * an image object from other libraries and written out to disk.
      */
-    QVector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
+    std::vector<UInt8ArrayType::Pointer> generatePoleFigure(PoleFigureConfiguration_t& config) const override;
 
     /**
      * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.

--- a/Source/OrientationLib/LaueOps/TrigonalOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.h
@@ -213,23 +213,12 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    /**
-     * @brief calculateMisorientationInternal
-     * @param quatsym
-     * @param numsym
-     * @param q1
-     * @param q2
-     * @return
-     */
-    OrientationD calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TrigonalOps(const TrigonalOps&) = delete;    // Copy Constructor Not Implemented
     TrigonalOps(TrigonalOps&&) = delete;         // Move Constructor Not Implemented
     TrigonalOps& operator=(const TrigonalOps&) = delete; // Copy Assignment Not Implemented
     TrigonalOps& operator=(TrigonalOps&&) = delete;      // Move Assignment Not Implemented
-
-  private:
 
 };
 

--- a/Source/OrientationLib/LaueOps/TrigonalOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.h
@@ -113,8 +113,21 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
      */
     std::array<size_t, 3> getOdfNumBins() const override;
 
-    double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
-    float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationD calculateMisorientation(const QuatType& q1, const QuatType& q2) const override;
+
+    /**
+     * @brief calculateMisorientation Finds the misorientation between 2 quaternions and returns the result as an Axis Angle value
+     * @param q1 Input Quaternion
+     * @param q2 Input Quaternion
+     * @return Axis Angle Representation
+     */
+    virtual OrientationF calculateMisorientation(const QuatF& q1, const QuatF& q2) const override;
 
     QuatType getQuatSymOp(int i) const override;
     void getRodSymOp(int i, double* r) const override;
@@ -200,7 +213,15 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
     UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
 
   protected:
-    double _calcMisoQuat(const QuatType quatsym[6], int numsym, QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const;
+    /**
+     * @brief calculateMisorientationInternal
+     * @param quatsym
+     * @param numsym
+     * @param q1
+     * @param q2
+     * @return
+     */
+    OrientationD calculateMisorientationInternal(const QuatType quatsym[6], int numsym, const QuatType& q1, const QuatType& q2) const;
 
   public:
     TrigonalOps(const TrigonalOps&) = delete;    // Copy Constructor Not Implemented

--- a/Source/OrientationLib/LaueOps/TrigonalOps.h
+++ b/Source/OrientationLib/LaueOps/TrigonalOps.h
@@ -76,10 +76,6 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
     TrigonalOps();
     ~TrigonalOps() override;
 
-    static const int k_OdfSize = 31104;
-    static const int k_MdfSize = 31104;
-    static const int k_NumSymQuats = 6;
-
 
     /**
      * @brief getHasInversion Returns if this Laue class has inversion
@@ -111,6 +107,12 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
      */
     QString getSymmetryName() const override;
 
+    /**
+     * @brief Returns the number of bins in each of the 3 dimensions
+     * @return
+     */
+    std::array<size_t, 3> getOdfNumBins() const override;
+
     double getMisoQuat(QuatType& q1, QuatType& q2, double& n1, double& n2, double& n3) const override;
     float getMisoQuat(QuatF& q1, QuatF& q2, float& n1, float& n2, float& n3) const override;
 
@@ -128,9 +130,9 @@ class OrientationLib_EXPORT TrigonalOps : public LaueOps
 
     int getMisoBin(const OrientationType& rod) const override;
     bool inUnitTriangle(double eta, double chi) const override;
-    OrientationType determineEulerAngles(uint64_t seed, int choose) const override;
+    OrientationType determineEulerAngles(double random[3], int choose) const override;
     OrientationType randomizeEulerAngles(const OrientationType& euler) const override;
-    OrientationType determineRodriguesVector(uint64_t seed, int choose) const override;
+    OrientationType determineRodriguesVector(double random[3], int choose) const override;
     int getOdfBin(const OrientationType& rod) const override;
     void getSchmidFactorAndSS(double load[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;
     void getSchmidFactorAndSS(double load[3], double plane[3], double direction[3], double& schmidfactor, double angleComps[2], int& slipsys) const override;

--- a/Source/OrientationLib/OrientationMath/OrientationConverter.hpp
+++ b/Source/OrientationLib/OrientationMath/OrientationConverter.hpp
@@ -36,8 +36,8 @@
 #pragma once
 
 #include <iostream>
+#include <vector>
 
-#include <QtCore/QVector>
 #include <QtCore/QString>
 
 #include "SIMPLib/SIMPLib.h"
@@ -191,9 +191,10 @@ class OrientationConverter
      * @brief GetOrientationTypeStrings
      * @return
      */
-    static QVector<QString> GetOrientationTypeStrings()
+    template <typename ContainerType>
+    static ContainerType GetOrientationTypeStrings()
     {
-      QVector<QString> otypes(7);
+      ContainerType otypes(7);
       otypes[0] = "Euler";
       otypes[1] = "Orientation Matrix";
       otypes[2] = "Quaternion";
@@ -208,9 +209,10 @@ class OrientationConverter
      * @brief GetComponentCounts
      * @return
      */
-    static QVector<int> GetComponentCounts()
+    template <typename ContainerType>
+    static ContainerType GetComponentCounts()
     {
-      QVector<int> counts(7);
+      ContainerType counts(7);
       counts[0] = 3; // Euler
       counts[1] = 9; // Orientation Matrix
       counts[2] = 4; // Quaternion
@@ -225,9 +227,9 @@ class OrientationConverter
      * @brief GetOrientationTypes
      * @return
      */
-    static QVector<OrientationRepresentation::Type> GetOrientationTypes()
+    static std::vector<OrientationRepresentation::Type> GetOrientationTypes()
     {
-      QVector<OrientationRepresentation::Type> ocTypes(7);
+      std::vector<OrientationRepresentation::Type> ocTypes(7);
       ocTypes[0] = OrientationRepresentation::Type::Euler;
       ocTypes[1] = OrientationRepresentation::Type::OrientationMatrix;
       ocTypes[2] = OrientationRepresentation::Type::Quaternion;

--- a/Source/OrientationLib/OrientationMath/OrientationConverter.hpp
+++ b/Source/OrientationLib/OrientationMath/OrientationConverter.hpp
@@ -45,11 +45,10 @@
 #include "SIMPLib/DataArrays/DataArray.hpp"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 
-#include "OrientationLib/Core/Orientation.hpp"
-#include "OrientationLib/Core/OrientationTransformation.hpp"
 #include "OrientationLib/OrientationLib.h"
 #include "OrientationLib/Core/Orientation.hpp"
-#include "OrientationLib/OrientationMath/OrientationRepresentation.h"
+#include "OrientationLib/Core/OrientationTransformation.hpp"
+#include "OrientationLib/Core/OrientationRepresentation.h"
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
 #include <tbb/blocked_range.h>
@@ -57,7 +56,6 @@
 #include <tbb/partitioner.h>
 #include <tbb/task_scheduler_init.h>
 #endif
-
 
 /**
  * @brief This is the top level superclass for doing the conversions between orientation

--- a/Source/OrientationLib/OrientationMath/SourceList.cmake
+++ b/Source/OrientationLib/OrientationMath/SourceList.cmake
@@ -1,7 +1,6 @@
 
 set(OrientationLib_OrientationMath_HDRS
   ${OrientationLib_SOURCE_DIR}/OrientationMath/OrientationConverter.hpp
-  ${OrientationLib_SOURCE_DIR}/OrientationMath/OrientationRepresentation.h
 )
 
 set(OrientationLib_OrientationMath_SRCS

--- a/Source/OrientationLib/Test/ODFTest.cpp
+++ b/Source/OrientationLib/Test/ODFTest.cpp
@@ -47,6 +47,7 @@
 
 #include "OrientationLib/Texture/StatsGen.hpp"
 #include "OrientationLib/Texture/Texture.hpp"
+#include "OrientationLib/LaueOps/CubicOps.h"
 
 #include "TestPrintFunctions.h"
 
@@ -60,12 +61,8 @@
 class ODFTest
 {
 public:
-  ODFTest()
-  {
-  }
-  virtual ~ODFTest()
-  {
-  }
+  ODFTest() = default;
+  ~ODFTest() = default;
 
   // -----------------------------------------------------------------------------
   //
@@ -77,9 +74,9 @@ public:
   }
 
   void CubicODFTest()
-  {
-    // Resize the ODF vector properly for Cubic
-    std::vector<float> odf(CubicOps::k_OdfSize);
+  { // Resize the ODF vector properly for Cubic
+    CubicOps ops;
+    std::vector<float> odf(ops.getODFSize());
     std::vector<float> e1s(2);
     std::vector<float> e2s(2);
     std::vector<float> e3s(2);
@@ -92,7 +89,7 @@ public:
     // Calculate the ODF Data
 
     size_t numEntries = e1s.size();
-    Texture::CalculateCubicODFData(&(e1s.front()), &(e2s.front()), &(e3s.front()), &(weights.front()), &(sigmas.front()), true, &(odf.front()), numEntries);
+    Texture::CalculateODFData<float, CubicOps, std::vector<float>>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
 
     size_t npoints = 1000;
     std::vector<float> x001(npoints * 3);
@@ -126,8 +123,6 @@ public:
     Print_Coord<float>(coordsRotated);
 
   }
-
-
 
 
   void operator()()

--- a/Source/OrientationLib/Test/OrientationConverterTest.cpp
+++ b/Source/OrientationLib/Test/OrientationConverterTest.cpp
@@ -113,10 +113,11 @@ public:
     eulers->setComponent(0, 1, phi);
     eulers->setComponent(0, 2, phi2);
 
+    using StringContainerType = std::vector<QString>;
     using OCType = OrientationConverter<float>;
-    QVector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
-    QVector<QString> tStrings = OCType::GetOrientationTypeStrings();
-    QVector<OCType::Pointer> converters(6);
+    std::vector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
+    StringContainerType tStrings = OCType::GetOrientationTypeStrings<StringContainerType>();
+    std::vector<OCType::Pointer> converters(6);
     converters[0] = EulerConverter<float>::New();
     converters[1] = OrientationMatrixConverter<float>::New();
     converters[2] = QuaternionConverter<float>::New();
@@ -126,7 +127,7 @@ public:
     // converters[6] = CubochoricConverter<float>::New();
 
     OrientationTransformation::ResultType result;
-    QVector<int> strides = OCType::GetComponentCounts();
+    std::vector<int> strides = OCType::GetComponentCounts<std::vector<int>>();
 
     for(int t0 = 0; t0 < 1; t0++)
     {

--- a/Source/OrientationLib/Test/TextureTest.cpp
+++ b/Source/OrientationLib/Test/TextureTest.cpp
@@ -1,47 +1,59 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <iostream>
 #include <vector>
 #include <string>
 
 #include "OrientationLib/Texture/Texture.hpp"
+#include "OrientationLib/Texture/StatsGen.hpp"
+#include "OrientationLib/LaueOps/CubicLowOps.h"
 #include "OrientationLib/LaueOps/CubicOps.h"
+#include "OrientationLib/LaueOps/HexagonalLowOps.h"
+#include "OrientationLib/LaueOps/HexagonalOps.h"
+#include "OrientationLib/LaueOps/MonoclinicOps.h"
+#include "OrientationLib/LaueOps/OrthoRhombicOps.h"
+#include "OrientationLib/LaueOps/TetragonalLowOps.h"
+#include "OrientationLib/LaueOps/TetragonalOps.h"
+#include "OrientationLib/LaueOps/TriclinicOps.h"
+#include "OrientationLib/LaueOps/TrigonalLowOps.h"
+#include "OrientationLib/LaueOps/TrigonalOps.h"
 
+#include "UnitTestSupport.hpp"
+
+#include "OrientationLibTestFileLocations.h"
 
 /**
  * @brief These tests are just here to make sure the code compiles. The tests will
@@ -56,40 +68,108 @@ class TextureTest
     TextureTest() = default;
     ~TextureTest() = default;
 
-    void operator()()
+    template <class LaueOps>
+    void TestTextureMdf()
     {
-      QVector<float> e1s;
-      QVector<float> e2s;
-      QVector<float> e3s;
-      QVector<float> weights;
-      QVector<float> sigmas;
-      QVector<float> odf;
+      LaueOps ops;
+      std::cout << "======================================================" << std::endl;
+      std::cout << ops.getNameOfClass().toStdString() << " MDF Plot Values" << std::endl;
 
-      CubicOps cubicOps;
-      HexagonalOps hexagonalOps;
-      OrthoRhombicOps orthOps;
+      std::vector<float> odf;
 
-      size_t numEntries = e1s.size();
-      odf.resize(cubicOps.getODFSize());
-      Texture::CalculateCubicODFData(e1s.data(), e2s.data(), e3s.data(), weights.data(), sigmas.data(), true, odf.data(), numEntries);
-      odf.resize(hexagonalOps.getODFSize());
-      Texture::CalculateHexODFData(e1s.data(), e2s.data(), e3s.data(), weights.data(), sigmas.data(), true,
-                                   odf.data(), numEntries);
+      int size = 10000;
+      std::vector<float> e1s;
+      std::vector<float> e2s;
+      std::vector<float> e3s;
+      std::vector<float> sigmas;
+      std::vector<float> angles;
+      std::vector<float> axes;
+      std::vector<float> weights;
+      size_t numEntries = static_cast<size_t>(e1s.size());
+      std::cout << "   Generating ODF....." << std::endl;
+      Texture::CalculateODFData<float, LaueOps, std::vector<float>>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
 
+      // Allocate a new vector to hold the mdf data
+      std::vector<float> mdf;
 
-      odf.resize(orthOps.getODFSize());
-      Texture::CalculateOrthoRhombicODFData(e1s.data(), e2s.data(), e3s.data(), weights.data(), sigmas.data(), true,
-                                            odf.data(), numEntries);
+      std::cout << "   Generating MDF....." << std::endl;
 
-
-      //int size = 1000;
+      // Calculate the MDF Data using the ODF data and the rows from the MDF Table model
+      Texture::CalculateMDFData<float, LaueOps, std::vector<float>>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
       // Now generate the actual XY point data that gets plotted.
       // These are the output vectors
-      QVector<float> angles;
-      QVector<float> axes;
-      QVector<float> mdf(CubicOps::k_MdfSize);
 
-      Texture::CalculateMDFData<float, CubicOps>(angles.data(), axes.data(), weights.data(), odf.data(), mdf.data(), angles.size());
+      int npoints = 36;
+      std::vector<float> x(npoints);
+      std::vector<float> y(npoints);
+      std::cout << "   Generating MDF Plot Data....." << std::endl;
+
+      int32_t err = StatsGen::GenMDFPlotData<float, LaueOps, std::vector<float>>(mdf, x, y, size);
+      if(err < 0)
+      {
+        std::cout << "Error Generating MDF Plot Valeus" << std::endl;
+        return;
+      }
+
+      std::cout << "    npoints: " << x.size() << std::endl;
+      for(size_t i = 0; i < x.size(); i++)
+      {
+        std::cout << x[i] << ", " << y[i] << std::endl;
+      }
+    }
+
+    void TestMdfGeneration()
+    {
+      TestTextureMdf<CubicLowOps>();
+      TestTextureMdf<CubicOps>();
+      TestTextureMdf<HexagonalLowOps>();
+      TestTextureMdf<HexagonalOps>();
+      TestTextureMdf<MonoclinicOps>();
+      TestTextureMdf<OrthoRhombicOps>();
+      TestTextureMdf<TetragonalLowOps>();
+      TestTextureMdf<TetragonalOps>();
+      TestTextureMdf<TriclinicOps>();
+      TestTextureMdf<TrigonalLowOps>();
+      TestTextureMdf<TrigonalOps>();
+    }
+
+    template <class LaueOps>
+    void TestTextureOdf()
+    {
+      std::vector<float> e1s;
+      std::vector<float> e2s;
+      std::vector<float> e3s;
+      std::vector<float> weights;
+      std::vector<float> sigmas;
+      std::vector<float> odf;
+
+      LaueOps ops;
+      size_t numEntries = e1s.size();
+      Texture::CalculateODFData<float, LaueOps, std::vector<float>>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+    }
+
+    void TestOdfGeneration()
+    {
+      TestTextureOdf<CubicLowOps>();
+      TestTextureOdf<CubicOps>();
+      TestTextureOdf<HexagonalLowOps>();
+      TestTextureOdf<HexagonalOps>();
+      TestTextureOdf<MonoclinicOps>();
+      TestTextureOdf<OrthoRhombicOps>();
+      TestTextureOdf<TetragonalLowOps>();
+      TestTextureOdf<TetragonalOps>();
+      TestTextureOdf<TriclinicOps>();
+      TestTextureOdf<TrigonalLowOps>();
+      TestTextureOdf<TrigonalOps>();
+    }
+
+    void operator()()
+    {
+      std::cout << "#### TextureTest Starting ####" << std::endl;
+
+      int err = EXIT_SUCCESS;
+      DREAM3D_REGISTER_TEST(TestOdfGeneration())
+      DREAM3D_REGISTER_TEST(TestMdfGeneration())
     }
 
   public:

--- a/Source/OrientationLib/Texture/Texture.hpp
+++ b/Source/OrientationLib/Texture/Texture.hpp
@@ -1,42 +1,44 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
 #include <fstream>
 #include <vector>
+#include <chrono>
+#include <random>
 
 #include <QtCore/QString>
 
@@ -54,13 +56,10 @@
 #include "OrientationLib/LaueOps/OrthoRhombicOps.h"
 
 /**
- * @class Texture Texture.h AIM/Common/Texture.h
- * @brief This class holds default data for Orientation Distribution Function
+ * @brief This class holds default data for Orientation Distribution Function (ODF)
+ * and Misorientation Distribution Functions (MDF)
  * calculations that the DREAM3D package will perform.
  *
- * @author Micharl A. Groeber for US Air Force Research Laboratory
- * @date Feb 1, 2011
- * @version 1.0
  */
 
 class Texture
@@ -69,23 +68,27 @@ public:
   virtual ~Texture() = default;
 
   /**
-  * @brief This will calculate ODF data based on an array of weights that are
-  * passed in and a Cubic Crystal Structure. The input data for the
-  * euler angles is in Columnar fashion instead of row major format.
-  * @param e1s Pointer to first Euler Angles
-  * @param e2s Pointer to the second euler angles
-  * @param e3s Pointer to the third euler angles
-  * @param weights Pointer to the Array of weights values.
-  * @param sigmas Pointer to the Array of sigma values.
-  * @param normalize Should the ODF data be normalized by the totalWeight value
-  * before returning.
-  * @param odf (OUT) Pointer to the ODF array that is generated from this function. NOTE: The memory
-  * for this MUST have already been allocated. Use ops.getODFSize() to allocate the proper amount
-  * @param numEntries The number of entries of Angle/Weight/Sigmas
-  */
-  template <typename T> static void CalculateCubicODFData(T* e1s, T* e2s, T* e3s, T* weights, T* sigmas, bool normalize, T* odf, size_t numEntries)
+   * @brief This will calculate ODF data based on an array of weights that are
+   * passed in and a Hexagonal Crystal Structure. This is templated on the container
+   * type that holds the data. Containers that adhere to the STL Vector API
+   * should be usable. QVector falls into this category. The input data for the
+   * euler angles is in Columnar fashion instead of row major format.
+   * @param e1s The first euler angles
+   * @param e2s The second euler angles
+   * @param e3s The third euler angles
+   * @param weights Array of weights values.
+   * @param sigmas Array of sigma values.
+   * @param normalize Should the ODF data be normalized by the totalWeight value
+   * before returning.
+   * @param odf (OUT) The ODF data that is generated from this function.
+   * @param numEntries (OUT) The TotalWeight value that is also calculated
+   */
+  template <typename T, class LaueOps, class Container>
+  static void CalculateODFData(Container& e1s, Container& e2s, Container& e3s, Container& weights, Container& sigmas, bool normalize, Container& odf, size_t numEntries)
   {
-    CubicOps ops;
+    LaueOps ops;
+    std::array<size_t, 3> odfNumBins = ops.getOdfNumBins();
+    odf.resize(ops.getODFSize());
     Int32ArrayType::Pointer textureBins = Int32ArrayType::CreateArray(numEntries, "TextureBins", true);
     int32_t* TextureBins = textureBins->getPointer(0);
 
@@ -114,9 +117,9 @@ public:
     for(size_t i = 0; i < numEntries; i++)
     {
       bin = TextureBins[i];
-      bin1 = bin % 18;
-      bin2 = (bin / 18) % 18;
-      bin3 = bin / (18 * 18);
+      bin1 = bin % odfNumBins[0];
+      bin2 = (bin / odfNumBins[0]) % odfNumBins[1];
+      bin3 = bin / (odfNumBins[0] * odfNumBins[1]);
       for(int j = -sigmas[i]; j <= sigmas[i]; j++)
       {
         int jsqrd = j * j;
@@ -129,18 +132,12 @@ public:
             addbin1 = bin1 + int(j);
             addbin2 = bin2 + int(k);
             addbin3 = bin3 + int(l);
-            // if(addbin1 < 0) addbin1 = addbin1 + 18;
-            // if(addbin1 >= 18) addbin1 = addbin1 - 18;
-            // if(addbin2 < 0) addbin2 = addbin2 + 18;
-            // if(addbin2 >= 18) addbin2 = addbin2 - 18;
-            // if(addbin3 < 0) addbin3 = addbin3 + 18;
-            // if(addbin3 >= 18) addbin3 = addbin3 - 18;
             int good = 1;
             if(addbin1 < 0)
             {
               good = 0;
             }
-            if(addbin1 >= 18)
+            if(addbin1 >= odfNumBins[0])
             {
               good = 0;
             }
@@ -148,7 +145,7 @@ public:
             {
               good = 0;
             }
-            if(addbin2 >= 18)
+            if(addbin2 >= odfNumBins[1])
             {
               good = 0;
             }
@@ -156,11 +153,11 @@ public:
             {
               good = 0;
             }
-            if(addbin3 >= 18)
+            if(addbin3 >= odfNumBins[2])
             {
               good = 0;
             }
-            addbin = (addbin3 * 18 * 18) + (addbin2 * 18) + (addbin1);
+            addbin = (addbin3 * odfNumBins[0] * odfNumBins[1]) + (addbin2 * odfNumBins[0]) + (addbin1);
             dist = powf((jsqrd + ksqrd + lsqrd), 0.5);
             fraction = 1.0 - (double(dist / int(sigmas[i])) * double(dist / int(sigmas[i])));
             if(dist <= int(sigmas[i]) && good == 1)
@@ -177,283 +174,9 @@ public:
         }
       }
     }
-    if(totaladdweight > totalweight)
-    {
-      float scale = (totaladdweight / totalweight);
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] = odf[i] / scale;
-      }
-    }
-    else
-    {
-      float remainingweight = totalweight - totaladdweight;
-      float background = remainingweight / static_cast<float>(ops.getODFSize());
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] += background;
-      }
-    }
-    if(normalize)
-    {
-      // Normalize the odf
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] = odf[i] / totalweight;
-      }
-    }
-  }
-
-  /**
-  * @brief This will calculate ODF data based on an array of weights that are
-  * passed in and a Hexagonal Crystal Structure. This is templated on the container
-  * type that holds the data. Containers that adhere to the STL Vector API
-  * should be usable. QVector falls into this category. The input data for the
-  * euler angles is in Columnar fashion instead of row major format.
-  * @param e1s The first euler angles
-  * @param e2s The second euler angles
-  * @param e3s The third euler angles
-  * @param weights Array of weights values.
-  * @param sigmas Array of sigma values.
-  * @param normalize Should the ODF data be normalized by the totalWeight value
-  * before returning.
-  * @param odf (OUT) The ODF data that is generated from this function.
-  * @param numEntries (OUT) The TotalWeight value that is also calculated
-  */
-  template <typename T> static void CalculateHexODFData(T* e1s, T* e2s, T* e3s, T* weights, T* sigmas, bool normalize, T* odf, size_t numEntries)
-  {
-
-    HexagonalOps hexOps;
-    Int32ArrayType::Pointer textureBins = Int32ArrayType::CreateArray(numEntries, "TextureBins", true);
-    int32_t* TextureBins = textureBins->getPointer(0);
-    float addweight = 0;
-    float totaladdweight = 0;
-    float totalweight = float(hexOps.getODFSize());
-    int bin, addbin;
-    int bin1, bin2, bin3;
-    int addbin1, addbin2, addbin3;
-    float dist, fraction;
-    HexagonalOps ops;
-    for(size_t i = 0; i < numEntries; i++)
-    {
-      OrientationF eu(e1s[i], e2s[i], e3s[i]);
-      OrientationD rod = OrientationTransformation::eu2ro<OrientationF, OrientationD>(eu);
-
-      rod = ops.getODFFZRod(rod);
-      bin = ops.getOdfBin(rod);
-      TextureBins[i] = static_cast<int>(bin);
-    }
-
-    for(int i = 0; i < hexOps.getODFSize(); i++)
-    {
-      odf[i] = 0;
-    }
-    for(size_t i = 0; i < numEntries; i++)
-    {
-      bin = TextureBins[i];
-      bin1 = bin % 36;
-      bin2 = (bin / 36) % 36;
-      bin3 = bin / (36 * 36);
-      for(int j = -sigmas[i]; j <= sigmas[i]; j++)
-      {
-        int jsqrd = j * j;
-        for(int k = -sigmas[i]; k <= sigmas[i]; k++)
-        {
-          int ksqrd = k * k;
-          for(int l = -sigmas[i]; l <= sigmas[i]; l++)
-          {
-            int lsqrd = l * l;
-            addbin1 = bin1 + int(j);
-            addbin2 = bin2 + int(k);
-            addbin3 = bin3 + int(l);
-            // if(addbin1 < 0) addbin1 = addbin1 + 36;
-            // if(addbin1 >= 36) addbin1 = addbin1 - 36;
-            // if(addbin2 < 0) addbin2 = addbin2 + 36;
-            // if(addbin2 >= 36) addbin2 = addbin2 - 36;
-            // if(addbin3 < 0) addbin3 = addbin3 + 12;
-            // if(addbin3 >= 12) addbin3 = addbin3 - 12;
-            int good = 1;
-            if(addbin1 < 0)
-            {
-              good = 0;
-            }
-            if(addbin1 >= 36)
-            {
-              good = 0;
-            }
-            if(addbin2 < 0)
-            {
-              good = 0;
-            }
-            if(addbin2 >= 36)
-            {
-              good = 0;
-            }
-            if(addbin3 < 0)
-            {
-              good = 0;
-            }
-            if(addbin3 >= 12)
-            {
-              good = 0;
-            }
-            addbin = (addbin3 * 36 * 36) + (addbin2 * 36) + (addbin1);
-            dist = powf((jsqrd + ksqrd + lsqrd), 0.5);
-            fraction = 1.0 - (double(dist / int(sigmas[i])) * double(dist / int(sigmas[i])));
-            if(dist <= int(sigmas[i]) && good == 1)
-            {
-              addweight = (weights[i] * fraction);
-              if(sigmas[i] == 0.0)
-              {
-                addweight = weights[i];
-              }
-              odf[addbin] = odf[addbin] + addweight;
-              totaladdweight = totaladdweight + addweight;
-            }
-          }
-        }
-      }
-    }
-    if(totaladdweight > totalweight)
-    {
-      float scale = (totaladdweight / totalweight);
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] = odf[i] / scale;
-      }
-    }
-    else
-    {
-      float remainingweight = totalweight - totaladdweight;
-      float background = remainingweight / static_cast<float>(ops.getODFSize());
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] += background;
-      }
-    }
-    if(normalize)
-    {
-      // Normalize the odf
-      for(int i = 0; i < ops.getODFSize(); i++)
-      {
-        odf[i] = odf[i] / totalweight;
-      }
-    }
-  }
-
-  /**
-  * @brief This will calculate ODF data based on an array of weights that are
-  * passed in and a OrthoRhombic Crystal Structure. This is templated on the container
-  * type that holds the data. Containers that adhere to the STL Vector API
-  * should be usable. QVector falls into this category. The input data for the
-  * euler angles is in Columnar fashion instead of row major format.
-  * @param e1s The first euler angles
-  * @param e2s The second euler angles
-  * @param e3s The third euler angles
-  * @param weights Array of weights values.
-  * @param sigmas Array of sigma values.
-  * @param normalize Should the ODF data be normalized by the totalWeight value
-  * before returning.
-  * @param odf (OUT) The ODF data that is generated from this function.
-  * @param numEntries The TotalWeight value that is also calculated
-  */
-  template <typename T> static void CalculateOrthoRhombicODFData(T* e1s, T* e2s, T* e3s, T* weights, T* sigmas, bool normalize, T* odf, size_t numEntries)
-  {
-    //  using OrientArrayType = OrientationArray<T>;
-    using OrientationD = Orientation<double>;
-    // using OrientTransformsType = OrientationTransforms<OrientArrayType, T>;
-
-    OrthoRhombicOps ops;
-    SIMPL_RANDOMNG_NEW()
-    Int32ArrayType::Pointer textureBins = Int32ArrayType::CreateArray(numEntries, "TextureBins", true);
-    int32_t* TextureBins = textureBins->getPointer(0);
-    float addweight = 0;
-    float totaladdweight = 0;
-    float totalweight = float(ops.getODFSize());
-    int bin, addbin;
-    int bin1, bin2, bin3;
-    int addbin1, addbin2, addbin3;
-    float dist, fraction;
-    for(size_t i = 0; i < numEntries; i++)
-    {
-      OrientationD eu(e1s[i], e2s[i], e3s[i]);
-      OrientationD rod = OrientationTransformation::eu2ro<OrientationD, OrientationD>(eu);
-
-      rod = ops.getODFFZRod(rod);
-      bin = ops.getOdfBin(rod);
-      TextureBins[i] = static_cast<int>(bin);
-    }
-
-    for(int i = 0; i < ops.getODFSize(); i++)
-    {
-      odf[i] = 0;
-    }
-    for(size_t i = 0; i < numEntries; i++)
-    {
-      bin = TextureBins[i];
-      bin1 = bin % 36;
-      bin2 = (bin / 36) % 36;
-      bin3 = bin / (36 * 36);
-      for(int j = -sigmas[i]; j <= sigmas[i]; j++)
-      {
-        int jsqrd = j * j;
-        for(int k = -sigmas[i]; k <= sigmas[i]; k++)
-        {
-          int ksqrd = k * k;
-          for(int l = -sigmas[i]; l <= sigmas[i]; l++)
-          {
-            int lsqrd = l * l;
-            addbin1 = bin1 + int(j);
-            addbin2 = bin2 + int(k);
-            addbin3 = bin3 + int(l);
-            // if (addbin1 < 0) addbin1 = addbin1 + 36;
-            // if (addbin1 >= 36) addbin1 = addbin1 - 36;
-            // if (addbin2 < 0) addbin2 = addbin2 + 36;
-            // if (addbin2 >= 36) addbin2 = addbin2 - 36;
-            // if (addbin3 < 0) addbin3 = addbin3 + 36;
-            // if (addbin3 >= 36) addbin3 = addbin3 - 36;
-            int good = 1;
-            if(addbin1 < 0)
-            {
-              good = 0;
-            }
-            if(addbin1 >= 36)
-            {
-              good = 0;
-            }
-            if(addbin2 < 0)
-            {
-              good = 0;
-            }
-            if(addbin2 >= 36)
-            {
-              good = 0;
-            }
-            if(addbin3 < 0)
-            {
-              good = 0;
-            }
-            if(addbin3 >= 36)
-            {
-              good = 0;
-            }
-            addbin = (addbin3 * 36 * 36) + (addbin2 * 36) + (addbin1);
-            dist = sqrtf(jsqrd + ksqrd + lsqrd);
-            fraction = 1.0 - (float(dist / int(sigmas[i])) * float(dist / int(sigmas[i])));
-            if(dist <= int(sigmas[i]) && good == 1)
-            {
-              addweight = (weights[i] * fraction);
-              if(sigmas[i] == 0.0)
-              {
-                addweight = weights[i];
-              }
-              odf[addbin] = odf[addbin] + addweight;
-              totaladdweight = totaladdweight + addweight;
-            }
-          }
-        }
-      }
-    }
+    // These next loops *look* like they can be parallelized but the arrays are not large enough
+    // to see any benefit so don't go down that road. std::transform is also slower than the
+    // manual loops that are coded.
     if(totaladdweight > totalweight)
     {
       float scale = (totaladdweight / totalweight);
@@ -492,16 +215,24 @@ public:
    * the value passed here is the minium size of all the arrays. The sizes of the ODF and MDF arrays are
    * determined by calling the getODFSize and getMDFSize functions of the parameterized LaueOps class.
    */
-  template <typename T, class LaueOps>
-  static void CalculateMDFData(T* angles, T* axes, T* weights, T* odf, T* mdf, size_t numEntries)
+  template <typename T, class LaueOps, class Container>
+  static void CalculateMDFData(Container& angles, Container& axes, Container& weights, Container& odf, Container& mdf, size_t numEntries)
   {
 
     LaueOps orientationOps;
     const int odfsize = orientationOps.getODFSize();
     const int mdfsize = orientationOps.getMDFSize();
+    mdf.resize(orientationOps.getMDFSize());
+    // uint64_t m_Seed = QDateTime::currentMSecsSinceEpoch();
 
-    uint64_t m_Seed = QDateTime::currentMSecsSinceEpoch();
-    SIMPL_RANDOMNG_NEW_SEEDED(m_Seed);
+    // Create a Random Number generator
+    std::random_device randomDevice;           // Will be used to obtain a seed for the random number engine
+    std::mt19937_64 generator(randomDevice()); // Standard mersenne_twister_engine seeded with rd()
+    std::mt19937_64::result_type seed = static_cast<std::mt19937_64::result_type>(std::chrono::steady_clock::now().time_since_epoch().count());
+    generator.seed(seed);
+    std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+    std::array<double, 3> randx3;
 
     int mbin;
 
@@ -530,10 +261,9 @@ public:
 
     for(int i = 0; i < remainingcount; i++)
     {
-      m_Seed++;
-      SIMPL_RANDOMNG_NEW_SEEDED(m_Seed);
-      random1 = rg.genrand_res53();
-      random2 = rg.genrand_res53();
+
+      random1 = distribution(generator);
+      random2 = distribution(generator);
       choose1 = 0;
       choose2 = 0;
 
@@ -553,11 +283,16 @@ public:
         }
       }
 
-      OrientationD eu = orientationOps.determineEulerAngles(m_Seed, choose1);
+      randx3[0] = distribution(generator);
+      randx3[1] = distribution(generator);
+      randx3[2] = distribution(generator);
+      OrientationD eu = orientationOps.determineEulerAngles(randx3.data(), choose1);
       QuatType q1 = OrientationTransformation::eu2qu<OrientationD, QuatType>(eu);
 
-      m_Seed++;
-      eu = orientationOps.determineEulerAngles(m_Seed, choose2);
+      randx3[0] = distribution(generator);
+      randx3[1] = distribution(generator);
+      randx3[2] = distribution(generator);
+      eu = orientationOps.determineEulerAngles(randx3.data(), choose2);
       QuatType q2 = OrientationTransformation::eu2qu<OrientationD, QuatType>(eu);
       double n1 = 0.0, n2 = 0.0, n3 = 0.0;
       double w = orientationOps.getMisoQuat(q1, q2, n1, n2, n3);
@@ -565,7 +300,7 @@ public:
       OrientationD ax(n1, n2, n3, w);
       OrientationD ro = OrientationTransformation::ax2ro<OrientationD, OrientationD>(ax);
 
-      ro = orientationOps.getMDFFZRod(ro);
+      ro = orientationOps.getMDFFZRod(ro); // <==== THIS IS NOT IMPELMENTED FOR ALL LAUE CLASSES
       mbin = orientationOps.getMisoBin(ro);
       if(mdf[mbin] >= 0)
       {

--- a/Source/OrientationLib/Texture/Texture.hpp
+++ b/Source/OrientationLib/Texture/Texture.hpp
@@ -294,10 +294,7 @@ public:
       randx3[2] = distribution(generator);
       eu = orientationOps.determineEulerAngles(randx3.data(), choose2);
       QuatType q2 = OrientationTransformation::eu2qu<OrientationD, QuatType>(eu);
-      double n1 = 0.0, n2 = 0.0, n3 = 0.0;
-      double w = orientationOps.getMisoQuat(q1, q2, n1, n2, n3);
-
-      OrientationD ax(n1, n2, n3, w);
+      OrientationD ax = orientationOps.calculateMisorientation(q1, q2);
       OrientationD ro = OrientationTransformation::ax2ro<OrientationD, OrientationD>(ax);
 
       ro = orientationOps.getMDFFZRod(ro); // <==== THIS IS NOT IMPELMENTED FOR ALL LAUE CLASSES

--- a/Source/OrientationLib/Texture/TexturePreset.cpp
+++ b/Source/OrientationLib/Texture/TexturePreset.cpp
@@ -52,9 +52,9 @@ TexturePreset::~TexturePreset() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<TexturePreset::Pointer> CubicTexturePresets::getTextures()
+std::vector<TexturePreset::Pointer> CubicTexturePresets::getTextures()
 {
-  QVector<TexturePreset::Pointer> textures;
+  std::vector<TexturePreset::Pointer> textures;
   ADD_NEW_TEXTURE( "Brass", Ebsd::CrystalStructure::Cubic_High, 35.0, 45.0, 0.0)
   ADD_NEW_TEXTURE( "S",  Ebsd::CrystalStructure::Cubic_High, 59.0, 37.0, 63.0)
   ADD_NEW_TEXTURE( "Copper", Ebsd::CrystalStructure::Cubic_High, 90.0, 35.0, 45.0)
@@ -75,10 +75,10 @@ QVector<TexturePreset::Pointer> CubicTexturePresets::getTextures()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<TexturePreset::Pointer> HexTexturePresets::getTextures()
+std::vector<TexturePreset::Pointer> HexTexturePresets::getTextures()
 {
-  QVector<TexturePreset::Pointer> textures;
-//  ADD_NEW_TEXTURE( "Brass", Ebsd::CrystalStructure::Hexagonal, 35.0, 45.0, 0.0)
+  std::vector<TexturePreset::Pointer> textures;
+  //  ADD_NEW_TEXTURE( "Brass", Ebsd::CrystalStructure::Hexagonal, 35.0, 45.0, 0.0)
 
   return textures;
 }

--- a/Source/OrientationLib/Texture/TexturePreset.h
+++ b/Source/OrientationLib/Texture/TexturePreset.h
@@ -37,13 +37,11 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
-#include <QtCore/QVector>
 #include <QtCore/QString>
 
 #include "EbsdLib/EbsdConstants.h"
-
-
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/Constants.h"
@@ -64,7 +62,7 @@ class OrientationLib_EXPORT TexturePreset
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    using Container = QVector<Pointer>;
+    using Container = std::vector<Pointer>;
 
     static Pointer New();
 

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.cpp
@@ -33,16 +33,14 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "VisualizeGBCDGMT.h"
 
-#include <QtCore/QDir>
+#include <memory>
 
+#include <QtCore/QDir>
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/DataContainers/DataContainer.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
@@ -57,6 +55,7 @@
 #include "OrientationLib/Core/Orientation.hpp"
 #include "OrientationLib/Core/OrientationTransformation.hpp"
 #include "OrientationLib/Core/Quaternion.hpp"
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "ImportExport/ImportExportConstants.h"
 #include "ImportExport/ImportExportVersion.h"
@@ -75,7 +74,7 @@ VisualizeGBCDGMT::VisualizeGBCDGMT()
   m_MisorientationRotation.k = 0.0f;
   m_MisorientationRotation.l = 0.0f;
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.h
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDGMT.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/SIMPLib.h"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "ImportExport/ImportExportDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The VisualizeGBCDGMT class. See [Filter documentation](@ref visualizegbcdgmt) for details.
@@ -249,8 +252,7 @@ private:
   DataArrayPath m_GBCDArrayPath = {};
   DataArrayPath m_CrystalStructuresArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-  QVector<float> gmtValues;
+  LaueOpsContainer m_OrientationOps;  QVector<float> gmtValues;
 
 public:
   VisualizeGBCDGMT(const VisualizeGBCDGMT&) = delete;            // Copy Constructor Not Implemented

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.cpp
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.cpp
@@ -32,17 +32,14 @@
  *    United States Prime Contract Navy N00173-07-C-2068
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#include "VisualizeGBCDPoleFigure.h"
 
 #include <memory>
 
-#include "VisualizeGBCDPoleFigure.h"
-
 #include <QtCore/QDir>
-
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/AxisAngleFilterParameter.h"
@@ -54,7 +51,7 @@
 #include "SIMPLib/Utilities/FileSystemPathHelper.h"
 #include "SIMPLib/Utilities/SIMPLibEndian.h"
 
-
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "ImportExport/ImportExportConstants.h"
 #include "ImportExport/ImportExportVersion.h"
@@ -73,7 +70,7 @@ VisualizeGBCDPoleFigure::VisualizeGBCDPoleFigure()
   m_MisorientationRotation.k = 0.0f;
   m_MisorientationRotation.l = 0.0f;
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.h
+++ b/Source/Plugins/ImportExport/ImportExportFilters/VisualizeGBCDPoleFigure.h
@@ -45,9 +45,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/SIMPLib.h"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "ImportExport/ImportExportDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The VisualizeGBCDPoleFigure class. See [Filter documentation](@ref visualizegbcdpolefigure) for details.
@@ -252,8 +255,7 @@ private:
   DataArrayPath m_GBCDArrayPath = {};
   DataArrayPath m_CrystalStructuresArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   /**
    * @brief writeCoords Writes a set of Axis coordinates to that are needed
    * for a Rectilinear Grid based data set to a VTK file

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/AxisAngleWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/AxisAngleWidget.cpp
@@ -44,7 +44,7 @@
 #include "SIMPLib/Math/SIMPLibMath.h"
 
 #include "OrientationLib/Core/OrientationTransformation.hpp"
-#include "OrientationLib/OrientationMath/OrientationRepresentation.h"
+#include "OrientationLib/Core/OrientationRepresentation.h"
 #include "OrientationUtilityCalculator.h"
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/CubochoricWidget.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/CubochoricWidget.cpp
@@ -39,7 +39,7 @@
 
 #include "OrientationLib/Core/OrientationTransformation.hpp"
 #include "OrientationLib/OrientationMath/OrientationConverter.hpp"
-#include "OrientationLib/OrientationMath/OrientationRepresentation.h"
+#include "OrientationLib/Core/OrientationRepresentation.h"
 
 #include "OrientationUtilityCalculator.h"
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.cpp
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.cpp
@@ -105,7 +105,7 @@ QVector<double> OrientationUtilityCalculator::getValues(OrientationRepresentatio
   converters[5] = HomochoricConverter<double>::New();
   converters[6] = CubochoricConverter<double>::New();
 
-  QVector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
+  std::vector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
 
   std::vector<size_t> cDims(1, m_InputData.size());
   DataArray<double>::Pointer inputDataArray = DataArray<double>::CreateArray(1, cDims, "Input Data", true);

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationUtilityCalculator.h
@@ -37,7 +37,7 @@
 
 #include <QtWidgets/QWidget>
 
-#include "OrientationLib/OrientationMath/OrientationRepresentation.h"
+#include "OrientationLib/Core/OrientationRepresentation.h"
 
 class OrientationUtilityCalculator;
 

--- a/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationWidget.h
+++ b/Source/Plugins/OrientationAnalysis/Gui/Widgets/OrientationWidget.h
@@ -37,7 +37,7 @@
 
 #include <QtWidgets/QWidget>
 
-#include "OrientationLib/OrientationMath/OrientationRepresentation.h"
+#include "OrientationLib/Core/OrientationRepresentation.h"
 
 class OrientationUtilityCalculator;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
@@ -224,7 +224,6 @@ void BadDataNeighborOrientationCheck::execute()
 
   float w = 10000.0f;
 
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   uint32_t phase1 = 0, phase2 = 0;
 
   QVector<int32_t> neighborCount(totalPoints, 0);
@@ -274,7 +273,8 @@ void BadDataNeighborOrientationCheck::execute()
 
           if(m_CellPhases[i] == m_CellPhases[neighbor] && m_CellPhases[i] > 0)
           {
-            w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+            OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+            w = axisAngle[3];
           }
           if(w < misorientationTolerance)
           {
@@ -341,7 +341,8 @@ void BadDataNeighborOrientationCheck::execute()
 
               if(m_CellPhases[i] == m_CellPhases[neighbor] && m_CellPhases[i] > 0)
               {
-                w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+                OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+                w = axisAngle[3];
               }
               if(w < misorientationTolerance)
               {

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.cpp
@@ -33,14 +33,13 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "BadDataNeighborOrientationCheck.h"
+
+#include <memory>
 
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatFilterParameter.h"
@@ -49,6 +48,8 @@
 #include "SIMPLib/Geometry/ImageGeom.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
+
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
@@ -64,7 +65,7 @@ BadDataNeighborOrientationCheck::BadDataNeighborOrientationCheck()
 , m_CrystalStructuresArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellEnsembleAttributeMatrixName, SIMPL::EnsembleData::CrystalStructures)
 , m_QuatsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Quats)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/BadDataNeighborOrientationCheck.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The BadDataNeighborOrientationCheck class. See [Filter documentation](@ref baddataneighbororientationcheck) for details.
@@ -258,8 +261,7 @@ private:
   DataArrayPath m_CrystalStructuresArrayPath = {};
   DataArrayPath m_QuatsArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   BadDataNeighborOrientationCheck(const BadDataNeighborOrientationCheck&) = delete; // Copy Constructor Not Implemented
   BadDataNeighborOrientationCheck(BadDataNeighborOrientationCheck&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/ConvertOrientations.cpp
@@ -89,8 +89,7 @@ void ConvertOrientations::setupFilterParameters()
     parameter->setSetterCallback(SIMPL_BIND_SETTER(ConvertOrientations, this, InputType));
     parameter->setGetterCallback(SIMPL_BIND_GETTER(ConvertOrientations, this, InputType));
 
-    QVector<QString> inputChoices = OrientationConverter<float>::GetOrientationTypeStrings();
-    parameter->setChoices(inputChoices);
+    parameter->setChoices(OrientationConverter<float>::GetOrientationTypeStrings<QVector<QString>>());
     parameter->setCategory(FilterParameter::Parameter);
     parameters.push_back(parameter);
   }
@@ -102,8 +101,7 @@ void ConvertOrientations::setupFilterParameters()
     parameter->setSetterCallback(SIMPL_BIND_SETTER(ConvertOrientations, this, OutputType));
     parameter->setGetterCallback(SIMPL_BIND_GETTER(ConvertOrientations, this, OutputType));
 
-    QVector<QString> inputChoices = OrientationConverter<float>::GetOrientationTypeStrings();
-    parameter->setChoices(inputChoices);
+    parameter->setChoices(OrientationConverter<float>::GetOrientationTypeStrings<QVector<QString>>());
     parameter->setCategory(FilterParameter::Parameter);
     parameters.push_back(parameter);
   }
@@ -181,12 +179,12 @@ void ConvertOrientations::dataCheck()
     return;
   }
   int numComps = iDataArrayPtr->getNumberOfComponents();
-  QVector<int32_t> componentCounts = OrientationConverter<float>::GetComponentCounts();
+  std::vector<int32_t> componentCounts = OrientationConverter<float>::GetComponentCounts<std::vector<int32_t>>();
   if(numComps != componentCounts[getInputType()])
   {
     QString sizeNameMappingString;
     QTextStream strm(&sizeNameMappingString);
-    QVector<QString> names = OrientationConverter<float>::GetOrientationTypeStrings();
+    std::vector<QString> names = OrientationConverter<float>::GetOrientationTypeStrings<std::vector<QString>>();
     for(int i = 0; i < OrientationConverter<float>::GetMaxIndex() + 1; i++)
     {
       strm << "[" << names[i] << "=" << componentCounts[i] << "] ";
@@ -226,7 +224,7 @@ void generateRepresentation(ConvertOrientations* filter, typename DataArray<T>::
 {
   using ArrayType = typename DataArray<T>::Pointer;
   using OCType = OrientationConverter<T>;
-  QVector<typename OCType::Pointer> converters(7);
+  std::vector<typename OCType::Pointer> converters(7);
 
   converters[0] = EulerConverter<T>::New();
   converters[1] = OrientationMatrixConverter<T>::New();
@@ -236,7 +234,7 @@ void generateRepresentation(ConvertOrientations* filter, typename DataArray<T>::
   converters[5] = HomochoricConverter<T>::New();
   converters[6] = CubochoricConverter<T>::New();
 
-  QVector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
+  std::vector<OrientationRepresentation::Type> ocTypes = OCType::GetOrientationTypes();
 
   converters[filter->getInputType()]->setInputData(inputOrientations);
   converters[filter->getInputType()]->convertRepresentationTo(ocTypes[filter->getOutputType()]);
@@ -277,7 +275,7 @@ void ConvertOrientations::execute()
   FloatArrayType::Pointer fArray = std::dynamic_pointer_cast<FloatArrayType>(iDataArrayPtr);
   if(nullptr != fArray.get())
   {
-    QVector<int32_t> componentCounts = OrientationConverter<float>::GetComponentCounts();
+    std::vector<int32_t> componentCounts = OrientationConverter<float>::GetComponentCounts<std::vector<int32_t>>();
     std::vector<size_t> outputCDims(1, componentCounts[getOutputType()]);
     FloatArrayType::Pointer outData = getDataContainerArray()->getPrereqArrayFromPath<DataArray<float>>(this, outputArrayPath, outputCDims);
     generateRepresentation<float>(this, fArray, outData);
@@ -286,7 +284,7 @@ void ConvertOrientations::execute()
   DoubleArrayType::Pointer dArray = std::dynamic_pointer_cast<DoubleArrayType>(iDataArrayPtr);
   if(nullptr != dArray.get())
   {
-    QVector<int32_t> componentCounts = OrientationConverter<double>::GetComponentCounts();
+    std::vector<int32_t> componentCounts = OrientationConverter<double>::GetComponentCounts<std::vector<int32_t>>();
     std::vector<size_t> outputCDims(1, componentCounts[getOutputType()]);
     DoubleArrayType::Pointer outData = getDataContainerArray()->getPrereqArrayFromPath<DataArray<double>>(this, outputArrayPath, outputCDims);
     generateRepresentation<double>(this, dArray, outData);

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.cpp
@@ -179,7 +179,7 @@ void FindAvgCAxes::execute()
   {
     return;
   }
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   size_t totalPoints = m_FeatureIdsPtr.lock()->getNumberOfTuples();
   size_t totalFeatures = m_AvgCAxesPtr.lock()->getNumberOfTuples();

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgCAxes.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindAvgCAxes class. See [Filter documentation](@ref findavgcaxes) for details.
@@ -214,8 +217,7 @@ private:
   DataArrayPath m_FeatureIdsArrayPath = {};
   DataArrayPath m_AvgCAxesArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindAvgCAxes(const FindAvgCAxes&) = delete;            // Copy Constructor Not Implemented
   FindAvgCAxes(FindAvgCAxes&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.cpp
@@ -222,7 +222,7 @@ void FindAvgOrientations::execute()
   {
     return;
   }
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   size_t totalPoints = m_FeatureIdsPtr.lock()->getNumberOfTuples();
   size_t totalFeatures = m_AvgQuatsPtr.lock()->getNumberOfTuples();

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindAvgOrientations.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindAvgOrientations class. See [Filter documentation](@ref findavgorientations) for details.
@@ -262,8 +265,7 @@ private:
   DataArrayPath m_AvgQuatsArrayPath = {};
   DataArrayPath m_AvgEulerAnglesArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindAvgOrientations(const FindAvgOrientations&) = delete; // Copy Constructor Not Implemented
   FindAvgOrientations(FindAvgOrientations&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.cpp
@@ -33,14 +33,13 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "FindBoundaryStrengths.h"
+
+#include <memory>
 
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
@@ -50,6 +49,8 @@
 #include "SIMPLib/Geometry/ImageGeom.h"
 #include "SIMPLib/Geometry/TriangleGeom.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
+
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
@@ -67,7 +68,7 @@ FindBoundaryStrengths::FindBoundaryStrengths()
 , m_SurfaceMeshF7sArrayName(SIMPL::FaceData::SurfaceMeshF7s)
 , m_SurfaceMeshmPrimesArrayName(SIMPL::FaceData::SurfaceMeshmPrimes)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   m_Loading[0] = 1.0f;
   m_Loading[1] = 1.0f;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindBoundaryStrengths.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindBoundaryStrengths class. See [Filter documentation](@ref findboundarystrengths) for details.
@@ -305,8 +308,7 @@ private:
   QString m_SurfaceMeshF7sArrayName = {};
   QString m_SurfaceMeshmPrimesArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   /**
    * @brief dataCheckVoxel Checks for the appropriate parameter values and availability of arrays
    */

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.cpp
@@ -144,7 +144,7 @@ void FindCAxisLocations::execute()
     return;
   }
 
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   FloatArrayType::Pointer quatsPtr = m_QuatsPtr.lock();
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindCAxisLocations.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindCAxisLocations class. See [Filter documentation](@ref findcaxislocations) for details.
@@ -198,8 +201,7 @@ private:
   DataArrayPath m_QuatsArrayPath = {};
   QString m_CAxisLocationsArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindCAxisLocations(const FindCAxisLocations&) = delete; // Copy Constructor Not Implemented
   FindCAxisLocations(FindCAxisLocations&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindDistsToCharactGBs.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindDistsToCharactGBs.cpp
@@ -71,6 +71,9 @@
 #include <tbb/partitioner.h>
 #include <tbb/task_scheduler_init.h>
 
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 /* Create Enumerations to allow the created Attribute Arrays to take part in renaming */
 enum createdPathID : RenameDataPath::DataID_t
 {
@@ -100,8 +103,7 @@ class TrisProcessor
   int32_t* m_Phases;
   int32_t* m_FaceLabels;
   double* m_FaceNormals;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   TrisProcessor(double* __m_DistToTilt, double* __m_DistToTwist, double* __m_DistToSymmetric, double* __m_DistTo180Tilt, uint32_t* __m_CrystalStructures, float* __m_Eulers, int32_t* __m_Phases,
                 int32_t* __m_FaceLabels, double* __m_FaceNormals)
@@ -115,7 +117,7 @@ public:
   , m_FaceLabels(__m_FaceLabels)
   , m_FaceNormals(__m_FaceNormals)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
 
   virtual ~TrisProcessor() = default;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindFeatureNeighborCAxisMisalignments class. See [Filter documentation](@ref findfeatureneighborcaxismisalignments) for details.
@@ -273,8 +276,7 @@ private:
   DataArrayPath m_CrystalStructuresArrayPath = {};
   QString m_AvgCAxisMisalignmentsArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   NeighborList<int32_t>::WeakPointer m_NeighborList;
   NeighborList<float>::WeakPointer m_CAxisMisalignmentList;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindFeatureReferenceCAxisMisorientations class. See [Filter documentation](@ref findfeaturereferencecaxismisorientations) for details.
@@ -278,8 +281,7 @@ private:
   QString m_FeatureStdevCAxisMisorientationsArrayName = {};
   QString m_FeatureReferenceCAxisMisorientationsArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindFeatureReferenceCAxisMisorientations(const FindFeatureReferenceCAxisMisorientations&) = delete; // Copy Constructor Not Implemented
   FindFeatureReferenceCAxisMisorientations(FindFeatureReferenceCAxisMisorientations&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
@@ -291,7 +291,7 @@ void FindFeatureReferenceMisorientations::execute()
   FloatArrayType::Pointer quatsPtr = m_QuatsPtr.lock();
   FloatArrayType::Pointer avgQuatsPtr = m_AvgQuatsPtr.lock();
 
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
+  // float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   uint32_t phase1 = Ebsd::CrystalStructure::UnknownCrystalStructure;
   uint32_t phase2 = Ebsd::CrystalStructure::UnknownCrystalStructure;
   SizeVec3Type udims = m->getGeometryAs<ImageGeom>()->getDimensions();
@@ -354,7 +354,10 @@ void FindFeatureReferenceMisorientations::execute()
             q2 = QuatF(avgQuatsPtr->getTuplePointer(m_Centers[gnum]));
             phase2 = m_CrystalStructures[m_CellPhases[m_Centers[gnum]]];
           }
-          m_FeatureReferenceMisorientations[point] = SIMPLib::Constants::k_180OverPi * m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+
+          OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+
+          m_FeatureReferenceMisorientations[point] = SIMPLib::Constants::k_180OverPi * axisAngle[3]; // convert to degrees
           idx = m_FeatureIds[point] * 2;
           avgMiso[idx + 0]++;
           avgMiso[idx + 1] = avgMiso[idx + 1] + m_FeatureReferenceMisorientations[point];

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.cpp
@@ -282,7 +282,7 @@ void FindFeatureReferenceMisorientations::execute()
     return;
   }
 
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName());
   size_t totalPoints = m_FeatureIdsPtr.lock()->getNumberOfTuples();

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceMisorientations.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindFeatureReferenceMisorientations class. See [Filter documentation](@ref findfeaturereferencemisorientations) for details.
@@ -308,8 +311,7 @@ private:
   QString m_FeatureReferenceMisorientationsArrayName = {};
   int m_ReferenceOrientation = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindFeatureReferenceMisorientations(const FindFeatureReferenceMisorientations&) = delete; // Copy Constructor Not Implemented
   FindFeatureReferenceMisorientations(FindFeatureReferenceMisorientations&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCD.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCD.cpp
@@ -70,6 +70,9 @@
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 /* Create Enumerations to allow the created Attribute Arrays to take part in renaming */
 enum createdPathID : RenameDataPath::DataID_t
 {
@@ -99,8 +102,7 @@ class CalculateGBCDImpl
   BoolArrayType::Pointer m_GbcdHemiCheckArray;
 
   UInt32ArrayType::Pointer m_CrystalStructuresArray;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   CalculateGBCDImpl(size_t i,
                     size_t numMisoReps,
@@ -127,7 +129,7 @@ public:
   , m_GbcdHemiCheckArray(std::move(hemiCheck))
   , m_CrystalStructuresArray(std::move(crystalStructures))
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
   virtual ~CalculateGBCDImpl() = default;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
@@ -42,17 +42,14 @@
  *    United States Prime Contract Navy N00173-07-C-2068
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+#include "FindGBCDMetricBased.h"
 
 #include <memory>
 
-#include "FindGBCDMetricBased.h"
-
 #include <QtCore/QDir>
-
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/AxisAngleFilterParameter.h"
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
@@ -79,6 +76,9 @@
 #include <tbb/partitioner.h>
 #include <tbb/task_scheduler_init.h>
 #endif
+
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
 
 const float FindGBCDMetricBased::k_ResolutionChoices[FindGBCDMetricBased::k_NumberResolutionChoices][2] = {{3.0f, 7.0f}, {5.0f, 5.0f}, {5.0f, 7.0f}, {5.0f, 8.0f},
                                                                                                            {6.0f, 7.0f}, {7.0f, 7.0f}, {8.0f, 8.0f}}; // { for misorient., for planes }
@@ -140,7 +140,7 @@ class TrisSelector
   int32_t m_PhaseOfInterest;
   float (&gFixedT)[3][3];
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
+  LaueOpsContainer m_OrientationOps;
   uint32_t cryst;
   int32_t nsym;
 
@@ -174,7 +174,7 @@ public:
   , m_FaceNormals(__m_FaceNormals)
   , m_FaceAreas(__m_FaceAreas)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
     cryst = __m_CrystalStructures[__m_PhaseOfInterest];
     nsym = m_OrientationOps[cryst]->getNumSymOps();
   }
@@ -812,7 +812,7 @@ void FindGBCDMetricBased::execute()
   // ------------------- before computing the distribution, we must find normalization factors -----
   double ballVolume = FindGBCDMetricBased::k_BallVolumesM3M[getChosenLimitDists()];
   {
-    QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
     int32_t cryst = m_CrystalStructures[m_PhaseOfInterest];
     int32_t nsym = m_OrientationOps[cryst]->getNumSymOps();
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBPDMetricBased.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBPDMetricBased.cpp
@@ -43,16 +43,14 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "FindGBPDMetricBased.h"
 
-#include <QtCore/QDir>
+#include <memory>
 
+#include <QtCore/QDir>
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
@@ -68,7 +66,6 @@
 
 #include "OrientationLib/LaueOps/LaueOps.h"
 
-
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
@@ -79,6 +76,9 @@
 #include <tbb/partitioner.h>
 #include <tbb/task_scheduler_init.h>
 #endif
+
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
 
 namespace GBPDMetricBased
 {
@@ -136,7 +136,7 @@ class TrisSelector
   QVector<TriAreaAndNormals>* selectedTris;
 #endif
   int32_t m_PhaseOfInterest;
-  QVector<LaueOps::Pointer> m_OrientationOps;
+  LaueOpsContainer m_OrientationOps;
   uint32_t cryst;
   int32_t nsym;
   float* m_Eulers = nullptr;
@@ -165,7 +165,7 @@ public:
   , m_FaceNormals(__m_FaceNormals)
   , m_FaceAreas(__m_FaceAreas)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
     cryst = __m_CrystalStructures[__m_PhaseOfInterest];
     nsym = m_OrientationOps[cryst]->getNumSymOps();
   }
@@ -262,8 +262,7 @@ class ProbeDistrib
   double totalFaceArea;
   int numDistinctGBs;
   double ballVolume;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-  uint32_t cryst;
+  LaueOpsContainer m_OrientationOps;  uint32_t cryst;
   int32_t nsym;
 
 public:
@@ -286,7 +285,7 @@ public:
   , ballVolume(__ballVolume)
   , cryst(__cryst)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
     nsym = m_OrientationOps[__cryst]->getNumSymOps();
   }
 
@@ -761,7 +760,7 @@ void FindGBPDMetricBased::execute()
   }
 
   // ------------------- before computing the distribution, we must find normalization factors -----
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
   int32_t cryst = m_CrystalStructures[m_PhaseOfInterest];
   int32_t nsym = m_OrientationOps[cryst]->getNumSymOps();
   double ballVolume = double(nsym) * 2.0 * (1.0 - cos(m_LimitDist));

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
@@ -223,8 +223,8 @@ void FindKernelAvgMisorientations::execute()
   int32_t numVoxel = 0; // number of voxels in the feature...
   bool good = false;
 
-  float w = 0.0f, totalmisorientation = 0.0f;
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
+  float totalmisorientation = 0.0f;
+
   uint32_t phase1 = Ebsd::CrystalStructure::UnknownCrystalStructure;
   uint32_t phase2 = Ebsd::CrystalStructure::UnknownCrystalStructure;
   SizeVec3Type udims = m->getGeometryAs<ImageGeom>()->getDimensions();
@@ -287,13 +287,11 @@ void FindKernelAvgMisorientations::execute()
                 }
                 if(good && m_FeatureIds[point] == m_FeatureIds[neighbor])
                 {
-                  w = std::numeric_limits<float>::max();
-
                   QuatF q2(quatPtr->getTuplePointer(neighbor));
                   phase2 = m_CrystalStructures[m_CellPhases[neighbor]];
-                  w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
-                  w = w * (180.0f / SIMPLib::Constants::k_Pi);
-                  totalmisorientation = totalmisorientation + w;
+                  OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+
+                  totalmisorientation = totalmisorientation + (axisAngle[3] * SIMPLib::Constants::k_180OverPi);
                   numVoxel++;
                 }
               }

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindKernelAvgMisorientations.cpp
@@ -217,7 +217,7 @@ void FindKernelAvgMisorientations::execute()
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName());
 
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
   FloatArrayType::Pointer quatPtr = m_QuatsPtr.lock();
 
   int32_t numVoxel = 0; // number of voxels in the feature...

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.cpp
@@ -76,7 +76,7 @@ FindLocalAverageCAxisMisalignments::FindLocalAverageCAxisMisalignments()
 , m_UnbiasedLocalCAxisMisalignmentsArrayName(SIMPL::FeatureData::UnbiasedLocalCAxisMisalignments)
 , m_NumFeaturesPerParentArrayName(SIMPL::FeatureData::NumFeaturesPerParent)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
 }
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindLocalAverageCAxisMisalignments.h
@@ -38,7 +38,6 @@
 
 #include <memory>
 
-#include "OrientationLib/LaueOps/LaueOps.h"
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/DataArrays/IDataArray.h"
 #include "SIMPLib/DataArrays/NeighborList.hpp"
@@ -47,6 +46,11 @@
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @class FindLocalAverageCAxisMisalignments FindLocalAverageCAxisMisalignments.h Plugins/Statistics/StatisticsFilters/FindLocalAverageCAxisMisalignments.h
@@ -371,8 +375,7 @@ private:
   QString m_LocalCAxisMisalignmentsArrayName = {};
   QString m_NumFeaturesPerParentArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   NeighborList<int>::WeakPointer m_NeighborList;
   NeighborList<float>::WeakPointer m_CAxisMisalignmentList;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
@@ -236,8 +236,6 @@ void FindMisorientations::execute()
 
   std::vector<std::vector<float>> misorientationlists;
 
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
-  float w = 0.0f;
   size_t tempMisoList = 0;
 
   uint32_t xtalType1 = 0, xtalType2 = 0;
@@ -254,15 +252,15 @@ void FindMisorientations::execute()
 
     for(size_t j = 0; j < featureNeighborList.size(); j++)
     {
-      w = std::numeric_limits<float>::max();
       nname = featureNeighborList[j];
       QuatF q2(m_AvgQuats + nname * 4);
       xtalType2 = m_CrystalStructures[m_FeaturePhases[nname]];
       tempMisoList = featureNeighborList.size();
       if(xtalType1 == xtalType2 && static_cast<int64_t>(xtalType1) < static_cast<int64_t>(m_OrientationOps.size()))
       {
-        w = m_OrientationOps[xtalType1]->getMisoQuat(q1, q2, n1, n2, n3);
-        misorientationlists[i][j] = w * SIMPLib::Constants::k_180OverPi;
+        OrientationD axisAngle = m_OrientationOps[xtalType1]->calculateMisorientation(q1, q2);
+
+        misorientationlists[i][j] = axisAngle[3] * SIMPLib::Constants::k_180OverPi;
         if(m_FindAvgMisors)
         {
           m_AvgMisorientations[i] += misorientationlists[i][j];

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.cpp
@@ -1,48 +1,46 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#include <memory>
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include "FindMisorientations.h"
 
+#include <memory>
 #include <cmath>
 
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
@@ -50,6 +48,9 @@
 #include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
+
+#include "OrientationLib/LaueOps/LaueOps.h"
+#include "OrientationLib/Core/Quaternion.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
@@ -73,7 +74,7 @@ FindMisorientations::FindMisorientations()
 , m_AvgMisorientationsArrayName(SIMPL::FeatureData::AvgMisorientations)
 , m_FindAvgMisors(false)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   m_NeighborList = NeighborList<int32_t>::NullPointer();
   m_MisorientationList = NeighborList<float>::NullPointer();

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindMisorientations.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindMisorientations class. See [Filter documentation](@ref findmisorientations) for details.
@@ -273,8 +276,7 @@ private:
   QString m_AvgMisorientationsArrayName = {};
   bool m_FindAvgMisors = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   NeighborList<int32_t>::WeakPointer m_NeighborList;
   NeighborList<float>::WeakPointer m_MisorientationList;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindOrientationFieldCurl.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindOrientationFieldCurl.cpp
@@ -74,7 +74,7 @@ public:
   , m_Neighbors(neighbors)
   , m_FaceIds(faceIds)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
   virtual ~FindMisorientationVectorsImpl() = default;
 
@@ -114,8 +114,7 @@ private:
   float* m_MisoVecs = nullptr;
   int64_t* m_Neighbors = nullptr;
   int64_t* m_FaceIds = nullptr;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-};
+  LaueOpsContainer m_OrientationOps;};
 
 // -----------------------------------------------------------------------------
 //
@@ -126,7 +125,7 @@ FindOrientationFieldCurl::FindOrientationFieldCurl()
 , m_QuatsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Quats)
 , m_DislocationTensorsArrayName(SIMPL::CellData::DislocationTensors)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   m_CurlSize[0] = 1;
   m_CurlSize[1] = 1;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindOrientationFieldCurl.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindOrientationFieldCurl.h
@@ -36,9 +36,9 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <QtCore/QString>
-#include <vector>
 
 #include "OrientationLib/LaueOps/LaueOps.h"
 #include "SIMPLib/SIMPLib.h"
@@ -49,6 +49,11 @@
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @class FindOrientationFieldCurl FindOrientationFieldCurl.h DREAM3DLib/GenericFilters/FindOrientationFieldCurl.h
@@ -253,8 +258,7 @@ private:
   QString m_DislocationTensorsArrayName = {};
   IntVec3Type m_CurlSize = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   FindOrientationFieldCurl(const FindOrientationFieldCurl&) = delete;            // Copy Constructor Not Implemented
   FindOrientationFieldCurl(FindOrientationFieldCurl&&) = delete;                 // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSchmids.cpp
@@ -286,7 +286,7 @@ void FindSchmids::execute()
   {
     return;
   }
-  QVector<LaueOps::Pointer> orientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> orientationOps = LaueOps::GetAllOrientationOps();
 
   size_t totalFeatures = m_SchmidsPtr.lock()->getNumberOfTuples();
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.cpp
@@ -233,7 +233,7 @@ void FindSlipTransmissionMetrics::execute()
   {
     return;
   }
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   size_t totalFeatures = m_FeaturePhasesPtr.lock()->getNumberOfTuples();
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindSlipTransmissionMetrics.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindSlipTransmissionMetrics class. See [Filter documentation](@ref findsliptransmissionmetrics) for details.
@@ -285,8 +288,7 @@ private:
   DataArrayPath m_FeaturePhasesArrayPath = {};
   DataArrayPath m_CrystalStructuresArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   NeighborList<float>::WeakPointer m_F1List;
   NeighborList<float>::WeakPointer m_F1sptList;
   NeighborList<float>::WeakPointer m_F7List;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
@@ -88,8 +88,7 @@ class CalculateTwinBoundaryImpl
   float* m_TwinBoundaryIncoherence = nullptr;
   uint32_t* m_CrystalStructures = nullptr;
   bool m_FindCoherence;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   CalculateTwinBoundaryImpl(float angtol, float axistol, int32_t* Labels, double* Normals, float* Quats, int32_t* Phases, unsigned int* CrystalStructures, bool* TwinBoundary,
                             float* TwinBoundaryIncoherence, bool FindCoherence)
@@ -104,7 +103,7 @@ public:
   , m_CrystalStructures(CrystalStructures)
   , m_FindCoherence(FindCoherence)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
 
   virtual ~CalculateTwinBoundaryImpl() = default;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindTwinBoundaries class. See [Filter documentation](@ref findtwinboundaries) for details.
@@ -316,8 +319,7 @@ private:
   QString m_SurfaceMeshTwinBoundaryArrayName = {};
   QString m_SurfaceMeshTwinBoundaryIncoherenceArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   /**
    * @brief dataCheckVoxel Checks for the appropriate parameter values and availability of arrays
    */

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.cpp
@@ -1,42 +1,41 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#include <memory>
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include "FindTwinBoundarySchmidFactors.h"
 
+#include <memory>
 #include <fstream>
 
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
@@ -49,7 +48,6 @@
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
@@ -64,7 +62,8 @@
 #include "SIMPLib/Utilities/FileSystemPathHelper.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 
-
+#include "OrientationLib/LaueOps/LaueOps.h"
+#include "OrientationLib/Core/Quaternion.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
@@ -81,8 +80,7 @@ class CalculateTwinBoundarySchmidFactorsImpl
   bool* m_TwinBoundary;
   float* m_TwinBoundarySchmidFactors;
   float* m_LoadDir;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   CalculateTwinBoundarySchmidFactorsImpl(float* LoadingDir, int32_t* Labels, double* Normals, float* Quats, bool* TwinBoundary, float* TwinBoundarySchmidFactors)
   : m_Labels(Labels)
@@ -92,7 +90,7 @@ public:
   , m_TwinBoundarySchmidFactors(TwinBoundarySchmidFactors)
   , m_LoadDir(LoadingDir)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
   virtual ~CalculateTwinBoundarySchmidFactorsImpl() = default;
 
@@ -244,7 +242,7 @@ FindTwinBoundarySchmidFactors::FindTwinBoundarySchmidFactors()
   m_LoadingDir[1] = 1.0f;
   m_LoadingDir[2] = 1.0f;
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
 }
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundarySchmidFactors.h
@@ -42,9 +42,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The FindTwinBoundarySchmidFactors class. See [Filter documentation](@ref findtwinboundaryschmidfactors) for details.
@@ -317,8 +320,7 @@ private:
   DataArrayPath m_SurfaceMeshTwinBoundaryArrayPath = {};
   QString m_SurfaceMeshTwinBoundarySchmidFactorsArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   /**
    * @brief dataCheckVoxel Checks for the appropriate parameter values and availability of arrays
    */

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.cpp
@@ -65,7 +65,7 @@ public:
    */
   void convert(size_t start, size_t end) const
   {
-    QVector<LaueOps::Pointer> ops = LaueOps::getOrientationOpsQVector();
+    std::vector<LaueOps::Pointer> ops = LaueOps::GetAllOrientationOps();
     int32_t phase = 0;
     bool calcIPF = false;
     size_t index = 0;
@@ -133,7 +133,7 @@ GenerateFZQuaternions::GenerateFZQuaternions()
 , m_GoodVoxelsArrayPath("", "", "")
 {
   initialize();
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFZQuaternions.h
@@ -10,9 +10,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The GenerateFZQuaternions class. See [Filter documentation](@ref generatefzquaternions) for details.
@@ -230,8 +233,7 @@ private:
   DataArrayPath m_GoodVoxelsArrayPath = {};
   DataArrayPath m_FZQuatsArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-  int32_t m_PhaseWarningCount = 0;
+  LaueOpsContainer m_OrientationOps;  int32_t m_PhaseWarningCount = 0;
 
 public:
   GenerateFZQuaternions(const GenerateFZQuaternions&) = delete; // Copy Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
@@ -101,7 +101,6 @@ public:
     //    QuatF q2 = QuaternionMathF::New();
     //    QuatF* quats = reinterpret_cast<QuatF*>(m_Quats);
 
-    float radToDeg = 180.0f / SIMPLib::Constants::k_Pi;
     for(size_t i = start; i < end; i++)
     {
       feature1 = m_Labels[2 * i];
@@ -130,12 +129,12 @@ public:
           QuatType q1(quatPtr[0], quatPtr[1], quatPtr[2], quatPtr[3]);
           quatPtr = m_Quats + feature2 * 4;
           QuatType q2(quatPtr[0], quatPtr[1], quatPtr[2], quatPtr[3]);
-          double w = 0.0f, n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
-          w = m_OrientationOps[m_CrystalStructures[phase1]]->getMisoQuat(q1, q2, n1, n2, n3);
-          w = w * radToDeg;
-          m_Colors[3 * i + 0] = w * n1;
-          m_Colors[3 * i + 1] = w * n2;
-          m_Colors[3 * i + 2] = w * n3;
+          // double w = 0.0f, n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
+          OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+
+          m_Colors[3 * i + 0] = axisAngle[0] * (axisAngle[3] * SIMPLib::Constants::k_180OverPi);
+          m_Colors[3 * i + 1] = axisAngle[1] * (axisAngle[3] * SIMPLib::Constants::k_180OverPi);
+          m_Colors[3 * i + 2] = axisAngle[2] * (axisAngle[3] * SIMPLib::Constants::k_180OverPi);
         }
       }
       else

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceMisorientationColoring.cpp
@@ -69,6 +69,9 @@
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 /**
  * @brief The CalculateFaceMisorientationColorsImpl class implements a threaded algorithm that computes the misorientation
  * colors for the given list of surface mesh labels
@@ -80,8 +83,7 @@ class CalculateFaceMisorientationColorsImpl
   float* m_Quats;
   float* m_Colors;
   unsigned int* m_CrystalStructures;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   CalculateFaceMisorientationColorsImpl(int32_t* labels, int32_t* phases, float* quats, float* colors, unsigned int* crystalStructures)
   : m_Labels(labels)
@@ -90,7 +92,7 @@ public:
   , m_Colors(colors)
   , m_CrystalStructures(crystalStructures)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
   virtual ~CalculateFaceMisorientationColorsImpl() = default;
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceSchuhMisorientationColoring.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateFaceSchuhMisorientationColoring.cpp
@@ -73,6 +73,9 @@
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 /**
  * @brief The CalculateFaceSchuhMisorientationColorsImpl class
  */
@@ -83,8 +86,7 @@ class CalculateFaceSchuhMisorientationColorsImpl
   float* m_Quats;
   uint8_t* m_Colors;
   unsigned int* m_CrystalStructures;
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   CalculateFaceSchuhMisorientationColorsImpl(int32_t* labels, int32_t* phases, float* quats, uint8_t* colors, unsigned int* crystalStructures)
   : m_Labels(labels)
@@ -93,7 +95,7 @@ public:
   , m_Colors(colors)
   , m_CrystalStructures(crystalStructures)
   {
-    m_OrientationOps = LaueOps::getOrientationOpsQVector();
+    m_OrientationOps = LaueOps::GetAllOrientationOps();
   }
   virtual ~CalculateFaceSchuhMisorientationColorsImpl() = default;
 
@@ -104,7 +106,7 @@ public:
    */
   void generate(size_t start, size_t end) const
   {
-    QVector<LaueOps::Pointer> ops = LaueOps::getOrientationOpsQVector();
+    std::vector<LaueOps::Pointer> ops = LaueOps::GetAllOrientationOps();
     SIMPL::Rgb argb = 0x00000000;
 
     int grain1, grain2, phase1, phase2;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateIPFColors.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/GenerateIPFColors.cpp
@@ -88,7 +88,7 @@ public:
 
   void convert(size_t start, size_t end) const
   {
-    QVector<LaueOps::Pointer> ops = LaueOps::getOrientationOpsQVector();
+    std::vector<LaueOps::Pointer> ops = LaueOps::GetAllOrientationOps();
     double refDir[3] = {m_ReferenceDir[0], m_ReferenceDir[1], m_ReferenceDir[2]};
     double dEuler[3] = {0.0, 0.0, 0.0};
     SIMPL::Rgb argb = 0x00000000;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
@@ -33,25 +33,14 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "NeighborOrientationCorrelation.h"
 
+#include <memory>
 #include <vector>
-
-#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
-#include <tbb/atomic.h>
-#include <tbb/blocked_range.h>
-#include <tbb/parallel_for.h>
-#include <tbb/task_group.h>
-#include <tbb/task_scheduler_init.h>
-#include <tbb/tick_count.h>
-#endif
 
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatFilterParameter.h"
@@ -62,8 +51,19 @@
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
 
+#include "OrientationLib/LaueOps/LaueOps.h"
+
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
+
+#ifdef SIMPL_USE_PARALLEL_ALGORITHMS
+#include <tbb/atomic.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/task_group.h>
+#include <tbb/task_scheduler_init.h>
+#include <tbb/tick_count.h>
+#endif
 
 class NeighborOrientationCorrelationTransferDataImpl
 {
@@ -123,7 +123,7 @@ NeighborOrientationCorrelation::NeighborOrientationCorrelation()
 , m_CrystalStructuresArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellEnsembleAttributeMatrixName, SIMPL::EnsembleData::CrystalStructures)
 , m_QuatsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Quats)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
 }
 

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.cpp
@@ -1,37 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <memory>
 
@@ -295,8 +295,6 @@ void NeighborOrientationCorrelation::execute()
   neighpoints[4] = static_cast<int64_t>(dims[0]);
   neighpoints[5] = static_cast<int64_t>(dims[0] * dims[1]);
 
-  float w = std::numeric_limits<float>::max();
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   uint32_t phase1 = 0, phase2 = 0;
 
   std::vector<int32_t> neighborDiffCount(totalPoints, 0);
@@ -365,12 +363,12 @@ void NeighborOrientationCorrelation::execute()
 
             phase2 = m_CrystalStructures[m_CellPhases[neighbor]];
             QuatF q2(m_Quats + neighbor * 4);
-
+            OrientationD axisAngle(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
             if(m_CellPhases[i] == m_CellPhases[neighbor] && m_CellPhases[i] > 0)
             {
-              w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+              axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
             }
-            if(w > misorientationToleranceR)
+            if(axisAngle[3] > misorientationToleranceR)
             {
               neighborDiffCount[i]++;
             }
@@ -409,11 +407,12 @@ void NeighborOrientationCorrelation::execute()
 
                 phase2 = m_CrystalStructures[m_CellPhases[neighbor]];
                 q2 = QuatF(m_Quats + neighbor * 4);
+                OrientationD axisAngle(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
                 if(m_CellPhases[neighbor2] == m_CellPhases[neighbor] && m_CellPhases[neighbor2] > 0)
                 {
-                  w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+                  axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
                 }
-                if(w < misorientationToleranceR)
+                if(axisAngle[3] < misorientationToleranceR)
                 {
                   neighborSimCount[j]++;
                   neighborSimCount[k]++;

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/NeighborOrientationCorrelation.h
@@ -41,9 +41,12 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "OrientationAnalysis/OrientationAnalysisDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The NeighborOrientationCorrelation class. See [Filter documentation](@ref neighbororientationcorrelation) for details.
@@ -291,8 +294,7 @@ private:
   size_t m_TotalProgress = 0;
   int32_t m_CurrentLevel = 0;
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   NeighborOrientationCorrelation(const NeighborOrientationCorrelation&) = delete; // Copy Constructor Not Implemented
   NeighborOrientationCorrelation(NeighborOrientationCorrelation&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/WritePoleFigure.cpp
@@ -33,16 +33,16 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "WritePoleFigure.h"
 
-#include <QtCore/QDir>
+#include <memory>
+#include <csetjmp>
+#include <vector>
 
+#include <QtCore/QDir>
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/ChoiceFilterParameter.h"
@@ -76,7 +76,6 @@
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
 #include "hpdf.h"
-#include <csetjmp>
 
 jmp_buf env;
 
@@ -329,7 +328,8 @@ void WritePoleFigure::dataCheck()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-template <typename Ops> QVector<UInt8ArrayType::Pointer> makePoleFigures(PoleFigureConfiguration_t& config)
+template <typename Ops>
+std::vector<UInt8ArrayType::Pointer> makePoleFigures(PoleFigureConfiguration_t& config)
 {
   Ops ops;
   return ops.generatePoleFigure(config);
@@ -724,7 +724,7 @@ void WritePoleFigure::execute()
       continue;
     } // Skip because we have no Pole Figure data
 
-    QVector<UInt8ArrayType::Pointer> figures;
+    std::vector<UInt8ArrayType::Pointer> figures;
 
     PoleFigureConfiguration_t config;
     config.eulers = subEulers.get();

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
@@ -245,7 +245,6 @@ void AlignSectionsMisorientation::find_shifts(std::vector<int64_t>& xshifts, std
   float count = 0.0f;
   int64_t slice = 0;
   float w = 0.0f;
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
 
   int64_t refposition = 0;
   int64_t curposition = 0;
@@ -322,7 +321,8 @@ void AlignSectionsMisorientation::find_shifts(std::vector<int64_t>& xshifts, std
                       phase2 = m_CrystalStructures[m_CellPhases[curposition]];
                       if(phase1 == phase2 && phase1 < static_cast<uint32_t>(m_OrientationOps.size()))
                       {
-                        w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+                        OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+                        w = axisAngle[3];
                       }
                     }
                     if(w > misorientationTolerance)

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMisorientation.cpp
@@ -234,7 +234,7 @@ void AlignSectionsMisorientation::find_shifts(std::vector<int64_t>& xshifts, std
       static_cast<int64_t>(udims[2]),
   };
 
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   float disorientation = 0.0f;
   float mindisorientation = std::numeric_limits<float>::max();

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
@@ -437,16 +437,9 @@ void AlignSectionsMutualInformation::form_features_sections()
   int32_t featurecount = 1;
   int64_t neighbor = 0;
 
-  //  QuatF q1 = QuaternionMathF::New();
-  //  QuatF q2 = QuaternionMathF::New();
-  //  QuatF* quats = reinterpret_cast<QuatF*>(m_Quats);
-
   FloatArrayType::Pointer quats = m_QuatsPtr.lock();
 
   float w = 0.0f;
-  float n1 = 0.0f;
-  float n2 = 0.0f;
-  float n3 = 0.0f;
   int64_t randx = 0;
   int64_t randy = 0;
   bool good = false;
@@ -559,7 +552,8 @@ void AlignSectionsMutualInformation::form_features_sections()
               phase2 = m_CrystalStructures[m_CellPhases[neighbor]];
               if(phase1 == phase2)
               {
-                w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+                OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+                w = axisAngle[3];
               }
               if(w < misorientationTolerance)
               {

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.cpp
@@ -41,7 +41,6 @@
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatFilterParameter.h"
@@ -51,6 +50,8 @@
 #include "SIMPLib/Math/SIMPLibRandom.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
+
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "Reconstruction/ReconstructionConstants.h"
 #include "Reconstruction/ReconstructionVersion.h"
@@ -68,7 +69,7 @@ AlignSectionsMutualInformation::AlignSectionsMutualInformation()
 {
   m_RandomSeed = QDateTime::currentMSecsSinceEpoch();
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   featurecounts = nullptr;
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/AlignSectionsMutualInformation.h
@@ -41,11 +41,14 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "Reconstruction/ReconstructionFilters/AlignSections.h"
-
 #include "Reconstruction/ReconstructionDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The AlignSectionsMutualInformation class. See [Filter documentation](@ref alignsectionsmutualinformation) for details.
@@ -281,8 +284,7 @@ private:
   DataArrayPath m_GoodVoxelsArrayPath = {};
   DataArrayPath m_CrystalStructuresArrayPath = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   Int32ArrayType::Pointer m_MIFeaturesPtr;
   uint64_t m_RandomSeed;
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.cpp
@@ -88,7 +88,7 @@ CAxisSegmentFeatures::CAxisSegmentFeatures()
 , m_FeatureIdsArrayName(SIMPL::CellData::FeatureIds)
 , m_ActiveArrayName(SIMPL::FeatureData::Active)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   m_MisoTolerance = 0.0f;
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/CAxisSegmentFeatures.h
@@ -42,11 +42,13 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "Reconstruction/ReconstructionFilters/SegmentFeatures.h"
-
 #include "Reconstruction/ReconstructionDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The CAxisSegmentFeatures class. See [Filter documentation](@ref caxissegmentfeatures) for details.
@@ -326,8 +328,7 @@ private:
   QString m_FeatureIdsArrayName = {};
   QString m_ActiveArrayName = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   std::random_device m_RandomDevice;
   std::mt19937_64 m_Generator;
   std::uniform_int_distribution<int64_t> m_Distribution;

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
@@ -365,13 +365,13 @@ bool EBSDSegmentFeatures::determineGrouping(int64_t referencepoint, int64_t neig
   if(m_FeatureIds[neighborpoint] == 0 && (!m_UseGoodVoxels || m_GoodVoxels[neighborpoint]))
   {
     float w = std::numeric_limits<float>::max();
-    float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
     QuatF q1(m_Quats + referencepoint * 4);
     QuatF q2(m_Quats + neighborpoint * 4);
 
     if(m_CellPhases[referencepoint] == m_CellPhases[neighborpoint])
     {
-      w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+      OrientationF axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+      w = axisAngle[3];
     }
     if(w < m_MisoTolerance)
     {

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.cpp
@@ -72,18 +72,8 @@ enum createdPathID : RenameDataPath::DataID_t
 //
 // -----------------------------------------------------------------------------
 EBSDSegmentFeatures::EBSDSegmentFeatures()
-: m_CellFeatureAttributeMatrixName(SIMPL::Defaults::CellFeatureAttributeMatrixName)
-, m_MisorientationTolerance(5.0f)
-, m_RandomizeFeatureIds(true)
-, m_UseGoodVoxels(true)
-, m_GoodVoxelsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Mask)
-, m_CellPhasesArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Phases)
-, m_CrystalStructuresArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellEnsembleAttributeMatrixName, SIMPL::EnsembleData::CrystalStructures)
-, m_QuatsArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Quats)
-, m_FeatureIdsArrayName(SIMPL::CellData::FeatureIds)
-, m_ActiveArrayName(SIMPL::FeatureData::Active)
 {
-  m_MisoTolerance = 0.0f;
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------
@@ -351,7 +341,6 @@ int64_t EBSDSegmentFeatures::getSeed(int32_t gnum, int64_t nextSeed)
 bool EBSDSegmentFeatures::determineGrouping(int64_t referencepoint, int64_t neighborpoint, int32_t gnum)
 {
   bool group = false;
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
 
   // Get the phases for each voxel
   int32_t phase1 = m_CrystalStructures[m_CellPhases[referencepoint]];

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/EBSDSegmentFeatures.h
@@ -36,16 +36,19 @@
 #pragma once
 
 #include <memory>
-
 #include <random>
+#include <vector>
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
 #include "Reconstruction/ReconstructionFilters/SegmentFeatures.h"
-
 #include "Reconstruction/ReconstructionDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
 
 /**
  * @brief The EBSDSegmentFeatures class. See [Filter documentation](@ref ebsdsegmentfeatures) for details.
@@ -314,23 +317,24 @@ private:
   std::weak_ptr<DataArray<int32_t>> m_FeatureIdsPtr;
   int32_t* m_FeatureIds = nullptr;
 
-  QString m_CellFeatureAttributeMatrixName = {};
-  float m_MisorientationTolerance = {};
-  bool m_RandomizeFeatureIds = {};
-  bool m_UseGoodVoxels = {};
-  DataArrayPath m_GoodVoxelsArrayPath = {};
-  DataArrayPath m_CellPhasesArrayPath = {};
-  DataArrayPath m_CrystalStructuresArrayPath = {};
-  DataArrayPath m_QuatsArrayPath = {};
-  QString m_FeatureIdsArrayName = {};
-  QString m_ActiveArrayName = {};
-
+  QString m_CellFeatureAttributeMatrixName = {SIMPL::Defaults::CellFeatureAttributeMatrixName};
+  float m_MisorientationTolerance = {5.0f};
+  bool m_RandomizeFeatureIds = {true};
+  bool m_UseGoodVoxels = {true};
+  DataArrayPath m_GoodVoxelsArrayPath = DataArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Mask);
+  DataArrayPath m_CellPhasesArrayPath = DataArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Phases);
+  DataArrayPath m_CrystalStructuresArrayPath = DataArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellEnsembleAttributeMatrixName, SIMPL::EnsembleData::CrystalStructures);
+  DataArrayPath m_QuatsArrayPath = DataArrayPath(SIMPL::Defaults::ImageDataContainerName, SIMPL::Defaults::CellAttributeMatrixName, SIMPL::CellData::Quats);
+  QString m_FeatureIdsArrayName = {SIMPL::CellData::FeatureIds};
+  QString m_ActiveArrayName = {SIMPL::FeatureData::Active};
 
   std::random_device m_RandomDevice;
   std::mt19937_64 m_Generator;
   std::uniform_int_distribution<int64_t> m_Distribution;
 
-  float m_MisoTolerance;
+  float m_MisoTolerance = 0.0f;
+
+  LaueOpsContainer m_OrientationOps;
 
   /**
    * @brief randomizeGrainIds Randomizes Feature Ids

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
@@ -33,10 +33,9 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <memory>
-
 #include "MergeColonies.h"
 
+#include <memory>
 #include <chrono>
 #include <cmath>
 #include <random>
@@ -44,7 +43,6 @@
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatFilterParameter.h"
@@ -57,7 +55,7 @@
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/DataContainers/DataContainer.h"
 
-
+#include "OrientationLib/LaueOps/LaueOps.h"
 
 #include "Reconstruction/ReconstructionConstants.h"
 #include "Reconstruction/ReconstructionVersion.h"
@@ -124,7 +122,7 @@ MergeColonies::MergeColonies()
 , m_RandomizeParentIds(true)
 , m_IdentifyGlobAlpha(false)
 {
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   m_AxisToleranceRad = 0.0f;
 

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.cpp
@@ -1,37 +1,37 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include <memory>
 
@@ -396,7 +396,6 @@ int32_t MergeColonies::getSeed(int32_t newFid)
 bool MergeColonies::determineGrouping(int32_t referenceFeature, int32_t neighborFeature, int32_t newFid)
 {
   double w = 0.0f;
-  double n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   bool colony = false;
 
   // QuatF* avgQuats = reinterpret_cast<QuatF*>(m_AvgQuats);
@@ -413,40 +412,39 @@ bool MergeColonies::determineGrouping(int32_t referenceFeature, int32_t neighbor
     uint32_t phase2 = m_CrystalStructures[m_FeaturePhases[neighborFeature]];
     if(phase1 == phase2 && (phase1 == Ebsd::CrystalStructure::Hexagonal_High))
     {
-      w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+      OrientationD ax = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
 
-      OrientationD ax(n1, n2, n3, w);
       OrientationD rod = OrientationTransformation::ax2ro<OrientationD, OrientationD>(ax);
       rod = m_OrientationOps[phase1]->getMDFFZRod(rod);
-      OrientationTransformation::ro2ax<OrientationD, OrientationD>(rod).toAxisAngle(n1, n2, n3, w);
+      ax = OrientationTransformation::ro2ax<OrientationD, OrientationD>(rod);
 
-      w = w * (180.0f / SIMPLib::Constants::k_Pi);
+      w = ax[3] * (180.0f / SIMPLib::Constants::k_Pi);
       float angdiff1 = std::fabs(w - 10.53f);
-      float axisdiff1 = std::acos(/*std::fabs(n1) * 0.0000f + std::fabs(n2) * 0.0000f +*/ std::fabs(n3) /* * 1.0000f */);
+      float axisdiff1 = std::acos(/*std::fabs(n1) * 0.0000f + std::fabs(n2) * 0.0000f +*/ std::fabs(ax[2]) /* * 1.0000f */);
       if(angdiff1 < m_AngleTolerance && axisdiff1 < m_AxisToleranceRad)
       {
         colony = true;
       }
       float angdiff2 = std::fabs(w - 90.00f);
-      float axisdiff2 = std::acos(std::fabs(n1) * 0.9958f + std::fabs(n2) * 0.0917f /* + std::fabs(n3) * 0.0000f */);
+      float axisdiff2 = std::acos(std::fabs(ax[0]) * 0.9958f + std::fabs(ax[1]) * 0.0917f /* + std::fabs(n3) * 0.0000f */);
       if(angdiff2 < m_AngleTolerance && axisdiff2 < m_AxisToleranceRad)
       {
         colony = true;
       }
       float angdiff3 = std::fabs(w - 60.00f);
-      float axisdiff3 = std::acos(std::fabs(n1) /* * 1.0000f + std::fabs(n2) * 0.0000f + std::fabs(n3) * 0.0000f*/);
+      float axisdiff3 = std::acos(std::fabs(ax[0]) /* * 1.0000f + std::fabs(n2) * 0.0000f + std::fabs(n3) * 0.0000f*/);
       if(angdiff3 < m_AngleTolerance && axisdiff3 < m_AxisToleranceRad)
       {
         colony = true;
       }
       float angdiff4 = std::fabs(w - 60.83f);
-      float axisdiff4 = std::acos(std::fabs(n1) * 0.9834f + std::fabs(n2) * 0.0905f + std::fabs(n3) * 0.1570f);
+      float axisdiff4 = std::acos(std::fabs(ax[0]) * 0.9834f + std::fabs(ax[1]) * 0.0905f + std::fabs(ax[2]) * 0.1570f);
       if(angdiff4 < m_AngleTolerance && axisdiff4 < m_AxisToleranceRad)
       {
         colony = true;
       }
       float angdiff5 = std::fabs(w - 63.26f);
-      float axisdiff5 = std::acos(std::fabs(n1) * 0.9549f /* + std::fabs(n2) * 0.0000f */+ std::fabs(n3) * 0.2969f);
+      float axisdiff5 = std::acos(std::fabs(ax[0]) * 0.9549f /* + std::fabs(n2) * 0.0000f */ + std::fabs(ax[2]) * 0.2969f);
       if(angdiff5 < m_AngleTolerance && axisdiff5 < m_AxisToleranceRad)
       {
         colony = true;

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.h
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeColonies.h
@@ -41,10 +41,15 @@
 #include "SIMPLib/Filtering/AbstractFilter.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
 
-#include "OrientationLib/LaueOps/LaueOps.h"
-
 #include "Reconstruction/ReconstructionFilters/GroupFeatures.h"
 #include "Reconstruction/ReconstructionDLLExport.h"
+
+#include "OrientationLib/Core/Quaternion.hpp"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The MergeColonies class. See [Filter documentation](@ref mergecolonies) for details.
@@ -404,8 +409,7 @@ private:
   bool m_RandomizeParentIds = {};
   bool m_IdentifyGlobAlpha = {};
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
   float m_AxisToleranceRad;
 
   /**

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
@@ -321,7 +321,7 @@ bool MergeTwins::determineGrouping(int32_t referenceFeature, int32_t neighborFea
   // float w = 0.0f;
   // float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   bool twin = false;
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
 
   if(m_FeatureParentIds[neighborFeature] == -1 && m_FeaturePhases[referenceFeature] > 0 && m_FeaturePhases[neighborFeature] > 0)
   {

--- a/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
+++ b/Source/Plugins/Reconstruction/ReconstructionFilters/MergeTwins.cpp
@@ -318,8 +318,8 @@ int32_t MergeTwins::getSeed(int32_t newFid)
 // -----------------------------------------------------------------------------
 bool MergeTwins::determineGrouping(int32_t referenceFeature, int32_t neighborFeature, int32_t newFid)
 {
-  float w = 0.0f;
-  float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
+  // float w = 0.0f;
+  // float n1 = 0.0f, n2 = 0.0f, n3 = 0.0f;
   bool twin = false;
   QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
 
@@ -333,10 +333,11 @@ bool MergeTwins::determineGrouping(int32_t referenceFeature, int32_t neighborFea
     uint32_t phase2 = m_CrystalStructures[m_FeaturePhases[neighborFeature]];
     if(phase1 == phase2 && (phase1 == Ebsd::CrystalStructure::Cubic_High))
     {
-      w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+      OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+      double w = axisAngle[3];
       w = w * (180.0f / SIMPLib::Constants::k_Pi);
-      float axisdiff111 = acosf(fabsf(n1) * 0.57735f + fabsf(n2) * 0.57735f + fabsf(n3) * 0.57735f);
-      float angdiff60 = fabsf(w - 60.0f);
+      double axisdiff111 = acosf(fabs(axisAngle[0]) * 0.57735f + fabs(axisAngle[1]) * 0.57735f + fabs(axisAngle[2]) * 0.57735f);
+      double angdiff60 = fabs(w - 60.0f);
       if(axisdiff111 < m_AxisToleranceRad && angdiff60 < m_AngleTolerance)
       {
         twin = true;

--- a/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
@@ -1018,7 +1018,7 @@ void GenerateEnsembleStatistics::gatherNeighborhoodStats()
 void GenerateEnsembleStatistics::gatherODFStats()
 {
   StatsDataArray& statsDataArray = *(m_StatsDataArray);
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
   size_t bin = 0;
   size_t numfeatures = m_FeatureEulerAnglesPtr.lock()->getNumberOfTuples();
   size_t numensembles = m_PhaseTypesPtr.lock()->getNumberOfTuples();
@@ -1096,7 +1096,7 @@ void GenerateEnsembleStatistics::gatherODFStats()
 void GenerateEnsembleStatistics::gatherMDFStats()
 {
   StatsDataArray& statsDataArray = *(m_StatsDataArray);
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
   // But since a pointer is difficult to use operators with we will now create a
   // reference variable to the pointer with the correct variable name that allows
   // us to use the same syntax as the "vector of vectors"
@@ -1205,7 +1205,7 @@ void GenerateEnsembleStatistics::gatherMDFStats()
 void GenerateEnsembleStatistics::gatherAxisODFStats()
 {
   StatsDataArray& statsDataArray = *(m_StatsDataArray);
-  QVector<LaueOps::Pointer> m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  std::vector<LaueOps::Pointer> m_OrientationOps = LaueOps::GetAllOrientationOps();
   int32_t bin = 0;
   QVector<FloatArrayType::Pointer> axisodf;
   QVector<float> totalaxes;

--- a/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
+++ b/Source/Plugins/Statistics/StatisticsFilters/GenerateEnsembleStatistics.cpp
@@ -1154,7 +1154,8 @@ void GenerateEnsembleStatistics::gatherMDFStats()
       phase2 = m_CrystalStructures[m_FeaturePhases[nname]];
       if(phase1 == phase2)
       {
-        w = m_OrientationOps[phase1]->getMisoQuat(q1, q2, n1, n2, n3);
+        OrientationD axisAngle = m_OrientationOps[phase1]->calculateMisorientation(q1, q2);
+        w = axisAngle[3];
       }
       if(phase1 == phase2)
       {

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
@@ -195,9 +195,9 @@ int StatsGenAxisODFWidget::getOrientationData(StatsData* statsData, PhaseType::T
   weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
-//  QVector<float> e1Rad = e1s;
-//  QVector<float> e2Rad = e2s;
-//  QVector<float> e3Rad = e3s;
+  //  QVector<float> e1Rad = e1s;
+  //  QVector<float> e2Rad = e2s;
+  //  QVector<float> e3Rad = e3s;
 
   // Convert from Degrees to Radians
   for(QVector<float>::size_type i = 0; i < e1s.size(); i++)
@@ -300,7 +300,6 @@ void StatsGenAxisODFWidget::setupGui()
     m_PFLambertSize->hide();
     m_PFLambertLabel->hide();
   }
-
 }
 
 // -----------------------------------------------------------------------------
@@ -432,13 +431,13 @@ void StatsGenAxisODFWidget::on_m_CalculateODFBtn_clicked()
 void StatsGenAxisODFWidget::calculateAxisODF()
 {
   int err = 0;
-
-  QwtArray<float> e1s;
-  QwtArray<float> e2s;
-  QwtArray<float> e3s;
-  QwtArray<float> weights;
-  QwtArray<float> sigmas;
-  QwtArray<float> odf;
+  using ContainerType = QwtArray<float>;
+  ContainerType e1s;
+  ContainerType e2s;
+  ContainerType e3s;
+  ContainerType weights;
+  ContainerType sigmas;
+  ContainerType odf;
 
   e1s = m_ODFTableModel->getData(SGODFTableModel::Euler1);
   e2s = m_ODFTableModel->getData(SGODFTableModel::Euler2);
@@ -460,14 +459,12 @@ void StatsGenAxisODFWidget::calculateAxisODF()
   int npoints = pfSamplePoints->value();
   std::vector<size_t> dims(1, 3);
   FloatArrayType::Pointer eulers = FloatArrayType::CreateArray(npoints, dims, "Eulers", true);
+  OrthoRhombicOps ops;
 
-  odf.resize(OrthoRhombicOps::k_OdfSize);
-
-  Texture::CalculateOrthoRhombicODFData(e1s.data(), e2s.data(), e3s.data(), weights.data(), sigmas.data(), true, odf.data(), numEntries);
+  Texture::CalculateODFData<float, OrthoRhombicOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
 
   err = StatsGen::GenAxisODFPlotData(odf.data(), eulers->getPointer(0), npoints);
 
-  OrthoRhombicOps ops;
   PoleFigureConfiguration_t config;
   config.eulers = eulers.get();
   config.imageDim = imageSize;
@@ -475,13 +472,13 @@ void StatsGenAxisODFWidget::calculateAxisODF()
   config.numColors = numColors;
   config.discrete = true;
   config.discreteHeatMap = false;
-    
+
   // Check if the user wants a Discreet or Lambert PoleFigure
   if(m_PFTypeCB->currentIndex() == 1)
   {
     config.discrete = false;
   }
-  
+
   QVector<QString> labels(3);
   labels[0] = QString("C Axis"); // 001
   labels[1] = QString("A Axis"); // 100

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenAxisODFWidget.cpp
@@ -182,11 +182,11 @@ int StatsGenAxisODFWidget::getOrientationData(StatsData* statsData, PhaseType::T
 {
   int retErr = 0;
 
-  QVector<float> e1s;
-  QVector<float> e2s;
-  QVector<float> e3s;
-  QVector<float> weights;
-  QVector<float> sigmas;
+  std::vector<float> e1s;
+  std::vector<float> e2s;
+  std::vector<float> e3s;
+  std::vector<float> weights;
+  std::vector<float> sigmas;
 
   // Initialize xMax and yMax....
   e1s = m_ODFTableModel->getData(SGODFTableModel::Euler1);
@@ -200,11 +200,11 @@ int StatsGenAxisODFWidget::getOrientationData(StatsData* statsData, PhaseType::T
   //  QVector<float> e3Rad = e3s;
 
   // Convert from Degrees to Radians
-  for(QVector<float>::size_type i = 0; i < e1s.size(); i++)
+  for(std::vector<float>::size_type i = 0; i < e1s.size(); i++)
   {
-    e1s[i] = static_cast<float>(e1s[i] * M_PI / 180.0);
-    e2s[i] = static_cast<float>(e2s[i] * M_PI / 180.0);
-    e3s[i] = static_cast<float>(e3s[i] * M_PI / 180.0);
+    e1s[i] = static_cast<float>(e1s[i] * SIMPLib::Constants::k_PiOver180);
+    e2s[i] = static_cast<float>(e2s[i] * SIMPLib::Constants::k_PiOver180);
+    e3s[i] = static_cast<float>(e3s[i] * SIMPLib::Constants::k_PiOver180);
   }
 
   StatsGeneratorUtilities::GenerateAxisODFBinData(statsData, phaseType, e1s, e2s, e3s, weights, sigmas, !preflight);
@@ -431,7 +431,7 @@ void StatsGenAxisODFWidget::on_m_CalculateODFBtn_clicked()
 void StatsGenAxisODFWidget::calculateAxisODF()
 {
   int err = 0;
-  using ContainerType = QwtArray<float>;
+  using ContainerType = std::vector<float>;
   ContainerType e1s;
   ContainerType e2s;
   ContainerType e3s;
@@ -445,11 +445,11 @@ void StatsGenAxisODFWidget::calculateAxisODF()
   weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
-  for(int i = 0; i < e1s.size(); i++)
+  for(size_t i = 0; i < e1s.size(); i++)
   {
-    e1s[i] = static_cast<float>(e1s[i] * M_PI / 180.0);
-    e2s[i] = static_cast<float>(e2s[i] * M_PI / 180.0);
-    e3s[i] = static_cast<float>(e3s[i] * M_PI / 180.0);
+    e1s[i] = static_cast<float>(e1s[i] * SIMPLib::Constants::k_PiOver180);
+    e2s[i] = static_cast<float>(e2s[i] * SIMPLib::Constants::k_PiOver180);
+    e3s[i] = static_cast<float>(e3s[i] * SIMPLib::Constants::k_PiOver180);
   }
   size_t numEntries = e1s.size();
 
@@ -491,7 +491,7 @@ void StatsGenAxisODFWidget::calculateAxisODF()
   order[2] = 1; // Show B Second
   config.order = order;
 
-  QVector<UInt8ArrayType::Pointer> figures = ops.generatePoleFigure(config);
+  std::vector<UInt8ArrayType::Pointer> figures = ops.generatePoleFigure(config);
   if(err == 1)
   {
     // TODO: Present Error Message

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
@@ -71,10 +71,18 @@
 
 #include "SVWidgetsLib/Widgets/SVStyle.h"
 
+#include "OrientationLib/LaueOps/CubicLowOps.h"
 #include "OrientationLib/LaueOps/CubicOps.h"
+#include "OrientationLib/LaueOps/HexagonalLowOps.h"
 #include "OrientationLib/LaueOps/HexagonalOps.h"
-#include "OrientationLib/LaueOps/LaueOps.h"
+#include "OrientationLib/LaueOps/MonoclinicOps.h"
 #include "OrientationLib/LaueOps/OrthoRhombicOps.h"
+#include "OrientationLib/LaueOps/TetragonalLowOps.h"
+#include "OrientationLib/LaueOps/TetragonalOps.h"
+#include "OrientationLib/LaueOps/TriclinicOps.h"
+#include "OrientationLib/LaueOps/TrigonalLowOps.h"
+#include "OrientationLib/LaueOps/TrigonalOps.h"
+#include "OrientationLib/LaueOps/LaueOps.h"
 #include "OrientationLib/Texture/StatsGen.hpp"
 #include "OrientationLib/Texture/Texture.hpp"
 
@@ -128,7 +136,6 @@ void StatsGenMDFWidget::setupGui()
   QAbstractItemDelegate* aid = m_MDFTableModel->getItemDelegate();
   m_MDFTableView->setItemDelegate(aid);
   m_PlotCurve = new QwtPlotCurve;
-
 }
 
 // -----------------------------------------------------------------------------
@@ -239,70 +246,92 @@ void StatsGenMDFWidget::on_m_MDFUpdateBtn_clicked()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void StatsGenMDFWidget::updateMDFPlot(QVector<float>& odf)
+void StatsGenMDFWidget::updateMDFPlot(QVector<float>& odfInput)
 {
   int err = 0;
   int size = 100000;
 
   // These are the input vectors
-  QVector<float> angles;
-  QVector<float> axes;
-  QVector<float> weights;
+  using ContainerType = std::vector<float>;
+  ContainerType angles;
+  ContainerType axes;
+  ContainerType weights;
 
-  angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
-  weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
-  axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
+  ContainerType odf = odfInput.toStdVector(); // Do this copy because using std::vector is 2x faster than QVector
+
+  angles = m_MDFTableModel->getData(SGMDFTableModel::Angle).toStdVector();
+  weights = m_MDFTableModel->getData(SGMDFTableModel::Weight).toStdVector();
+  axes = m_MDFTableModel->getData(SGMDFTableModel::Axis).toStdVector();
 
   // These are the output vectors
-  QVector<float> x;
-  QVector<float> y;
-  if(Ebsd::CrystalStructure::Cubic_High == m_CrystalStructure)
+  int npoints = 36;
+  ContainerType x(npoints);
+  ContainerType y(npoints);
+  ContainerType mdf;
+
+  //// ODF/MDF Update Codes
+  switch(m_CrystalStructure)
   {
-    // Allocate a new vector to hold the mdf data
-    QVector<float> mdf(CubicOps::k_MdfSize);
-    // Calculate the MDF Data using the ODF data and the rows from the MDF Table model
-    Texture::CalculateMDFData<float, CubicOps>(angles.data(), axes.data(), weights.data(), odf.data(), mdf.data(), static_cast<size_t>(angles.size()));
-    // Now generate the actual XY point data that gets plotted.
-    int npoints = 13;
-    x.resize(npoints);
-    y.resize(npoints);
-    err = StatsGen::GenCubicMDFPlotData(mdf.data(), x.data(), y.data(), npoints, size);
-    if(err < 0)
-    {
-      return;
-    }
+  case Ebsd::CrystalStructure::Triclinic: // 4; Triclinic -1
+    Texture::CalculateMDFData<float, TriclinicOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, TriclinicOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Monoclinic: // 5; Monoclinic 2/m
+    Texture::CalculateMDFData<float, MonoclinicOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, MonoclinicOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::OrthoRhombic: // 6; Orthorhombic mmm
+    Texture::CalculateMDFData<float, OrthoRhombicOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, OrthoRhombicOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Tetragonal_Low: // 7; Tetragonal-Low 4/m
+    Texture::CalculateMDFData<float, TetragonalLowOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, TetragonalLowOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Tetragonal_High: // 8; Tetragonal-High 4/mmm
+    Texture::CalculateMDFData<float, TetragonalOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, TetragonalOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Trigonal_Low: // 9; Trigonal-Low -3
+    Texture::CalculateMDFData<float, TrigonalLowOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, TrigonalLowOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Trigonal_High: // 10; Trigonal-High -3m
+    Texture::CalculateMDFData<float, TrigonalOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, TrigonalOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Hexagonal_Low: // 2; Hexagonal-Low 6/m
+    Texture::CalculateMDFData<float, HexagonalLowOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, HexagonalLowOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Hexagonal_High: // 0; Hexagonal-High 6/mmm
+    Texture::CalculateMDFData<float, HexagonalOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, HexagonalOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Cubic_Low: // 3; Cubic Cubic-Low m3 (Tetrahedral)
+    Texture::CalculateMDFData<float, CubicLowOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, CubicLowOps, ContainerType>(mdf, x, y, size);
+    break;
+  case Ebsd::CrystalStructure::Cubic_High: // 1; Cubic Cubic-High m3m
+    Texture::CalculateMDFData<float, CubicOps, ContainerType>(angles, axes, weights, odf, mdf, static_cast<size_t>(angles.size()));
+    err = StatsGen::GenMDFPlotData<float, CubicOps, ContainerType>(mdf, x, y, size);
+    break;
+  default:
+    err = -1;
+    break;
   }
-  else if(Ebsd::CrystalStructure::Hexagonal_High == m_CrystalStructure)
+
+  if(err < 0)
   {
-    // Allocate a new vector to hold the mdf data
-    QVector<float> mdf(HexagonalOps::k_MdfSize);
-    // Calculate the MDF Data using the ODF data and the rows from the MDF Table model
-    Texture::CalculateMDFData<float, HexagonalOps>(angles.data(), axes.data(), weights.data(), odf.data(), mdf.data(), static_cast<size_t>(angles.size()));
-    // Now generate the actual XY point data that gets plotted.
-    int npoints = 20;
-    x.resize(npoints);
-    y.resize(npoints);
-    err = StatsGen::GenHexMDFPlotData(mdf.data(), x.data(), y.data(), npoints, size);
-    if(err < 0)
-    {
-      return;
-    }
-  }
-  else
-  {
-    err = 1;
-    QString ss("Only Cubic_High or Hexagonal_High are allowed for the Laue group.");
-    QMessageBox::StandardButton reply;
-    reply = QMessageBox::critical(nullptr, QString("MDF Generation Error"), ss, QMessageBox::Ok);
-    Q_UNUSED(reply);
+    return;
   }
 
   QwtArray<double> xD(static_cast<int>(x.size()));
   QwtArray<double> yD(static_cast<int>(x.size()));
-  for(qint32 i = 0; i < x.size(); ++i)
+  for(ContainerType::size_type i = 0; i < x.size(); ++i)
   {
-    xD[i] = static_cast<double>(x.at(i));
-    yD[i] = static_cast<double>(y.at(i));
+    xD[i] = static_cast<double>(x[i]);
+    yD[i] = static_cast<double>(y[i]);
   }
 
   // This will actually plot the XY data in the Qwt plot widget
@@ -374,37 +403,37 @@ void StatsGenMDFWidget::on_loadMDFBtn_clicked()
     return;
   }
 
-    QFileInfo fi(file);
-    m_OpenDialogLastFilePath = fi.filePath();
+  QFileInfo fi(file);
+  m_OpenDialogLastFilePath = fi.filePath();
 
-    size_t numMisorients = 0;
-    QString filename = file;
-    std::ifstream inFile;
-    inFile.open(filename.toLatin1().data());
+  size_t numMisorients = 0;
+  QString filename = file;
+  std::ifstream inFile;
+  inFile.open(filename.toLatin1().data());
 
-    inFile >> numMisorients;
+  inFile >> numMisorients;
 
-    float angle, weight;
-    std::string n1, n2, n3;
-    for(size_t i = 0; i < numMisorients; i++)
+  float angle, weight;
+  std::string n1, n2, n3;
+  for(size_t i = 0; i < numMisorients; i++)
+  {
+    inFile >> angle >> n1 >> n2 >> n3 >> weight;
+
+    QString axis = QString("<" + QString::fromStdString(n1) + "," + QString::fromStdString(n2) + "," + QString::fromStdString(n3) + ">");
+
+    if(!m_MDFTableModel->insertRow(m_MDFTableModel->rowCount()))
     {
-      inFile >> angle >> n1 >> n2 >> n3 >> weight;
-
-      QString axis = QString("<" + QString::fromStdString(n1) + "," + QString::fromStdString(n2) + "," + QString::fromStdString(n3) + ">");
-
-      if(!m_MDFTableModel->insertRow(m_MDFTableModel->rowCount()))
-      {
-        return;
-      }
-      int row = m_MDFTableModel->rowCount() - 1;
-      m_MDFTableModel->setRowData(row, angle, axis, weight);
-
-      m_MDFTableView->resizeColumnsToContents();
-      m_MDFTableView->scrollToBottom();
-      m_MDFTableView->setFocus();
-      QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
-      m_MDFTableView->setCurrentIndex(index);
+      return;
     }
+    int row = m_MDFTableModel->rowCount() - 1;
+    m_MDFTableModel->setRowData(row, angle, axis, weight);
+
+    m_MDFTableView->resizeColumnsToContents();
+    m_MDFTableView->scrollToBottom();
+    m_MDFTableView->setFocus();
+    QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
+    m_MDFTableView->setCurrentIndex(index);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
@@ -205,11 +205,11 @@ void StatsGenMDFWidget::initQwtPlot(QString xAxisName, QString yAxisName, QwtPlo
 void StatsGenMDFWidget::updatePlots()
 {
   // Generate the ODF Data from the current values in the ODFTableModel
-  QVector<float> e1s;
-  QVector<float> e2s;
-  QVector<float> e3s;
-  QVector<float> weights;
-  QVector<float> sigmas;
+  std::vector<float> e1s;
+  std::vector<float> e2s;
+  std::vector<float> e3s;
+  std::vector<float> weights;
+  std::vector<float> sigmas;
   if(nullptr == m_ODFTableModel)
   {
     return;
@@ -221,14 +221,14 @@ void StatsGenMDFWidget::updatePlots()
   weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
-  for(qint32 i = 0; i < e1s.size(); i++)
+  for(size_t i = 0; i < e1s.size(); i++)
   {
     e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e2s[i] = e2s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e3s[i] = e3s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
   }
 
-  QVector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, weights, sigmas);
+  std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, weights, sigmas);
 
   updateMDFPlot(odf);
 
@@ -246,7 +246,7 @@ void StatsGenMDFWidget::on_m_MDFUpdateBtn_clicked()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void StatsGenMDFWidget::updateMDFPlot(QVector<float>& odfInput)
+void StatsGenMDFWidget::updateMDFPlot(std::vector<float>& odf)
 {
   int err = 0;
   int size = 100000;
@@ -257,11 +257,11 @@ void StatsGenMDFWidget::updateMDFPlot(QVector<float>& odfInput)
   ContainerType axes;
   ContainerType weights;
 
-  ContainerType odf = odfInput.toStdVector(); // Do this copy because using std::vector is 2x faster than QVector
+  // ContainerType odf = odfInput; // Do this copy because using std::vector is 2x faster than QVector
 
-  angles = m_MDFTableModel->getData(SGMDFTableModel::Angle).toStdVector();
-  weights = m_MDFTableModel->getData(SGMDFTableModel::Weight).toStdVector();
-  axes = m_MDFTableModel->getData(SGMDFTableModel::Axis).toStdVector();
+  angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
+  weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
+  axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
 
   // These are the output vectors
   int npoints = 36;
@@ -500,11 +500,11 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
   int retErr = 0;
 
   // Generate the ODF Data from the current values in the ODFTableModel
-  QVector<float> e1s;
-  QVector<float> e2s;
-  QVector<float> e3s;
-  QVector<float> odf_weights;
-  QVector<float> sigmas;
+  std::vector<float> e1s;
+  std::vector<float> e2s;
+  std::vector<float> e3s;
+  std::vector<float> odf_weights;
+  std::vector<float> sigmas;
 
   e1s = m_ODFTableModel->getData(SGODFTableModel::Euler1);
   e2s = m_ODFTableModel->getData(SGODFTableModel::Euler2);
@@ -512,19 +512,19 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
   odf_weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
-  for(qint32 i = 0; i < e1s.size(); i++)
+  for(size_t i = 0; i < e1s.size(); i++)
   {
     e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e2s[i] = e2s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e3s[i] = e3s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
   }
 
-  QVector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, odf_weights, sigmas, !preflight);
+  std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, odf_weights, sigmas, !preflight);
 
   // Now use the ODF data to generate the MDF data ************************************************
-  QVector<float> angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
-  QVector<float> weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
-  QVector<float> axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
+  std::vector<float> angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
+  std::vector<float> weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
+  std::vector<float> axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
 
   StatsGeneratorUtilities::GenerateMisorientationBinData(statsData, phaseType, m_CrystalStructure, odf, angles, axes, weights, !preflight);
   return retErr;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
@@ -119,7 +119,7 @@ signals:
   void dataChanged();
 
 protected:
-  void updateMDFPlot(QVector<float>& odf);
+  void updateMDFPlot(std::vector<float>& odf);
 
 private:
   SGODFTableModel* m_ODFTableModel = nullptr;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
@@ -39,6 +39,7 @@
 
 //-- C++ Includes
 #include <iostream>
+#include <vector>
 
 //-- Qt Includes
 #include <QtCore/QDir>
@@ -207,11 +208,11 @@ int StatsGenODFWidget::getOrientationData(StatsData* statsData, PhaseType::Type 
 {
   int retErr = 0;
 
-  QVector<float> e1s;
-  QVector<float> e2s;
-  QVector<float> e3s;
-  QVector<float> weights;
-  QVector<float> sigmas;
+  std::vector<float> e1s;
+  std::vector<float> e2s;
+  std::vector<float> e3s;
+  std::vector<float> weights;
+  std::vector<float> sigmas;
 
   SGODFTableModel* tableModel = nullptr;
 
@@ -231,7 +232,7 @@ int StatsGenODFWidget::getOrientationData(StatsData* statsData, PhaseType::Type 
   sigmas = tableModel->getData(SGODFTableModel::Sigma);
 
   // Convert from Degrees to Radians
-  for(QVector<float>::size_type i = 0; i < e1s.size(); i++)
+  for(std::vector<float>::size_type i = 0; i < e1s.size(); i++)
   {
     e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e2s[i] = e2s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
@@ -546,11 +547,11 @@ void StatsGenODFWidget::calculateODF()
     npoints = tableModel->rowCount();
   }
 
-  e1s = tableModel->getData(SGODFTableModel::Euler1).toStdVector();
-  e2s = tableModel->getData(SGODFTableModel::Euler2).toStdVector();
-  e3s = tableModel->getData(SGODFTableModel::Euler3).toStdVector();
-  weights = tableModel->getData(SGODFTableModel::Weight).toStdVector();
-  sigmas = tableModel->getData(SGODFTableModel::Sigma).toStdVector();
+  e1s = tableModel->getData(SGODFTableModel::Euler1);
+  e2s = tableModel->getData(SGODFTableModel::Euler2);
+  e3s = tableModel->getData(SGODFTableModel::Euler3);
+  weights = tableModel->getData(SGODFTableModel::Weight);
+  sigmas = tableModel->getData(SGODFTableModel::Sigma);
 
   // Convert from Degrees to Radians
   for(ContainerType::size_type i = 0; i < e1s.size(); i++)
@@ -580,7 +581,7 @@ void StatsGenODFWidget::calculateODF()
   {
     config.discrete = false;
   }
-  QVector<UInt8ArrayType::Pointer> figures;
+  std::vector<UInt8ArrayType::Pointer> figures;
 
   //// ODF/MDF Update Codes
   LaueOps::Pointer ops = LaueOps::NullPointer();

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenPlotWidget.cpp
@@ -217,8 +217,8 @@ VectorOfFloatArray StatsGenPlotWidget::getStatisticsData()
   FloatArrayType::Pointer col1;
   FloatArrayType::Pointer col2;
 
-  QVector<float> v0;
-  QVector<float> v1;
+  std::vector<float> v0;
+  std::vector<float> v1;
   Q_ASSERT(m_PhaseIndex >= 0);
 
   // Create a new Table Model
@@ -227,16 +227,16 @@ VectorOfFloatArray StatsGenPlotWidget::getStatisticsData()
   case SIMPL::DistributionType::Beta:
     v0 = m_TableModel->getData(SGBetaTableModel::Alpha);
     v1 = m_TableModel->getData(SGBetaTableModel::Beta);
-    col0 = FloatArrayType::FromQVector(v0, SIMPL::StringConstants::Alpha);
-    col1 = FloatArrayType::FromQVector(v1, SIMPL::StringConstants::Beta);
+    col0 = FloatArrayType::FromStdVector(v0, SIMPL::StringConstants::Alpha);
+    col1 = FloatArrayType::FromStdVector(v1, SIMPL::StringConstants::Beta);
     data.push_back(col0);
     data.push_back(col1);
     break;
   case SIMPL::DistributionType::LogNormal:
     v0 = m_TableModel->getData(SGLogNormalTableModel::Average);
     v1 = m_TableModel->getData(SGLogNormalTableModel::StdDev);
-    col0 = FloatArrayType::FromQVector(v0, SIMPL::StringConstants::Average);
-    col1 = FloatArrayType::FromQVector(v1, SIMPL::StringConstants::StandardDeviation);
+    col0 = FloatArrayType::FromStdVector(v0, SIMPL::StringConstants::Average);
+    col1 = FloatArrayType::FromStdVector(v1, SIMPL::StringConstants::StandardDeviation);
     data.push_back(col0);
     data.push_back(col1);
     break;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGAbstractTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGAbstractTableModel.h
@@ -170,41 +170,40 @@ public:
    *
    * @param binNumbers
    */
-  // virtual void setBinNumbers(QVector<float> binNumbers) = 0;
   virtual void setTableData(QVector<float> bins, QVector<QVector<float>> data, QVector<SIMPL::Rgb> colors) = 0;
 
   /**
    *
    * @return
    */
-  virtual QVector<float>& getBinNumbers() = 0;
+  virtual const QVector<float>& getBinNumbers() const = 0;
 
   /**
    *
    * @param row
    * @return
    */
-  virtual float getBinNumber(qint32 row) = 0;
+  virtual float getBinNumber(qint32 row) const = 0;
 
   /**
    *
    * @return
    */
-  virtual QVector<SIMPL::Rgb>& getColors() = 0;
+  virtual const QVector<SIMPL::Rgb>& getColors() const = 0;
 
   /**
    *
    * @param row
    * @return
    */
-  virtual SIMPL::Rgb getColor(qint32 row) = 0;
+  virtual SIMPL::Rgb getColor(qint32 row) const = 0;
 
   /**
    *
    * @param col
    * @return
    */
-  virtual QVector<float> getData(int col) = 0;
+  virtual std::vector<float> getData(int col) const = 0;
 
   /**
    *
@@ -212,8 +211,13 @@ public:
    * @param row
    * @return
    */
-  virtual float getDataValue(int col, int row) = 0;
+  virtual float getDataValue(int col, int row) const = 0;
 
+  /**
+   * @brief setColumnData
+   * @param col
+   * @param data
+   */
   virtual void setColumnData(int col, QVector<float>& data) = 0;
 
 public:

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.cpp
@@ -297,27 +297,27 @@ bool SGBetaTableModel::removeRows(int row, int count, const QModelIndex& index)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> SGBetaTableModel::getData(int col)
+std::vector<float> SGBetaTableModel::getData(int col) const
 {
 
   switch(col)
   {
   case Alpha:
-    return m_Alpha;
+    return std::vector<float>(m_Alpha.begin(), m_Alpha.end());
     break;
   case Beta:
-    return m_Beta;
+    return std::vector<float>(m_Beta.begin(), m_Beta.end());
     break;
   default:
     Q_ASSERT(false);
   }
-  return QVector<float>();
+  return std::vector<float>();
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-float SGBetaTableModel::getDataValue(int col, int row)
+float SGBetaTableModel::getDataValue(int col, int row) const
 {
   switch(col)
   {
@@ -402,4 +402,47 @@ void SGBetaTableModel::setTableData(QVector<float> bins, QVector<QVector<float>>
     QModelIndex botRight = createIndex(offset, ColumnCount);
     emit dataChanged(topLeft, botRight);
   }
+}
+
+const QVector<float>& SGBetaTableModel::getBinNumbers() const
+{
+  return m_BinNumbers;
+}
+
+float SGBetaTableModel::getBinNumber(qint32 row) const
+{
+  return m_BinNumbers[row];
+}
+
+const QVector<SIMPL::Rgb>& SGBetaTableModel::getColors() const
+{
+  return m_Colors;
+}
+
+SIMPL::Rgb SGBetaTableModel::getColor(qint32 row) const
+{
+  return m_Colors[row];
+}
+
+bool SGBetaTableModel::setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role)
+{
+  return false;
+}
+
+const QVector<float>& SGBetaTableModel::getAlphas() const
+{
+  return m_Alpha;
+}
+const QVector<float>& SGBetaTableModel::getBetas() const
+{
+  return m_Beta;
+}
+
+float SGBetaTableModel::getAlpha(qint32 row) const
+{
+  return m_Alpha[row];
+}
+float SGBetaTableModel::getBeta(qint32 row) const
+{
+  return m_Beta[row];
 }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGBetaTableModel.h
@@ -63,74 +63,155 @@ public:
   };
 
   SGBetaTableModel(QObject* parent = nullptr);
-  virtual ~SGBetaTableModel();
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-  int rowCount(const QModelIndex& parent = QModelIndex()) const;
-  int columnCount(const QModelIndex& parent = QModelIndex()) const;
+  ~SGBetaTableModel();
 
-  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
   /**
-   *
+   * @brief flags
+   * @param index
+   * @return
+   */
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+  /**
+   * @brief data
+   * @param index
+   * @param role
+   * @return
+   */
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief headerData
+   * @param section
+   * @param orientation
+   * @param role
+   * @return
+   */
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief rowCount
+   * @param parent
+   * @return
+   */
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief columnCount
+   * @param parent
+   * @return
+   */
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief setData
+   * @param index
+   * @param value
+   * @param role
+   * @return
+   */
+  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+
+  /**
+   * @brief setHeaderData
    * @param col
    * @param orientation
    * @param data
    * @param role
    * @return
    */
-  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole)
-  {
-    return false;
-  }
+  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole) override;
 
-  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
-  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  /**
+   * @brief insertRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
-  QAbstractItemDelegate* getItemDelegate();
+  /**
+   * @brief removeRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
+  /**
+   * @brief getItemDelegate
+   * @return
+   */
+  QAbstractItemDelegate* getItemDelegate() override;
+
+  /**
+   * @brief setTableData
+   * @param bins
+   * @param data
+   * @param colors
+   */
   void setTableData(QVector<float> bins, QVector<QVector<float>> data, QVector<SIMPL::Rgb> colors) override;
 
-  QVector<float>& getBinNumbers()
-  {
-    return m_BinNumbers;
-  }
-  float getBinNumber(qint32 row)
-  {
-    return m_BinNumbers[row];
-  }
+  /**
+   * @brief getBinNumbers
+   * @return
+   */
+  const QVector<float>& getBinNumbers() const override;
 
-  QVector<SIMPL::Rgb>& getColors()
-  {
-    return m_Colors;
-  }
-  SIMPL::Rgb getColor(qint32 row)
-  {
-    return m_Colors[row];
-  }
+  /**
+   * @brief getBinNumber
+   * @param row
+   * @return
+   */
+  float getBinNumber(qint32 row) const override;
 
-  virtual QVector<float> getData(int col);
-  virtual float getDataValue(int col, int row);
-  void setColumnData(int col, QVector<float>& data);
+  /**
+   * @brief getColors
+   * @return
+   */
+  const QVector<SIMPL::Rgb>& getColors() const override;
 
-  QVector<float>& getAlphas()
-  {
-    return m_Alpha;
-  }
-  QVector<float>& getBetas()
-  {
-    return m_Beta;
-  }
+  /**
+   * @brief getColor
+   * @param row
+   * @return
+   */
+  SIMPL::Rgb getColor(qint32 row) const override;
 
-  float getAlpha(qint32 row)
-  {
-    return m_Alpha[row];
-  }
-  float getBeta(qint32 row)
-  {
-    return m_Beta[row];
-  }
+  /**
+   * @brief getData
+   * @param col
+   * @return
+   */
+  std::vector<float> getData(int col) const override;
+
+  /**
+   * @brief getDataValue
+   * @param col
+   * @param row
+   * @return
+   */
+  float getDataValue(int col, int row) const override;
+
+  /**
+   * @brief setColumnData
+   * @param col
+   * @param data
+   */
+  void setColumnData(int col, QVector<float>& data) override;
+
+  //------------------------------- Class Specific Data Accessors
+
+  const QVector<float>& getAlphas() const;
+
+  const QVector<float>& getBetas() const;
+
+  float getAlpha(qint32 row) const;
+
+  float getBeta(qint32 row) const;
 
 private:
   int m_ColumnCount;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.cpp
@@ -296,27 +296,27 @@ bool SGLogNormalTableModel::removeRows(int row, int count, const QModelIndex& in
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> SGLogNormalTableModel::getData(int col)
+std::vector<float> SGLogNormalTableModel::getData(int col) const
 {
 
   switch(col)
   {
   case Average:
-    return m_Average;
+    return std::vector<float>(m_Average.begin(), m_Average.end());
     break;
   case StdDev:
-    return m_StdDev;
+    return std::vector<float>(m_StdDev.begin(), m_StdDev.end());
     break;
   default:
     Q_ASSERT(false);
   }
-  return QVector<float>();
+  return std::vector<float>();
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-float SGLogNormalTableModel::getDataValue(int col, int row)
+float SGLogNormalTableModel::getDataValue(int col, int row) const
 {
   switch(col)
   {
@@ -401,4 +401,48 @@ void SGLogNormalTableModel::setTableData(QVector<float> bins, QVector<QVector<fl
 QAbstractItemDelegate* SGLogNormalTableModel::getItemDelegate()
 {
   return new SGLogNormalItemDelegate;
+}
+
+bool SGLogNormalTableModel::setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role)
+{
+  return false;
+}
+
+const QVector<float>& SGLogNormalTableModel::getBinNumbers() const
+{
+  return m_BinNumbers;
+}
+
+float SGLogNormalTableModel::getBinNumber(qint32 row) const
+{
+  return m_BinNumbers[row];
+}
+
+const QVector<SIMPL::Rgb>& SGLogNormalTableModel::getColors() const
+{
+  return m_Colors;
+}
+
+SIMPL::Rgb SGLogNormalTableModel::getColor(qint32 row) const
+{
+  return m_Colors[row];
+}
+
+const QVector<float>& SGLogNormalTableModel::getAvergaes() const
+{
+  return m_Average;
+}
+const QVector<float>& SGLogNormalTableModel::getStdDevs() const
+{
+  return m_StdDev;
+}
+
+float SGLogNormalTableModel::getAverage(qint32 row) const
+{
+  return m_Average[row];
+}
+
+float SGLogNormalTableModel::getStdDev(qint32 row) const
+{
+  return m_StdDev[row];
 }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGLogNormalTableModel.h
@@ -63,74 +63,154 @@ public:
   };
 
   SGLogNormalTableModel(QObject* parent = nullptr);
-  virtual ~SGLogNormalTableModel();
+  ~SGLogNormalTableModel();
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-  int rowCount(const QModelIndex& parent = QModelIndex()) const;
-  int columnCount(const QModelIndex& parent = QModelIndex()) const;
-
-  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
   /**
-   *
+   * @brief flags
+   * @param index
+   * @return
+   */
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+  /**
+   * @brief data
+   * @param index
+   * @param role
+   * @return
+   */
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief headerData
+   * @param section
+   * @param orientation
+   * @param role
+   * @return
+   */
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief rowCount
+   * @param parent
+   * @return
+   */
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief columnCount
+   * @param parent
+   * @return
+   */
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief setData
+   * @param index
+   * @param value
+   * @param role
+   * @return
+   */
+  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+
+  /**
+   * @brief setHeaderData
    * @param col
    * @param orientation
    * @param data
    * @param role
    * @return
    */
-  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole)
-  {
-    return false;
-  }
+  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole) override;
 
-  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
-  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  /**
+   * @brief insertRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
-  QAbstractItemDelegate* getItemDelegate();
+  /**
+   * @brief removeRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
+  /**
+   * @brief getItemDelegate
+   * @return
+   */
+  QAbstractItemDelegate* getItemDelegate() override;
+
+  /**
+   * @brief setTableData
+   * @param bins
+   * @param data
+   * @param colors
+   */
   void setTableData(QVector<float> bins, QVector<QVector<float>> data, QVector<SIMPL::Rgb> colors) override;
 
-  QVector<float>& getBinNumbers()
-  {
-    return m_BinNumbers;
-  }
-  float getBinNumber(qint32 row)
-  {
-    return m_BinNumbers[row];
-  }
+  /**
+   * @brief getBinNumbers
+   * @return
+   */
+  const QVector<float>& getBinNumbers() const override;
 
-  QVector<SIMPL::Rgb>& getColors()
-  {
-    return m_Colors;
-  }
-  SIMPL::Rgb getColor(qint32 row)
-  {
-    return m_Colors[row];
-  }
+  /**
+   * @brief getBinNumber
+   * @param row
+   * @return
+   */
+  float getBinNumber(qint32 row) const override;
 
-  virtual QVector<float> getData(int col);
-  virtual float getDataValue(int col, int row);
-  virtual void setColumnData(int col, QVector<float>& data);
+  /**
+   * @brief getColors
+   * @return
+   */
+  const QVector<SIMPL::Rgb>& getColors() const override;
 
-  QVector<float>& getAvergaes()
-  {
-    return m_Average;
-  }
-  QVector<float>& getStdDevs()
-  {
-    return m_StdDev;
-  }
+  /**
+   * @brief getColor
+   * @param row
+   * @return
+   */
+  SIMPL::Rgb getColor(qint32 row) const override;
 
-  float getAverage(qint32 row)
-  {
-    return m_Average[row];
-  }
-  float getStdDev(qint32 row)
-  {
-    return m_StdDev[row];
-  }
+  /**
+   * @brief getData
+   * @param col
+   * @return
+   */
+  std::vector<float> getData(int col) const override;
+
+  /**
+   * @brief getDataValue
+   * @param col
+   * @param row
+   * @return
+   */
+  float getDataValue(int col, int row) const override;
+
+  /**
+   * @brief setColumnData
+   * @param col
+   * @param data
+   */
+  void setColumnData(int col, QVector<float>& data) override;
+
+  //------------------------------- Class Specific Data Accessors
+
+  const QVector<float>& getAvergaes() const;
+
+  const QVector<float>& getStdDevs() const;
+
+  float getAverage(qint32 row) const;
+
+  float getStdDev(qint32 row) const;
 
 private:
   int m_ColumnCount;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
@@ -299,15 +299,16 @@ bool SGMDFTableModel::removeRows(int row, int count, const QModelIndex& index)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> SGMDFTableModel::getData(int col)
+std::vector<float> SGMDFTableModel::getData(int col)
 {
+  std::vector<float> data;
   if(col == Angle)
   {
-    return m_Angles;
+    return std::vector<float>(m_Angles.begin(), m_Angles.end());
   }
   if(col == Weight)
   {
-    return m_Weights;
+    return std::vector<float>(m_Weights.begin(), m_Weights.end());
   }
   if(col == Axis)
   {
@@ -327,9 +328,9 @@ QVector<float> SGMDFTableModel::getData(int col)
         values.push_back(l);
       }
     }
-    return values;
+    return std::vector<float>(values.begin(), values.end());
   }
-  return QVector<float>();
+  return data;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
@@ -65,7 +65,7 @@ public:
    * @param index
    * @return
    */
-  virtual Qt::ItemFlags flags(const QModelIndex& index) const;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
   /**
    *
@@ -73,7 +73,7 @@ public:
    * @param role
    * @return
    */
-  virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
   /**
    *
@@ -82,21 +82,21 @@ public:
    * @param role
    * @return
    */
-  virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
   /**
    *
    * @param parent
    * @return
    */
-  virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
   /**
    *
    * @param parent
    * @return
    */
-  virtual int columnCount(const QModelIndex& parent = QModelIndex()) const;
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
   /**
    *
@@ -105,7 +105,7 @@ public:
    * @param role
    * @return
    */
-  virtual bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
   /**
    *
@@ -115,7 +115,7 @@ public:
    * @param role
    * @return
    */
-  virtual bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole);
+  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole) override;
 
   /**
    *
@@ -124,7 +124,7 @@ public:
    * @param parent
    * @return
    */
-  virtual bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   /**
    *
@@ -133,20 +133,20 @@ public:
    * @param parent
    * @return
    */
-  virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   /**
    *
    * @return
    */
-  virtual QAbstractItemDelegate* getItemDelegate();
+  QAbstractItemDelegate* getItemDelegate();
 
   /**
    *
    * @param col
    * @return
    */
-  virtual QVector<float> getData(int col);
+  std::vector<float> getData(int col);
 
   /**
    *
@@ -158,11 +158,11 @@ public:
 
   int parseHKLRow(int row, float& h, float& k, float& l);
 
-  virtual void setColumnData(int col, QVector<float>& data);
+  void setColumnData(int col, QVector<float>& data);
 
-  virtual void setRowData(int row, float angle, QString axis, float weight);
+  void setRowData(int row, float angle, QString axis, float weight);
 
-  virtual void setInitialValues();
+  void setInitialValues();
 
   void setTableData(QVector<float> angles, QVector<float> axis, QVector<float> weights);
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.cpp
@@ -292,30 +292,30 @@ bool SGODFTableModel::removeRows(int row, int count, const QModelIndex& index)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> SGODFTableModel::getData(int col)
+std::vector<float> SGODFTableModel::getData(int col)
 {
+
+  QVector<float> data;
 
   switch(col)
   {
   case Euler1:
-    return m_Euler1s;
+    data = m_Euler1s;
     break;
   case Euler2:
-    return m_Euler2s;
+    data = m_Euler2s;
     break;
   case Euler3:
-    return m_Euler3s;
+    data = m_Euler3s;
     break;
   case Weight:
-    return m_Weights;
+    data = m_Weights;
     break;
   case Sigma:
-    return m_Sigmas;
+    data = m_Sigmas;
     break;
-  default:
-    Q_ASSERT(false);
   }
-  return QVector<float>();
+  return std::vector<float>(data.begin(), data.end());
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QtCore/QAbstractTableModel>
 #include <QtCore/QVariant>
 #include <QtCore/QVector>
@@ -145,7 +147,7 @@ public:
    * @param col
    * @return
    */
-  virtual QVector<float> getData(int col);
+  virtual std::vector<float> getData(int col);
 
   /**
    *

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.cpp
@@ -324,30 +324,30 @@ bool SGPowerLawTableModel::removeRows(int row, int count, const QModelIndex& ind
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> SGPowerLawTableModel::getData(int col)
+std::vector<float> SGPowerLawTableModel::getData(int col) const
 {
 
   switch(col)
   {
   case Alpha:
-    return m_Alpha;
+    return std::vector<float>(m_Alpha.begin(), m_Alpha.end());
     break;
   case K:
-    return m_K;
+    return std::vector<float>(m_K.begin(), m_K.end());
     break;
   case Beta:
-    return m_Beta;
+    return std::vector<float>(m_Beta.begin(), m_Beta.end());
     break;
   default:
     Q_ASSERT(false);
   }
-  return QVector<float>();
+  return std::vector<float>();
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-float SGPowerLawTableModel::getDataValue(int col, int row)
+float SGPowerLawTableModel::getDataValue(int col, int row) const
 {
   switch(col)
   {
@@ -440,4 +440,59 @@ void SGPowerLawTableModel::setTableData(QVector<float> bins, QVector<QVector<flo
 QAbstractItemDelegate* SGPowerLawTableModel::getItemDelegate()
 {
   return new SGPowerLawItemDelegate;
+}
+
+bool SGPowerLawTableModel::setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role)
+{
+  return false;
+}
+
+const QVector<float>& SGPowerLawTableModel::getBinNumbers() const
+{
+  return m_BinNumbers;
+}
+
+float SGPowerLawTableModel::getBinNumber(qint32 row) const
+{
+  return m_BinNumbers[row];
+}
+
+const QVector<SIMPL::Rgb>& SGPowerLawTableModel::getColors() const
+{
+  return m_Colors;
+}
+
+SIMPL::Rgb SGPowerLawTableModel::getColor(qint32 row) const
+{
+  return m_Colors[row];
+}
+
+const QVector<float>& SGPowerLawTableModel::getAlphas() const
+{
+  return m_Alpha;
+}
+
+const QVector<float>& SGPowerLawTableModel::getKs() const
+{
+  return m_K;
+}
+
+const QVector<float>& SGPowerLawTableModel::getBetas() const
+{
+  return m_Beta;
+}
+
+float SGPowerLawTableModel::getAlpha(qint32 row) const
+{
+  return m_Alpha[row];
+}
+
+float SGPowerLawTableModel::getK(qint32 row) const
+{
+  return m_K[row];
+}
+
+float SGPowerLawTableModel::getBeta(qint32 row) const
+{
+  return m_Beta[row];
 }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGPowerLawTableModel.h
@@ -66,80 +66,152 @@ public:
   SGPowerLawTableModel(QObject* parent = nullptr);
   virtual ~SGPowerLawTableModel();
 
-  Qt::ItemFlags flags(const QModelIndex& index) const;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-  int rowCount(const QModelIndex& parent = QModelIndex()) const;
-  int columnCount(const QModelIndex& parent = QModelIndex()) const;
-
-  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
   /**
-   *
+   * @brief flags
+   * @param index
+   * @return
+   */
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+  /**
+   * @brief data
+   * @param index
+   * @param role
+   * @return
+   */
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief headerData
+   * @param section
+   * @param orientation
+   * @param role
+   * @return
+   */
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+  /**
+   * @brief rowCount
+   * @param parent
+   * @return
+   */
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief columnCount
+   * @param parent
+   * @return
+   */
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+
+  /**
+   * @brief setData
+   * @param index
+   * @param value
+   * @param role
+   * @return
+   */
+  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+
+  /**
+   * @brief setHeaderData
    * @param col
    * @param orientation
    * @param data
    * @param role
    * @return
    */
-  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole)
-  {
-    return false;
-  }
+  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole) override;
 
-  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
-  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  /**
+   * @brief insertRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
-  QAbstractItemDelegate* getItemDelegate();
+  /**
+   * @brief removeRows
+   * @param row
+   * @param count
+   * @param parent
+   * @return
+   */
+  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
+  /**
+   * @brief getItemDelegate
+   * @return
+   */
+  QAbstractItemDelegate* getItemDelegate() override;
+
+  /**
+   * @brief setTableData
+   * @param bins
+   * @param data
+   * @param colors
+   */
   void setTableData(QVector<float> bins, QVector<QVector<float>> data, QVector<SIMPL::Rgb> colors) override;
 
-  QVector<float>& getBinNumbers()
-  {
-    return m_BinNumbers;
-  }
-  float getBinNumber(qint32 row)
-  {
-    return m_BinNumbers[row];
-  }
+  /**
+   * @brief getBinNumbers
+   * @return
+   */
+  const QVector<float>& getBinNumbers() const override;
 
-  QVector<SIMPL::Rgb>& getColors()
-  {
-    return m_Colors;
-  }
-  SIMPL::Rgb getColor(qint32 row)
-  {
-    return m_Colors[row];
-  }
+  /**
+   * @brief getBinNumber
+   * @param row
+   * @return
+   */
+  float getBinNumber(qint32 row) const override;
 
-  virtual QVector<float> getData(int col);
-  virtual float getDataValue(int col, int row);
-  virtual void setColumnData(int col, QVector<float>& data);
+  /**
+   * @brief getColors
+   * @return
+   */
+  const QVector<SIMPL::Rgb>& getColors() const override;
 
-  QVector<float>& getAlphas()
-  {
-    return m_Alpha;
-  }
-  QVector<float>& getKs()
-  {
-    return m_K;
-  }
-  QVector<float>& getBetas()
-  {
-    return m_Beta;
-  }
+  /**
+   * @brief getColor
+   * @param row
+   * @return
+   */
+  SIMPL::Rgb getColor(qint32 row) const override;
 
-  float getAlpha(qint32 row)
-  {
-    return m_Alpha[row];
-  }
-  float getK(qint32 row)
-  {
-    return m_K[row];
-  }
-  float getBeta(qint32 row)
-  {
-    return m_Beta[row];
-  }
+  /**
+   * @brief getData
+   * @param col
+   * @return
+   */
+  std::vector<float> getData(int col) const override;
+
+  /**
+   * @brief getDataValue
+   * @param col
+   * @param row
+   * @return
+   */
+  float getDataValue(int col, int row) const override;
+
+  /**
+   * @brief setColumnData
+   * @param col
+   * @param data
+   */
+  void setColumnData(int col, QVector<float>& data) override;
+
+  //------------------------------- Class Specific Data Accessors
+
+  const QVector<float>& getAlphas() const;
+  const QVector<float>& getKs() const;
+  const QVector<float>& getBetas() const;
+
+  float getAlpha(qint32 row) const;
+  float getK(qint32 row) const;
+  float getBeta(qint32 row) const;
 
 private:
   int m_ColumnCount;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGRDFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGRDFTableModel.h
@@ -60,7 +60,7 @@ public:
    * @param index
    * @return
    */
-  virtual Qt::ItemFlags flags(const QModelIndex& index) const;
+  Qt::ItemFlags flags(const QModelIndex& index) const override;
 
   /**
    *
@@ -68,7 +68,7 @@ public:
    * @param role
    * @return
    */
-  virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
   /**
    *
@@ -77,21 +77,21 @@ public:
    * @param role
    * @return
    */
-  virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
   /**
    *
    * @param parent
    * @return
    */
-  virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
   /**
    *
    * @param parent
    * @return
    */
-  virtual int columnCount(const QModelIndex& parent = QModelIndex()) const;
+  int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
   /**
    *
@@ -100,7 +100,7 @@ public:
    * @param role
    * @return
    */
-  virtual bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+  bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
   /**
    *
@@ -110,7 +110,7 @@ public:
    * @param role
    * @return
    */
-  virtual bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole);
+  bool setHeaderData(int col, Qt::Orientation orientation, const QVariant& data, int role = Qt::EditRole) override;
 
   /**
    *
@@ -119,7 +119,7 @@ public:
    * @param parent
    * @return
    */
-  virtual bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   /**
    *
@@ -128,20 +128,20 @@ public:
    * @param parent
    * @return
    */
-  virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
+  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   /**
    *
    * @return
    */
-  virtual QAbstractItemDelegate* getItemDelegate();
+  QAbstractItemDelegate* getItemDelegate();
 
   /**
    *
    * @param col
    * @return
    */
-  virtual QVector<float> getData(int col);
+  QVector<float> getData(int col);
 
   /**
    *
@@ -149,13 +149,13 @@ public:
    * @param row
    * @return
    */
-  virtual int getDataValue(int col, int row);
+  int getDataValue(int col, int row);
 
-  virtual void setColumnData(int col, QVector<float>& data);
+  void setColumnData(int col, QVector<float>& data);
 
-  virtual void setRowData(int row, int freq);
+  void setRowData(int row, int freq);
 
-  virtual void setInitialValues();
+  void setInitialValues();
 
   void setTableData(QVector<float> freqs);
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TextureDialog.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TextureDialog.h
@@ -83,7 +83,7 @@ protected:
 private:
   unsigned int m_CrystalStructure = {};
 
-  QVector<TexturePreset::Pointer> m_Presets;
+  std::vector<TexturePreset::Pointer> m_Presets;
 
 public:
   TextureDialog(const TextureDialog&) = delete;  // Copy Constructor Not Implemented

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrecipitateStatsData.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrecipitateStatsData.cpp
@@ -521,11 +521,11 @@ void GeneratePrecipitateStatsData::execute()
   {
     absPresetPtr->initializeODFTableModel(dataMap);
 
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> weights;
+    std::vector<float> sigmas;
 
     std::vector<std::vector<double>> odfData = m_OdfData.getTableData();
     for(size_t i = 0; i < odfData.size(); i++)
@@ -545,11 +545,11 @@ void GeneratePrecipitateStatsData::execute()
   notifyStatusMessage(msg);
   {
     absPresetPtr->initializeMDFTableModel(dataMap);
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> odf_weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> odf_weights;
+    std::vector<float> sigmas;
     std::vector<std::vector<double>> odfData = m_OdfData.getTableData();
     for(size_t i = 0; i < odfData.size(); i++)
     {
@@ -560,11 +560,11 @@ void GeneratePrecipitateStatsData::execute()
       sigmas.push_back(static_cast<float>(odfData[i][4]));
     }
 
-    QVector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalSymmetry, e1s, e2s, e3s, odf_weights, sigmas, true);
+    std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalSymmetry, e1s, e2s, e3s, odf_weights, sigmas, true);
 
-    QVector<float> angles;
-    QVector<float> axes;
-    QVector<float> weights;
+    std::vector<float> angles;
+    std::vector<float> axes;
+    std::vector<float> weights;
     std::vector<std::vector<double>> mdfData = m_MdfData.getTableData();
     for(size_t i = 0; i < mdfData.size(); i++)
     {
@@ -583,11 +583,11 @@ void GeneratePrecipitateStatsData::execute()
   notifyStatusMessage(msg);
   {
     absPresetPtr->initializeAxisODFTableModel(dataMap);
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> weights;
+    std::vector<float> sigmas;
     std::vector<std::vector<double>> axisOdfData = m_AxisOdfData.getTableData();
     for(size_t i = 0; i < axisOdfData.size(); i++)
     {

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrimaryStatsData.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/GeneratePrimaryStatsData.cpp
@@ -496,11 +496,11 @@ void GeneratePrimaryStatsData::execute()
   {
     absPresetPtr->initializeODFTableModel(dataMap);
 
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> weights;
+    std::vector<float> sigmas;
 
     std::vector<std::vector<double>> odfData = m_OdfData.getTableData();
     for(size_t i = 0; i < odfData.size(); i++)
@@ -517,11 +517,11 @@ void GeneratePrimaryStatsData::execute()
 
   {
     absPresetPtr->initializeMDFTableModel(dataMap);
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> odf_weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> odf_weights;
+    std::vector<float> sigmas;
     std::vector<std::vector<double>> odfData = m_OdfData.getTableData();
     for(size_t i = 0; i < odfData.size(); i++)
     {
@@ -532,11 +532,11 @@ void GeneratePrimaryStatsData::execute()
       sigmas.push_back(odfData[i][4]);
     }
 
-    QVector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalSymmetry, e1s, e2s, e3s, odf_weights, sigmas, true);
+    std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalSymmetry, e1s, e2s, e3s, odf_weights, sigmas, true);
 
-    QVector<float> angles;
-    QVector<float> axes;
-    QVector<float> weights;
+    std::vector<float> angles;
+    std::vector<float> axes;
+    std::vector<float> weights;
     std::vector<std::vector<double>> mdfData = m_MdfData.getTableData();
     for(size_t i = 0; i < mdfData.size(); i++)
     {
@@ -552,11 +552,11 @@ void GeneratePrimaryStatsData::execute()
 
   {
     absPresetPtr->initializeAxisODFTableModel(dataMap);
-    QVector<float> e1s;
-    QVector<float> e2s;
-    QVector<float> e3s;
-    QVector<float> weights;
-    QVector<float> sigmas;
+    std::vector<float> e1s;
+    std::vector<float> e2s;
+    std::vector<float> e3s;
+    std::vector<float> weights;
+    std::vector<float> sigmas;
     std::vector<std::vector<double>> axisOdfData = m_AxisOdfData.getTableData();
     for(size_t i = 0; i < axisOdfData.size(); i++)
     {

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertPrecipitatePhases.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertPrecipitatePhases.cpp
@@ -35,19 +35,17 @@
  *    United States Prime Contract Navy N00173-07-C-2068
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#include <memory>
-
 #include "InsertPrecipitatePhases.h"
 
+#include <memory>
 #include <fstream>
+#include <random>
+#include <chrono>
 
 #include <QtCore/QDir>
-
 #include <QtCore/QTextStream>
 
 #include "SIMPLib/Common/Constants.h"
-
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
 #include "SIMPLib/FilterParameters/AttributeMatrixCreationFilterParameter.h"
 #include "SIMPLib/FilterParameters/AttributeMatrixSelectionFilterParameter.h"
@@ -1650,7 +1648,8 @@ void InsertPrecipitatePhases::generate_precipitate(int32_t phase, Precip_t* prec
       break;
     }
   }
-  OrientationD eulers = OrthoOps->determineEulerAngles(m_Seed, bin);
+  std::array<double, 3> randx3 = {rg.genrand_res53(), rg.genrand_res53(), rg.genrand_res53()};
+  OrientationD eulers = OrthoOps->determineEulerAngles(randx3.data(), bin);
   VectorOfFloatArray omega3 = pp->getFeatureSize_Omegas();
   float mf = omega3[0]->getValue(diameter);
   float s = omega3[1]->getValue(diameter);

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.cpp
@@ -105,7 +105,7 @@ MatchCrystallography::MatchCrystallography()
   m_ActualMdf = FloatArrayType::NullPointer();
   m_SimMdf = FloatArrayType::NullPointer();
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 
 }
 
@@ -232,7 +232,7 @@ void MatchCrystallography::initialize()
   m_SimMdf = FloatArrayType::NullPointer();
   m_MisorientationLists.clear();
 
-  m_OrientationOps = LaueOps::getOrientationOpsQVector();
+  m_OrientationOps = LaueOps::GetAllOrientationOps();
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/MatchCrystallography.h
@@ -46,8 +46,12 @@
 
 #include "SyntheticBuilding/SyntheticBuildingConstants.h"
 #include "SyntheticBuilding/SyntheticBuildingVersion.h"
-
 #include "SyntheticBuilding/SyntheticBuildingDLLExport.h"
+
+class LaueOps;
+using LaueOpsShPtrType = std::shared_ptr<LaueOps>;
+using LaueOpsContainer = std::vector<LaueOpsShPtrType>;
+
 
 /**
  * @brief The MatchCrystallography class. See [Filter documentation](@ref matchcrystallography) for details.
@@ -485,8 +489,7 @@ private:
 
   std::vector<std::vector<float>> m_MisorientationLists;
 
-  QVector<LaueOps::Pointer> m_OrientationOps;
-
+  LaueOpsContainer m_OrientationOps;
 public:
   MatchCrystallography(const MatchCrystallography&) = delete; // Copy Constructor Not Implemented
   MatchCrystallography(MatchCrystallography&&) = delete;      // Move Constructor Not Implemented

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/PackPrimaryPhases.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/PackPrimaryPhases.cpp
@@ -1871,7 +1871,8 @@ void PackPrimaryPhases::generateFeature(int32_t phase, Feature_t* feature, uint3
       break;
     }
   }
-  OrientationD eulers = m_OrthoOps->determineEulerAngles(m_Seed, bin);
+  std::array<double, 3> randx3 = {rg.genrand_res53(), rg.genrand_res53(), rg.genrand_res53()};
+  OrientationD eulers = m_OrthoOps->determineEulerAngles(randx3.data(), bin);
   VectorOfFloatArray omega3 = pp->getFeatureSize_Omegas();
   float mf = omega3[0]->getValue(diameter);
   float s = omega3[1]->getValue(diameter);

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorFilter.cpp
@@ -373,11 +373,11 @@ void StatsGeneratorFilter::execute()
       }
 
       // ODF Data ************************************************************************
-      QVector<float> e1s;
-      QVector<float> e2s;
-      QVector<float> e3s;
-      QVector<float> weights;
-      QVector<float> sigmas;
+      std::vector<float> e1s;
+      std::vector<float> e2s;
+      std::vector<float> e3s;
+      std::vector<float> weights;
+      std::vector<float> sigmas;
 
       if(odfWeights.size() == 5)
       {
@@ -396,9 +396,9 @@ void StatsGeneratorFilter::execute()
       StatsGeneratorUtilities::GenerateODFBinData(statsData.get(), phaseType, crystalStruct, e1s, e2s, e3s, weights, sigmas);
 
       // MDF Data ************************************************************************
-      QVector<float> mdf_angles;
-      QVector<float> mdf_axes;
-      QVector<float> mdf_weights;
+      std::vector<float> mdf_angles;
+      std::vector<float> mdf_axes;
+      std::vector<float> mdf_weights;
 
       if(mdfWeights.size() == 3)
       {
@@ -414,17 +414,17 @@ void StatsGeneratorFilter::execute()
       }
 
       // Compute the ODF representation that will be used to determine the MDF
-      QVector<float> odf = StatsGeneratorUtilities::GenerateODFData(crystalStruct, e1s, e2s, e3s, weights, sigmas);
+      std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(crystalStruct, e1s, e2s, e3s, weights, sigmas);
 
       // Compute the binned MDF and set it into the StatsDataArray
       StatsGeneratorUtilities::GenerateMisorientationBinData(statsData.get(), phaseType, crystalStruct, odf, mdf_angles, mdf_axes, mdf_weights);
 
       // AxisODF Data ********************************************************************
-      QVector<float> axis_e1s;
-      QVector<float> axis_e2s;
-      QVector<float> axis_e3s;
-      QVector<float> axis_weights;
-      QVector<float> axis_sigmas;
+      std::vector<float> axis_e1s;
+      std::vector<float> axis_e2s;
+      std::vector<float> axis_e3s;
+      std::vector<float> axis_weights;
+      std::vector<float> axis_sigmas;
 
       if(aodfWeights.size() == 5)
       {

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.cpp
@@ -85,26 +85,37 @@ void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType
     {
     case Ebsd::CrystalStructure::Triclinic: // 4; Triclinic -1
       Texture::CalculateODFData<float, TriclinicOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Monoclinic: // 5; Monoclinic 2/m
       Texture::CalculateODFData<float, MonoclinicOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::OrthoRhombic: // 6; Orthorhombic mmm
       Texture::CalculateODFData<float, OrthoRhombicOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Tetragonal_Low: // 7; Tetragonal-Low 4/m
       Texture::CalculateODFData<float, TetragonalLowOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Tetragonal_High: // 8; Tetragonal-High 4/mmm
       Texture::CalculateODFData<float, TetragonalOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Trigonal_Low: // 9; Trigonal-Low -3
       Texture::CalculateODFData<float, TrigonalLowOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Trigonal_High: // 10; Trigonal-High -3m
       Texture::CalculateODFData<float, TrigonalOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Hexagonal_Low: // 2; Hexagonal-Low 6/m
       Texture::CalculateODFData<float, HexagonalLowOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Hexagonal_High: // 0; Hexagonal-High 6/mmm
       Texture::CalculateODFData<float, HexagonalOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Cubic_Low: // 3; Cubic Cubic-Low m3 (Tetrahedral)
       Texture::CalculateODFData<float, CubicLowOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     case Ebsd::CrystalStructure::Cubic_High: // 1; Cubic Cubic-High m3m
       Texture::CalculateODFData<float, CubicOps, ContainerType>(e1s, e2s, e3s, weights, sigmas, true, odf, numEntries);
+      break;
     default:
       break;
     }

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.cpp
@@ -70,10 +70,10 @@ StatsGeneratorUtilities::~StatsGeneratorUtilities() = default;
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s,
-                                                 QVector<float>& weights, QVector<float>& sigmas, bool computeODF)
+void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, std::vector<float>& e1s, std::vector<float>& e2s,
+                                                 std::vector<float>& e3s, std::vector<float>& weights, std::vector<float>& sigmas, bool computeODF)
 {
-  using ContainerType = QVector<float>;
+  using ContainerType = std::vector<float>;
 
   ContainerType odf;
   size_t numEntries = e1s.size();
@@ -123,7 +123,7 @@ void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType
 
   if(!odf.empty())
   {
-    FloatArrayType::Pointer p = FloatArrayType::FromQVector(odf, SIMPL::StringConstants::ODF);
+    FloatArrayType::Pointer p = FloatArrayType::FromStdVector(odf, SIMPL::StringConstants::ODF);
     if(phaseType == PhaseType::Type::Primary)
     {
       PrimaryStatsData* pp = dynamic_cast<PrimaryStatsData*>(statsData);
@@ -141,11 +141,11 @@ void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType
     }
     if(!e1s.empty())
     {
-      FloatArrayType::Pointer euler1 = FloatArrayType::FromQVector(e1s, SIMPL::StringConstants::Euler1);
-      FloatArrayType::Pointer euler2 = FloatArrayType::FromQVector(e2s, SIMPL::StringConstants::Euler2);
-      FloatArrayType::Pointer euler3 = FloatArrayType::FromQVector(e3s, SIMPL::StringConstants::Euler3);
-      FloatArrayType::Pointer sigma = FloatArrayType::FromQVector(sigmas, SIMPL::StringConstants::Sigma);
-      FloatArrayType::Pointer weight = FloatArrayType::FromQVector(weights, SIMPL::StringConstants::Weight);
+      FloatArrayType::Pointer euler1 = FloatArrayType::FromStdVector(e1s, SIMPL::StringConstants::Euler1);
+      FloatArrayType::Pointer euler2 = FloatArrayType::FromStdVector(e2s, SIMPL::StringConstants::Euler2);
+      FloatArrayType::Pointer euler3 = FloatArrayType::FromStdVector(e3s, SIMPL::StringConstants::Euler3);
+      FloatArrayType::Pointer sigma = FloatArrayType::FromStdVector(sigmas, SIMPL::StringConstants::Sigma);
+      FloatArrayType::Pointer weight = FloatArrayType::FromStdVector(weights, SIMPL::StringConstants::Weight);
 
       VectorOfFloatArray odfWeights;
       odfWeights.push_back(euler1);
@@ -175,10 +175,10 @@ void StatsGeneratorUtilities::GenerateODFBinData(StatsData* statsData, PhaseType
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void StatsGeneratorUtilities::GenerateAxisODFBinData(StatsData* statsData, PhaseType::Type phaseType, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s, QVector<float>& weights,
-                                                     QVector<float>& sigmas, bool computeAxisODF)
+void StatsGeneratorUtilities::GenerateAxisODFBinData(StatsData* statsData, PhaseType::Type phaseType, std::vector<float>& e1s, std::vector<float>& e2s, std::vector<float>& e3s,
+                                                     std::vector<float>& weights, std::vector<float>& sigmas, bool computeAxisODF)
 {
-  using ContainerType = QVector<float>;
+  using ContainerType = std::vector<float>;
   ContainerType aodf;
   size_t numEntries = e1s.size();
   OrthoRhombicOps ops;
@@ -190,7 +190,7 @@ void StatsGeneratorUtilities::GenerateAxisODFBinData(StatsData* statsData, Phase
 
   if(!aodf.empty())
   {
-    FloatArrayType::Pointer aodfData = FloatArrayType::FromQVector(aodf, SIMPL::StringConstants::AxisOrientation);
+    FloatArrayType::Pointer aodfData = FloatArrayType::FromStdVector(aodf, SIMPL::StringConstants::AxisOrientation);
     if(phaseType == PhaseType::Type::Primary)
     {
       PrimaryStatsData* pp = dynamic_cast<PrimaryStatsData*>(statsData);
@@ -208,11 +208,11 @@ void StatsGeneratorUtilities::GenerateAxisODFBinData(StatsData* statsData, Phase
     }
     if(!e1s.empty())
     {
-      FloatArrayType::Pointer euler1 = FloatArrayType::FromQVector(e1s, SIMPL::StringConstants::Euler1);
-      FloatArrayType::Pointer euler2 = FloatArrayType::FromQVector(e2s, SIMPL::StringConstants::Euler2);
-      FloatArrayType::Pointer euler3 = FloatArrayType::FromQVector(e3s, SIMPL::StringConstants::Euler3);
-      FloatArrayType::Pointer sigma = FloatArrayType::FromQVector(sigmas, SIMPL::StringConstants::Sigma);
-      FloatArrayType::Pointer weight = FloatArrayType::FromQVector(weights, SIMPL::StringConstants::Weight);
+      FloatArrayType::Pointer euler1 = FloatArrayType::FromStdVector(e1s, SIMPL::StringConstants::Euler1);
+      FloatArrayType::Pointer euler2 = FloatArrayType::FromStdVector(e2s, SIMPL::StringConstants::Euler2);
+      FloatArrayType::Pointer euler3 = FloatArrayType::FromStdVector(e3s, SIMPL::StringConstants::Euler3);
+      FloatArrayType::Pointer sigma = FloatArrayType::FromStdVector(sigmas, SIMPL::StringConstants::Sigma);
+      FloatArrayType::Pointer weight = FloatArrayType::FromStdVector(weights, SIMPL::StringConstants::Weight);
 
       VectorOfFloatArray aodfWeights;
       aodfWeights.push_back(euler1);
@@ -242,11 +242,11 @@ void StatsGeneratorUtilities::GenerateAxisODFBinData(StatsData* statsData, Phase
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QVector<float> StatsGeneratorUtilities::GenerateODFData(unsigned int crystalStructure, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s, QVector<float>& weights, QVector<float>& sigmas,
-                                                        bool computeODF)
+std::vector<float> StatsGeneratorUtilities::GenerateODFData(unsigned int crystalStructure, std::vector<float>& e1s, std::vector<float>& e2s, std::vector<float>& e3s, std::vector<float>& weights,
+                                                            std::vector<float>& sigmas, bool computeODF)
 {
 
-  using ContainerType = QVector<float>;
+  using ContainerType = std::vector<float>;
   ContainerType odf;
   //// ODF/MDF Update Codes
   size_t numEntries = static_cast<size_t>(e1s.size());
@@ -300,10 +300,10 @@ QVector<float> StatsGeneratorUtilities::GenerateODFData(unsigned int crystalStru
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void StatsGeneratorUtilities::GenerateMisorientationBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, QVector<float>& odf, QVector<float>& angles,
-                                                            QVector<float>& axes, QVector<float>& weights, bool computeMDF)
+void StatsGeneratorUtilities::GenerateMisorientationBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, std::vector<float>& odf, std::vector<float>& angles,
+                                                            std::vector<float>& axes, std::vector<float>& weights, bool computeMDF)
 {
-  using ContainerType = QVector<float>;
+  using ContainerType = std::vector<float>;
 
   ContainerType x;
   ContainerType y;

--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include <QtCore/QVector>
+#include <vector>
 
 #include "SIMPLib/Common/PhaseType.h"
 
@@ -56,17 +56,17 @@ public:
    * @param weights
    * @param sigmas
    */
-  static void GenerateODFBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s, QVector<float>& weights,
-                                 QVector<float>& sigmas, bool computeODF = true);
+  static void GenerateODFBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStructure, std::vector<float>& e1s, std::vector<float>& e2s, std::vector<float>& e3s,
+                                 std::vector<float>& weights, std::vector<float>& sigmas, bool computeODF = true);
 
-  static void GenerateAxisODFBinData(StatsData* statsData, PhaseType::Type phaseType, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s, QVector<float>& weights, QVector<float>& sigmas,
-                                     bool computeAxisODF = true);
+  static void GenerateAxisODFBinData(StatsData* statsData, PhaseType::Type phaseType, std::vector<float>& e1s, std::vector<float>& e2s, std::vector<float>& e3s, std::vector<float>& weights,
+                                     std::vector<float>& sigmas, bool computeAxisODF = true);
 
-  static QVector<float> GenerateODFData(unsigned int crystalStructure, QVector<float>& e1s, QVector<float>& e2s, QVector<float>& e3s, QVector<float>& weights, QVector<float>& sigmas,
-                                        bool computeODF = true);
+  static std::vector<float> GenerateODFData(unsigned int crystalStructure, std::vector<float>& e1s, std::vector<float>& e2s, std::vector<float>& e3s, std::vector<float>& weights,
+                                            std::vector<float>& sigmas, bool computeODF = true);
 
-  static void GenerateMisorientationBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStruct, QVector<float>& odf, QVector<float>& angles, QVector<float>& axes,
-                                            QVector<float>& weights, bool computeMDF = true);
+  static void GenerateMisorientationBinData(StatsData* statsData, PhaseType::Type phaseType, unsigned int crystalStruct, std::vector<float>& odf, std::vector<float>& angles, std::vector<float>& axes,
+                                            std::vector<float>& weights, bool computeMDF = true);
 
 protected:
   StatsGeneratorUtilities();


### PR DESCRIPTION
Remove uses of QVector where possible.

APIs to calculate a misorientation have been updated to be more explicit about returned types.