### PR TITLE
Fix errors when generating MDF Plot data in StatsGenerator

### DIFF
--- a/Source/Plugins/SyntheticBuilding/Documentation/SyntheticBuildingFilters/StatsGeneratorFilter.md
+++ b/Source/Plugins/SyntheticBuilding/Documentation/SyntheticBuildingFilters/StatsGeneratorFilter.md
@@ -194,13 +194,22 @@ Choice of delimiter can be Comma (,), semicolon (;), space ( ), colon (:) or tab
 
 ### MDF Section ###
 
-This sub-tab will display the baseline _misorientation distribution function_ (MDF) for the generated ODF.  The  implemented algorithm proceeds by randomly sampling pairs of orientations from the ODF and calculating the misorientation (axis-angle only). Only the angle is plotted in the misorientation distribution plot.  The user can also add axis-angle pairs to increase in weight.
+This sub-tab will display the baseline _misorientation distribution function_ (MDF) for the generated ODF.  The  implemented algorithm proceeds by randomly sampling pairs of orientations from the ODF and calculating the misorientation (axis-angle only). Only the angle is plotted in the misorientation distribution plot.  The user can also add axis-angle pairs to weight the sampling in favor of a particular misorientation.
 
 ![MDF GUI](Images/SG_MDF_Plot.png)
 
-+ **Angle**: The angle of the misorientation to increase in weight
-+ **Axis**: The axis of the misorientation to increase in weight.  If the crystal structure being used for the phase is Hexagonal, then this axis is in the 3-index, orthogonal convention, not the true (hkil) convention
++ **Angle**: The angle in **Degrees** of the misorientation to increase in weight
++ **Axis**: The axis of the misorientation to increase in weight.  If the crystal structure being used for the phase is Hexagonal, then this axis is in the 3-index, orthogonal convention, not the true (_hkil_) convention. For other Laue systems the user can use either the HKL integers or a normalized HKL vector.
 + **Weight**: The weight in units of MRD (multiples of random distribution) for the entered misorientation
+
+The option to load each row of data from a file is also allowed. The data in the input file must be of the following form:
+
+        [NUMBER OF ENTRIES]
+        [ANGLE] [AXIS H] [AXIS K] [AXIS L] [WEIGHT]
+
+Note that the text file is **not** allowed to have any comment lines or extra lines.
+
+Note that during the computation the Axis-Angle will be sanity checked to ensure that the angle is within the [0.0, Pi] range and the *axis* part is normalized.
 
 ## Axis ODF Tab ##
 
@@ -210,12 +219,12 @@ This tab works in a similar fashion to the ODF tab in that the user can enter va
 
 ### Weights and Spreads Section (Axis ODF) ###
 
-+ **Euler 1-3**: The Euler angles that define an orientation that the user would like to increase in weight
++ **Euler 1-3**: The Euler angles that define an orientation that the user would like to increase in weight given in **Degrees** and in the **Bunge** convention
 + **Weight**: The weight in units of MRD (multiples of random distribution) for the entered orientation
 + **Sigma**: Spread to use in blurring out the orientation chosen. The value corresponds to the number of bins in Rodrigues (orientation) space it takes for the MRD value entered in the _Weight_ column to reduce to 0.0 (decreasing quadratically from the bin of the entered orientation)
 + **Calculate ODF**: Builds the ODF and then creates pole figures (PFs) for the user to inspect
 
-+ Three PFs are formed, which correspond to the location of the 3 principal axes of the grains to be generated (i.e., A > B > C)
++ Three polefigures are formed, which correspond to the location of the 3 principal axes of the grains to be generated (i.e., A > B > C)
 
 ## Required Geometry ##
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrecipitatePhaseWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrecipitatePhaseWidget.cpp
@@ -393,7 +393,7 @@ int PrecipitatePhaseWidget::gatherStatsData(AttributeMatrix::Pointer attrMat, bo
     }
 
     getODFWidget()->getOrientationData(precipitateStatsData.get(), PhaseType::Type::Precipitate, preflight);
-    getMDFWidget()->getMisorientationData(precipitateStatsData.get(), PhaseType::Type::Precipitate, !preflight);
+    getMDFWidget()->getMisorientationData(precipitateStatsData.get(), PhaseType::Type::Precipitate, preflight);
 
     err = getAxisODFWidget()->getOrientationData(precipitateStatsData.get(), PhaseType::Type::Precipitate, preflight);
   }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrimaryPhaseWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/PrimaryPhaseWidget.cpp
@@ -438,12 +438,14 @@ void PrimaryPhaseWidget::setupGui()
 
   connect(m_ODFWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
   connect(m_ODFWidget, SIGNAL(bulkLoadEvent(bool)), this, SLOT(bulkLoadEvent(bool)));
-  connect(m_AxisODFWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
+  connect(m_ODFWidget, SIGNAL(odfDataChanged()), this, SLOT(dataChanged()));
+  connect(m_ODFWidget, SIGNAL(odfDataChanged()), m_MDFWidget, SLOT(updatePlots()));
+
   connect(m_MDFWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
 
-  connect(m_ODFWidget, SIGNAL(odfDataChanged()), m_MDFWidget, SLOT(updatePlots()));
-  connect(m_FeatureSizeDistWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
+  connect(m_AxisODFWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
 
+  connect(m_FeatureSizeDistWidget, SIGNAL(dataChanged()), this, SIGNAL(dataChanged()));
   connect(m_FeatureSizeDistWidget, SIGNAL(userEnteredValidData(bool)), m_GenerateDefaultData, SLOT(setEnabled(bool)));
 }
 
@@ -760,7 +762,7 @@ int PrimaryPhaseWidget::gatherStatsData(AttributeMatrix::Pointer attrMat, bool p
     }
 
     m_ODFWidget->getOrientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
-    m_MDFWidget->getMisorientationData(primaryStatsData.get(), PhaseType::Type::Primary, !preflight);
+    m_MDFWidget->getMisorientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
 
     err = m_AxisODFWidget->getOrientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
   }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenFeatureSizeWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenFeatureSizeWidget.cpp
@@ -37,14 +37,11 @@
 #include <iostream>
 #include <limits>
 
+#include <QtCore/QDebug>
+
 #include <QtGui/QDoubleValidator>
 #include <QtGui/QMouseEvent>
 #include <QtWidgets/QLineEdit>
-
-// Needed for AxisAngle_t and Crystal Symmetry constants
-#include "EbsdLib/Core/EbsdLibConstants.h"
-
-#include <QtCore/QDebug>
 
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/SIMPLib.h"
@@ -55,6 +52,7 @@
 #include "SVWidgetsLib/Widgets/SVStyle.h"
 
 #include "EbsdLib/Texture/StatsGen.hpp"
+#include "EbsdLib/Core/EbsdLibConstants.h"
 
 #include "SyntheticBuilding/Gui/Widgets/StatsGenCurveTracker.h"
 #include "SyntheticBuilding/SyntheticBuildingConstants.h"

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
@@ -296,22 +296,22 @@ void StatsGenMDFWidget::updateMDFPlot(std::vector<float>& odf)
   {
     while(angle > 180.0)
     {
-      angle = angle - 180.0;
+      angle -= 180.0;
     }
     while(angle < 0.0)
     {
-      angle = angle + 180.0;
+      angle += 180.0;
     }
-    angle = angle * SIMPLib::Constants::k_DegToRad;
+    angle *= SIMPLib::Constants::k_DegToRad;
   }
 
   // Normalize the axis to unit norm
   for(size_t i = 0; i < axes.size(); i = i + 3)
   {
     float length = std::sqrt(axes[i] * axes[i] + axes[i + 1] * axes[i + 1] + axes[i + 2] * axes[i + 2]);
-    axes[i] = axes[i] / length;
-    axes[i + 1] = axes[i + 1] / length;
-    axes[i + 2] = axes[i + 2] / length;
+    axes[i] /= length;
+    axes[i + 1] /= length;
+    axes[i + 2] /= length;
   }
 
   // Sanity check the Axis_Angle inputs;
@@ -490,7 +490,9 @@ void StatsGenMDFWidget::on_loadMDFBtn_clicked()
   // If the file is UTF8 with a BOM marker then read the first 3 bytes and dump them.
   if(isUtf8.first)
   {
-    char a, b, c;
+    char a = '\0';
+    char b = '\0';
+    char c = '\0';
     inFile >> a >> b >> c;
   }
 
@@ -552,25 +554,25 @@ void StatsGenMDFWidget::extractStatsData(int index, StatsData* statsData, PhaseT
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Axis) == 0)
     {
       axis = QVector<float>(static_cast<int>(arrays[i]->getSize())); // This one is 3xn in size
-      ::memcpy(axis.data(), arrays[i]->getVoidPointer(0), sizeof(float) * axis.size());
+      std::copy_n(arrays[i]->cbegin(), axis.size(), axis.begin());
     }
 
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Angle) == 0)
     {
       angles = QVector<float>(static_cast<int>(arrays[i]->getNumberOfTuples()));
-      ::memcpy(angles.data(), arrays[i]->getVoidPointer(0), sizeof(float) * angles.size());
+      std::copy_n(arrays[i]->cbegin(), angles.size(), angles.begin());
     }
 
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Weight) == 0)
     {
       weights = QVector<float>(static_cast<int>(arrays[i]->getNumberOfTuples()));
-      ::memcpy(weights.data(), arrays[i]->getVoidPointer(0), sizeof(float) * weights.size());
+      std::copy_n(arrays[i]->cbegin(), weights.size(), weights.begin());
     }
   }
   // Convert from Radians to Degrees
   for(float& a : angles)
   {
-    a = a * static_cast<float>(SIMPLib::Constants::k_RadToDeg);
+    a *= static_cast<float>(SIMPLib::Constants::k_RadToDeg);
   }
   if(!arrays.empty())
   {
@@ -604,9 +606,9 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
   // Convert from Degrees to Radians
   for(size_t i = 0; i < e1s.size(); i++)
   {
-    e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
-    e2s[i] = e2s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
-    e3s[i] = e3s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
+    e1s[i] *= static_cast<float>(SIMPLib::Constants::k_PiOver180);
+    e2s[i] *= static_cast<float>(SIMPLib::Constants::k_PiOver180);
+    e3s[i] *= static_cast<float>(SIMPLib::Constants::k_PiOver180);
   }
 
   std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, odf_weights, sigmas, !preflight);
@@ -616,7 +618,7 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
   // Convert from Degrees to Radians
   for(float& a : angles)
   {
-    a = a * static_cast<float>(SIMPLib::Constants::k_DegToRad);
+    a *= static_cast<float>(SIMPLib::Constants::k_DegToRad);
   }
 
   std::vector<float> weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.cpp
@@ -46,6 +46,7 @@
 #include <QtCore/QModelIndex>
 #include <QtCore/QString>
 #include <QtCore/QVector>
+
 #include <QtWidgets/QAbstractItemDelegate>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMessageBox>
@@ -64,10 +65,11 @@
 #include <qwt_scale_widget.h>
 #include <qwt_series_data.h>
 #include <qwt_symbol.h>
-
-#include "EbsdLib/Core/EbsdLibConstants.h"
+#include <qwt_picker_machine.h>
+#include <qwt_plot_picker.h>
 
 #include "SIMPLib/Math/SIMPLibMath.h"
+#include "SIMPLib/Utilities/UTFUtilities.hpp"
 
 #include "SVWidgetsLib/Widgets/SVStyle.h"
 
@@ -87,6 +89,7 @@
 #include "EbsdLib/Texture/Texture.hpp"
 
 #include "SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h"
+#include "SyntheticBuilding/Gui/Widgets/StatsProgressWidget.h"
 #include "SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h"
 #include "SyntheticBuilding/SyntheticBuildingConstants.h"
 
@@ -95,8 +98,6 @@
 // -----------------------------------------------------------------------------
 StatsGenMDFWidget::StatsGenMDFWidget(QWidget* parent)
 : QWidget(parent)
-, m_PhaseIndex(-1)
-, m_CrystalStructure(EbsdLib::CrystalStructure::Cubic_High)
 {
   this->setupUi(this);
   this->setupGui();
@@ -110,6 +111,14 @@ StatsGenMDFWidget::~StatsGenMDFWidget()
   if(nullptr != m_MDFTableModel)
   {
     m_MDFTableModel->deleteLater();
+  }
+  if(nullptr != m_PlotPicker)
+  {
+    delete m_PlotPicker;
+  }
+  if(nullptr != m_PlotPickerMachine)
+  {
+    delete m_PlotPickerMachine;
   }
 }
 
@@ -146,8 +155,7 @@ void StatsGenMDFWidget::tableDataChanged(const QModelIndex& topLeft, const QMode
   Q_UNUSED(topLeft);
   Q_UNUSED(bottomRight);
 
-  on_m_MDFUpdateBtn_clicked();
-  emit dataChanged();
+  updatePlots();
 }
 
 // -----------------------------------------------------------------------------
@@ -184,7 +192,9 @@ void StatsGenMDFWidget::initQwtPlot(QString xAxisName, QString yAxisName, QwtPlo
   xAxis.setRenderFlags(Qt::AlignHCenter | Qt::AlignTop);
   xAxis.setFont(font);
   xAxis.setColor(SVStyle::Instance()->getQLabel_color());
+
   plot->setAxisTitle(QwtPlot::xBottom, xAxisName);
+  plot->setAxisScale(QwtPlot::xBottom, 0.0, 180.0, 10);
 
   QwtText yAxis(yAxisName);
   yAxis.setRenderFlags(Qt::AlignHCenter | Qt::AlignTop);
@@ -197,6 +207,11 @@ void StatsGenMDFWidget::initQwtPlot(QString xAxisName, QString yAxisName, QwtPlo
 
   plot->setAxisTitle(QwtPlot::xBottom, xAxis);
   plot->setAxisTitle(QwtPlot::yLeft, yAxis);
+
+  QwtPlotPicker* m_PlotPicker = new QwtPlotPicker(plot->xBottom, plot->yLeft, QwtPicker::CrossRubberBand, QwtPicker::AlwaysOn, plot->canvas());
+  QwtPickerMachine* m_PlotPickerMachine = new QwtPickerClickPointMachine();
+  m_PlotPicker->setTrackerPen(QPen(SVStyle::Instance()->getQLabel_color()));
+  m_PlotPicker->setStateMachine(m_PlotPickerMachine);
 }
 
 // -----------------------------------------------------------------------------
@@ -221,12 +236,23 @@ void StatsGenMDFWidget::updatePlots()
   weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
+  // Convert Degrees to Radians for ODF
   for(size_t i = 0; i < e1s.size(); i++)
   {
     e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e2s[i] = e2s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
     e3s[i] = e3s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
   }
+
+  StatsProgressWidget progress("Calculating/Updating the ODF", "Cancel", nullptr);
+  progress.setLabelText("Please Wait...");
+  progress.setProgTitle("Generating ODF Plot Data...");
+  progress.setVisible(true);
+  progress.show();
+  qApp->processEvents();
+
+  progress.setValue(0);
+  progress.setLabelText("Calculating ODF");
 
   std::vector<float> odf = StatsGeneratorUtilities::GenerateODFData(m_CrystalStructure, e1s, e2s, e3s, weights, sigmas);
 
@@ -251,23 +277,68 @@ void StatsGenMDFWidget::updateMDFPlot(std::vector<float>& odf)
   int err = 0;
   int size = 100000;
 
+  StatsProgressWidget progress("Calculating/Updating the MDF", "Cancel", nullptr);
+  progress.setLabelText("Please Wait...");
+  progress.setProgTitle("Generating MDF Plot Data...");
+  progress.setVisible(true);
+  progress.show();
+  qApp->processEvents();
+
   // These are the input vectors
   using ContainerType = std::vector<float>;
-  ContainerType angles;
-  ContainerType axes;
-  ContainerType weights;
 
-  // ContainerType odf = odfInput; // Do this copy because using std::vector is 2x faster than QVector
+  ContainerType angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
+  ContainerType axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
+  ContainerType weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
 
-  angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
-  weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
-  axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
+  // Ensure that the angle is in range of [0,pi] and Convert Angles to Radians
+  for(auto& angle : angles)
+  {
+    while(angle > 180.0)
+    {
+      angle = angle - 180.0;
+    }
+    while(angle < 0.0)
+    {
+      angle = angle + 180.0;
+    }
+    angle = angle * SIMPLib::Constants::k_DegToRad;
+  }
+
+  // Normalize the axis to unit norm
+  for(size_t i = 0; i < axes.size(); i = i + 3)
+  {
+    float length = std::sqrt(axes[i] * axes[i] + axes[i + 1] * axes[i + 1] + axes[i + 2] * axes[i + 2]);
+    axes[i] = axes[i] / length;
+    axes[i + 1] = axes[i + 1] / length;
+    axes[i + 2] = axes[i + 2] / length;
+  }
+
+  // Sanity check the Axis_Angle inputs;
+  for(size_t i = 0; i < angles.size(); i++)
+  {
+    OrientationF ax(axes[i * 3], axes[i * 3 + 1], axes[i * 3 + 2], angles[i]);
+    OrientationTransformation::ResultType result = OrientationTransformation::ax_check<OrientationF>(ax);
+    if(result.result < 0)
+    {
+      QMessageBox msgBox;
+      msgBox.setText("The Axis Angle was not normalized and/or the angle was not within the range of [0, Pi]");
+      msgBox.setStandardButtons(QMessageBox::Ok);
+      msgBox.setDefaultButton(QMessageBox::Ok);
+      std::ignore = msgBox.exec();
+
+      return;
+    }
+  }
 
   // These are the output vectors
   int npoints = 36;
   ContainerType x(npoints);
   ContainerType y(npoints);
   ContainerType mdf;
+
+  progress.setValue(1);
+  progress.setLabelText("Calculating and Generating MDF.....");
 
   //// ODF/MDF Update Codes
   switch(m_CrystalStructure)
@@ -360,12 +431,11 @@ void StatsGenMDFWidget::on_addMDFRowBtn_clicked()
   {
     return;
   }
+  QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
+  m_MDFTableView->setCurrentIndex(index);
   m_MDFTableView->resizeColumnsToContents();
   m_MDFTableView->scrollToBottom();
   m_MDFTableView->setFocus();
-  QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
-  m_MDFTableView->setCurrentIndex(index);
-  emit dataChanged();
 }
 
 // -----------------------------------------------------------------------------
@@ -388,7 +458,6 @@ void StatsGenMDFWidget::on_deleteMDFRowBtn_clicked()
   {
     m_MDFTableView->resizeColumnsToContents();
   }
-  emit dataChanged();
 }
 
 // -----------------------------------------------------------------------------
@@ -406,34 +475,49 @@ void StatsGenMDFWidget::on_loadMDFBtn_clicked()
   QFileInfo fi(file);
   m_OpenDialogLastFilePath = fi.filePath();
 
-  size_t numMisorients = 0;
+  std::pair<bool, int32_t> isUtf8 = UTFUtilities::IsUtf8(fi.filePath().toStdString());
+
   QString filename = file;
   std::ifstream inFile;
-  inFile.open(filename.toLatin1().data());
+  inFile.open(filename.toLatin1().data(), std::ios::in);
+  if(!inFile.is_open())
+  {
+    return;
+  }
+
+  int32_t numMisorients = 0;
+
+  // If the file is UTF8 with a BOM marker then read the first 3 bytes and dump them.
+  if(isUtf8.first)
+  {
+    char a, b, c;
+    inFile >> a >> b >> c;
+  }
 
   inFile >> numMisorients;
 
-  float angle, weight;
-  std::string n1, n2, n3;
-  for(size_t i = 0; i < numMisorients; i++)
+  QVector<float> angles(numMisorients);
+  QVector<float> axis(numMisorients * 3);
+  QVector<float> weights(numMisorients);
+
+  float angle, weight, n1, n2, n3;
+  for(int32_t i = 0; i < numMisorients - 1; i++)
   {
     inFile >> angle >> n1 >> n2 >> n3 >> weight;
-
-    QString axis = QString("<" + QString::fromStdString(n1) + "," + QString::fromStdString(n2) + "," + QString::fromStdString(n3) + ">");
-
-    if(!m_MDFTableModel->insertRow(m_MDFTableModel->rowCount()))
-    {
-      return;
-    }
-    int row = m_MDFTableModel->rowCount() - 1;
-    m_MDFTableModel->setRowData(row, angle, axis, weight);
-
-    m_MDFTableView->resizeColumnsToContents();
-    m_MDFTableView->scrollToBottom();
-    m_MDFTableView->setFocus();
-    QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
-    m_MDFTableView->setCurrentIndex(index);
+    angles[i] = angle;
+    axis[i * 3] = n1;
+    axis[i * 3 + 1] = n2;
+    axis[i * 3 + 2] = n3;
+    weights[i] = weight;
   }
+
+  m_MDFTableModel->setTableData(angles, axis, weights);
+
+  m_MDFTableView->resizeColumnsToContents();
+  m_MDFTableView->scrollToBottom();
+  m_MDFTableView->setFocus();
+  QModelIndex index = m_MDFTableModel->index(m_MDFTableModel->rowCount() - 1, 0);
+  m_MDFTableView->setCurrentIndex(index);
 }
 
 // -----------------------------------------------------------------------------
@@ -460,7 +544,7 @@ void StatsGenMDFWidget::extractStatsData(int index, StatsData* statsData, PhaseT
   }
 
   QVector<float> axis;
-  QVector<float> angle;
+  QVector<float> angles;
   QVector<float> weights;
 
   for(int i = 0; i < arrays.size(); i++)
@@ -468,25 +552,30 @@ void StatsGenMDFWidget::extractStatsData(int index, StatsData* statsData, PhaseT
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Axis) == 0)
     {
       axis = QVector<float>(static_cast<int>(arrays[i]->getSize())); // This one is 3xn in size
-      ::memcpy(&(axis.front()), arrays[i]->getVoidPointer(0), sizeof(float) * axis.size());
+      ::memcpy(axis.data(), arrays[i]->getVoidPointer(0), sizeof(float) * axis.size());
     }
 
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Angle) == 0)
     {
-      angle = QVector<float>(static_cast<int>(arrays[i]->getNumberOfTuples()));
-      ::memcpy(&(angle.front()), arrays[i]->getVoidPointer(0), sizeof(float) * angle.size());
+      angles = QVector<float>(static_cast<int>(arrays[i]->getNumberOfTuples()));
+      ::memcpy(angles.data(), arrays[i]->getVoidPointer(0), sizeof(float) * angles.size());
     }
 
     if(arrays[i]->getName().compare(SIMPL::StringConstants::Weight) == 0)
     {
       weights = QVector<float>(static_cast<int>(arrays[i]->getNumberOfTuples()));
-      ::memcpy(&(weights.front()), arrays[i]->getVoidPointer(0), sizeof(float) * weights.size());
+      ::memcpy(weights.data(), arrays[i]->getVoidPointer(0), sizeof(float) * weights.size());
     }
+  }
+  // Convert from Radians to Degrees
+  for(float& a : angles)
+  {
+    a = a * static_cast<float>(SIMPLib::Constants::k_RadToDeg);
   }
   if(!arrays.empty())
   {
     // Load the data into the table model
-    m_MDFTableModel->setTableData(angle, axis, weights);
+    m_MDFTableModel->setTableData(angles, axis, weights);
   }
 
   on_m_MDFUpdateBtn_clicked();
@@ -512,6 +601,7 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
   odf_weights = m_ODFTableModel->getData(SGODFTableModel::Weight);
   sigmas = m_ODFTableModel->getData(SGODFTableModel::Sigma);
 
+  // Convert from Degrees to Radians
   for(size_t i = 0; i < e1s.size(); i++)
   {
     e1s[i] = e1s[i] * static_cast<float>(SIMPLib::Constants::k_PiOver180);
@@ -523,6 +613,12 @@ int StatsGenMDFWidget::getMisorientationData(StatsData* statsData, PhaseType::Ty
 
   // Now use the ODF data to generate the MDF data ************************************************
   std::vector<float> angles = m_MDFTableModel->getData(SGMDFTableModel::Angle);
+  // Convert from Degrees to Radians
+  for(float& a : angles)
+  {
+    a = a * static_cast<float>(SIMPLib::Constants::k_DegToRad);
+  }
+
   std::vector<float> weights = m_MDFTableModel->getData(SGMDFTableModel::Weight);
   std::vector<float> axes = m_MDFTableModel->getData(SGMDFTableModel::Axis);
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenMDFWidget.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include "ui_StatsGenMDFWidget.h"
+
 #include <QtWidgets/QWidget>
 
 #include "SIMPLib/Common/Constants.h"
@@ -44,11 +45,16 @@
 #include "SIMPLib/StatsData/PrimaryStatsData.h"
 #include "SIMPLib/StatsData/StatsData.h"
 #include "SIMPLib/StatsData/TransformationStatsData.h"
+
+#include "EbsdLib/Core/EbsdLibConstants.h"
+
 #include "SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h"
 
 class SGMDFTableModel;
 class QwtPlot;
 class QwtPlotCurve;
+class QwtPlotPicker;
+class QwtPickerMachine;
 
 /**
  * @class StatsGenMDFWidget StatsGenMDFWidget.h StatsGenerator/StatsGenMDFWidget.h
@@ -66,6 +72,13 @@ public:
   virtual ~StatsGenMDFWidget();
 
   void setupGui();
+
+  /**
+   * @brief initQwtPlot
+   * @param xAxisName
+   * @param yAxisName
+   * @param plot
+   */
   void initQwtPlot(QString xAxisName, QString yAxisName, QwtPlot* plot);
 
   /**
@@ -99,8 +112,19 @@ public:
   SGODFTableModel* getODFTableModel() const;
 
   int getMisorientationData(StatsData* statsData, PhaseType::Type phaseType, bool preflight = false);
+
+  /**
+   * @brief extractStatsData
+   * @param index
+   * @param statsData
+   * @param phaseType
+   */
   void extractStatsData(int index, StatsData* statsData, PhaseType::Type phaseType);
 
+  /**
+   * @brief tableModel
+   * @return
+   */
   SGMDFTableModel* tableModel();
 
 public slots:
@@ -112,9 +136,15 @@ protected slots:
   void on_m_MDFUpdateBtn_clicked();
   void on_loadMDFBtn_clicked();
 
+  /**
+   * @brief tableDataChanged
+   * @param topLeft
+   * @param bottomRight
+   */
   void tableDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
 signals:
+
   void dataChanged();
 
 protected:
@@ -123,11 +153,14 @@ protected:
 private:
   SGODFTableModel* m_ODFTableModel = nullptr;
 
-  int m_PhaseIndex = {};
-  unsigned int m_CrystalStructure = {};
+  int m_PhaseIndex = {-1};
+  unsigned int m_CrystalStructure = {EbsdLib::CrystalStructure::Cubic_High};
 
   SGMDFTableModel* m_MDFTableModel = nullptr;
   QwtPlotCurve* m_PlotCurve = nullptr;
+
+  QwtPlotPicker* m_PlotPicker = nullptr;
+  QwtPickerMachine* m_PlotPickerMachine = nullptr;
 
   QString m_OpenDialogLastFilePath; // Must be last in the list
 

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/StatsGenODFWidget.cpp
@@ -90,6 +90,7 @@
 #include "SyntheticBuilding/Gui/Widgets/TableModels/SGODFTableModel.h"
 #include "SyntheticBuilding/Gui/Widgets/TextureDialog.h"
 #include "SyntheticBuilding/SyntheticBuildingFilters/StatsGeneratorUtilities.h"
+#include "SyntheticBuilding/Gui/Widgets/StatsProgressWidget.h"
 
 #define SHOW_POLE_FIGURES 1
 #define COLOR_POLE_FIGURES 1
@@ -519,11 +520,15 @@ void StatsGenODFWidget::calculateODF()
   {
     return;
   }
-  ProgressDialog* progressDialog = new ProgressDialog();
-  progressDialog->setLabelText("Updating ODF Sampling.... ");
-  progressDialog->show();
-  progressDialog->raise();
-  progressDialog->activateWindow();
+  StatsProgressWidget progress("Calculating/Updating the ODF", "Cancel", nullptr);
+  progress.setLabelText("Please Wait...");
+  progress.setProgTitle("Generating ODF Plot Data...");
+  progress.setVisible(true);
+  progress.show();
+  qApp->processEvents();
+
+  progress.setValue(0);
+  progress.setLabelText("Calculating ODF");
 
   using ContainerType = std::vector<float>;
   ContainerType e1s;
@@ -671,8 +676,6 @@ void StatsGenODFWidget::calculateODF()
     m_PoleFigureLabel->setPixmap(QPixmap::fromImage(image));
     emit dataChanged();
   }
-
-  delete progressDialog;
 }
 
 // -----------------------------------------------------------------------------
@@ -680,7 +683,7 @@ void StatsGenODFWidget::calculateODF()
 // -----------------------------------------------------------------------------
 void StatsGenODFWidget::on_addODFTextureBtn_clicked()
 {
-  TextureDialog t(m_CrystalStructure, nullptr);
+  TextureDialog t(m_CrystalStructure, this);
   int r = t.exec();
   if(r == QDialog::Accepted)
   {

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
@@ -177,7 +177,7 @@ QVariant SGMDFTableModel::headerData(int section, Qt::Orientation orientation, i
     switch(section)
     {
     case Angle:
-      return QVariant(QString("Angle\n(w)"));
+      return QVariant(QString("Angle\n(w) Degrees"));
       break;
     case Weight:
       return QVariant(QString("Weight\n(MRD)"));
@@ -213,6 +213,10 @@ int SGMDFTableModel::columnCount(const QModelIndex& index) const
 // -----------------------------------------------------------------------------
 bool SGMDFTableModel::setHeaderData(int col, Qt::Orientation o, const QVariant& var, int role)
 {
+  std::ignore = col;
+  std::ignore = o;
+  std::ignore = var;
+  std::ignore = role;
   return false;
 }
 
@@ -255,7 +259,7 @@ bool SGMDFTableModel::setData(const QModelIndex& index, const QVariant& value, i
 bool SGMDFTableModel::insertRows(int row, int count, const QModelIndex& index)
 {
   QString axis("<0,0,1>");
-  float weight = 0.0;
+  float weight = 50000.0; // Use a heavy default weight to show the user a major change in the MDF
   float angle = 0.0;
 
   beginInsertRows(QModelIndex(), row, row + count - 1);
@@ -333,7 +337,7 @@ std::vector<float> SGMDFTableModel::getData(int col)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-int SGMDFTableModel::parseHKLRow(int row, float& h, float& k, float& l)
+int SGMDFTableModel::parseHKLRow(int row, float& h, float& k, float& l) const
 {
   QString hklStr = m_Axis[row];
   hklStr.chop(1);      // remove the ">" charater from the end;
@@ -349,30 +353,10 @@ int SGMDFTableModel::parseHKLRow(int row, float& h, float& k, float& l)
   return -1;
 }
 
-#if 0
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-float SGMDFTableModel::getDataValue(int col, int row)
-{
-  switch(col)
-  {
-    case Angle:
-      return m_Angles[row];
-    case Weight:
-      return m_Weights[row];
-    case Axis:
-//      return m_Axis[row];
-    default:
-      Q_ASSERT(false);
-  }
-  return 0.0;
-}
-#endif
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void SGMDFTableModel::setColumnData(int col, QVector<float>& data)
+void SGMDFTableModel::setColumnData(int col, const QVector<float>& data)
 {
   switch(col)
   {
@@ -392,7 +376,7 @@ void SGMDFTableModel::setColumnData(int col, QVector<float>& data)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SGMDFTableModel::setTableData(QVector<float> angles, QVector<float> axis, QVector<float> weights)
+void SGMDFTableModel::setTableData(const QVector<float>& angles, const QVector<float>& axis, const QVector<float>& weights)
 {
   qint32 count = angles.count();
 
@@ -410,7 +394,7 @@ void SGMDFTableModel::setTableData(QVector<float> angles, QVector<float> axis, Q
     m_Weights = weights;
 
     m_Axis.clear();
-    int h, k, l;
+    float h, k, l;
     for(int i = 0; i < axis.size(); ++i)
     {
       h = axis[i];
@@ -431,7 +415,7 @@ void SGMDFTableModel::setTableData(QVector<float> angles, QVector<float> axis, Q
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SGMDFTableModel::setRowData(int row, float angle, QString axis, float weight)
+void SGMDFTableModel::setRowData(int row, float angle, const QString& axis, float weight)
 {
   m_Angles[row] = angle;
   m_Axis[row] = (axis);

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.cpp
@@ -314,7 +314,6 @@ std::vector<float> SGMDFTableModel::getData(int col)
   if(col == Axis)
   {
     int count = rowCount();
-    QVector<float> values;
     float h = 0.0;
     float k = 0.0;
     float l = 0.0;
@@ -324,12 +323,11 @@ std::vector<float> SGMDFTableModel::getData(int col)
       err = parseHKLRow(r, h, k, l);
       if(err >= 0)
       {
-        values.push_back(h);
-        values.push_back(k);
-        values.push_back(l);
+        data.push_back(h);
+        data.push_back(k);
+        data.push_back(l);
       }
     }
-    return std::vector<float>(values.begin(), values.end());
   }
   return data;
 }
@@ -344,7 +342,15 @@ int SGMDFTableModel::parseHKLRow(int row, float& h, float& k, float& l) const
   hklStr.remove(0, 1); // Remove the front "<" character
   bool ok = false;
   h = hklStr.section(',', 0, 0).toFloat(&ok);
+  if(ok)
+  {
+    return 0;
+  }
   k = hklStr.section(',', 1, 1).toFloat(&ok);
+  if(ok)
+  {
+    return 0;
+  }
   l = hklStr.section(',', 2, 2).toFloat(&ok);
   if(ok)
   {
@@ -394,7 +400,7 @@ void SGMDFTableModel::setTableData(const QVector<float>& angles, const QVector<f
     m_Weights = weights;
 
     m_Axis.clear();
-    float h, k, l;
+    float h = 0.0f, k = 0.0f, l = 0.0f;
     for(int i = 0; i < axis.size(); ++i)
     {
       h = axis[i];

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TableModels/SGMDFTableModel.h
@@ -136,7 +136,7 @@ public:
   bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   /**
-   *
+   * @brief getItemDelegate
    * @return
    */
   QAbstractItemDelegate* getItemDelegate();
@@ -149,22 +149,43 @@ public:
   std::vector<float> getData(int col);
 
   /**
-   *
-   * @param col
-   * @param row
+   * @brief Parses an "Axes" value
+   * @param row The row that is going to be parsed.
+   * @param h
+   * @param k
+   * @param l
    * @return
    */
-  // virtual float getDataValue(int col, int row);
+  int parseHKLRow(int row, float& h, float& k, float& l) const;
 
-  int parseHKLRow(int row, float& h, float& k, float& l);
+  /**
+   * @brief Sets the data for a column of data
+   * @param col
+   * @param data
+   */
+  void setColumnData(int col, const QVector<float>& data);
 
-  void setColumnData(int col, QVector<float>& data);
+  /**
+   * @brief Sets the data for a row in the table
+   * @param row
+   * @param angle
+   * @param axis
+   * @param weight
+   */
+  void setRowData(int row, float angle, const QString& axis, float weight);
 
-  void setRowData(int row, float angle, QString axis, float weight);
-
+  /**
+   * @brief setInitialValues
+   */
   void setInitialValues();
 
-  void setTableData(QVector<float> angles, QVector<float> axis, QVector<float> weights);
+  /**
+   * @brief Sets all the table data in one function
+   * @param angles The Angles
+   * @param axis The Axis
+   * @param weights The weight values
+   */
+  void setTableData(const QVector<float>& angles, const QVector<float>& axis, const QVector<float>& weights);
 
 private:
   int m_ColumnCount;

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/TransformationPhaseWidget.cpp
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/TransformationPhaseWidget.cpp
@@ -636,7 +636,7 @@ int TransformationPhaseWidget::gatherStatsData(AttributeMatrix::Pointer attrMat,
     }
 
     m_ODFWidget->getOrientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
-    m_MDFWidget->getMisorientationData(primaryStatsData.get(), PhaseType::Type::Primary, !preflight);
+    m_MDFWidget->getMisorientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
 
     err = m_AxisODFWidget->getOrientationData(primaryStatsData.get(), PhaseType::Type::Primary, preflight);
   }

--- a/Source/Plugins/SyntheticBuilding/Gui/Widgets/UI_Files/StatsGenMDFWidget.ui
+++ b/Source/Plugins/SyntheticBuilding/Gui/Widgets/UI_Files/StatsGenMDFWidget.ui
@@ -207,7 +207,7 @@
         <enum>Qt::Vertical</enum>
        </property>
        <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
+        <enum>QSizePolicy::Expanding</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>


### PR DESCRIPTION
* The Axis Angle was not checked for the proper range of the angle
* The Axis Angle was not checked for a normalized vector part
* The ODF update function would leave the macOS menu bar in an unusable state
* Update documentation for MDF Tab in StatsGenerator
* Optimize reading of a MDF data file into the MDF tab of StatsGenerator
* Update some API in the Table Models
* Update default weight value when adding a new MDF row.
* Fix layout of the MDFWidget buttons.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>

Requires [https://github.com/BlueQuartzSoftware/SIMPL/pull/403](https://github.com/BlueQuartzSoftware/SIMPL/pull/403)