### PR TITLE
Add option to skip voxel fixes.

### DIFF
--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.cpp
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.cpp
@@ -1612,6 +1612,10 @@ void QuickSurfaceMesh::execute()
       edgeCount++;
     }
   }
+  if(m_GenerateTripleLines)
+  {
+      generateTripleLines();
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -1630,7 +1634,6 @@ void QuickSurfaceMesh::generateTripleLines()
    * later if needed.
    * Mike Jackson, JULY 2018
    */
-  throw std::exception();
 
   DataContainer::Pointer m = getDataContainerArray()->getDataContainer(m_FeatureIdsArrayPath.getDataContainerName());
   DataContainer::Pointer sm = getDataContainerArray()->getDataContainer(getSurfaceDataContainerName());

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
@@ -34,7 +34,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 #pragma once
 
-#include <memory>
+#include "SurfaceMeshing/SurfaceMeshingDLLExport.h"
 
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/DataArrays/DataArray.hpp"
@@ -42,7 +42,7 @@
 #include "SIMPLib/Geometry/IGeometry.h"
 #include "SIMPLib/Geometry/IGeometryGrid.h"
 
-#include "SurfaceMeshing/SurfaceMeshingDLLExport.h"
+#include <memory>
 
 /**
  * @brief The QuickSurfaceMesh class. See [Filter documentation](@ref quicksurfacemesh) for details.
@@ -64,6 +64,7 @@ class SurfaceMeshing_EXPORT QuickSurfaceMesh : public AbstractFilter
   PYB11_PROPERTY(QString FaceLabelsArrayName READ getFaceLabelsArrayName WRITE setFaceLabelsArrayName)
   PYB11_PROPERTY(QString NodeTypesArrayName READ getNodeTypesArrayName WRITE setNodeTypesArrayName)
   PYB11_PROPERTY(QString FeatureAttributeMatrixName READ getFeatureAttributeMatrixName WRITE setFeatureAttributeMatrixName)
+  PYB11_PROPERTY(bool FixProblemVoxels READ getFixProblemVoxels WRITE setFixProblemVoxels)
   PYB11_END_BINDINGS()
   // End Python bindings declarations
 
@@ -197,6 +198,17 @@ public:
   Q_PROPERTY(QString FeatureAttributeMatrixName READ getFeatureAttributeMatrixName WRITE setFeatureAttributeMatrixName)
 
   /**
+   * @brief Setter property for FeatureAttributeMatrixName
+   */
+  void setFixProblemVoxels(bool value);
+  /**
+   * @brief Getter property for FeatureAttributeMatrixName
+   * @return Value of FeatureAttributeMatrixName
+   */
+  bool getFixProblemVoxels() const;
+  Q_PROPERTY(bool FixProblemVoxels READ getFixProblemVoxels WRITE setFixProblemVoxels)
+
+  /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
    */
   QString getCompiledLibraryName() const override;
@@ -280,6 +292,7 @@ private:
   QString m_FaceLabelsArrayName = {SIMPL::FaceData::SurfaceMeshFaceLabels};
   QString m_NodeTypesArrayName = {SIMPL::VertexData::SurfaceMeshNodeType};
   QString m_FeatureAttributeMatrixName = {SIMPL::Defaults::FaceFeatureAttributeMatrixName};
+  bool m_FixProblemVoxels = true;
 
   std::vector<IDataArray::WeakPointer> m_SelectedWeakPtrVector;
   std::vector<IDataArray::WeakPointer> m_CreatedWeakPtrVector;

--- a/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
+++ b/Source/Plugins/SurfaceMeshing/SurfaceMeshingFilters/QuickSurfaceMesh.h
@@ -293,6 +293,7 @@ private:
   QString m_NodeTypesArrayName = {SIMPL::VertexData::SurfaceMeshNodeType};
   QString m_FeatureAttributeMatrixName = {SIMPL::Defaults::FaceFeatureAttributeMatrixName};
   bool m_FixProblemVoxels = true;
+  bool m_GenerateTripleLines = false;
 
   std::vector<IDataArray::WeakPointer> m_SelectedWeakPtrVector;
   std::vector<IDataArray::WeakPointer> m_CreatedWeakPtrVector;


### PR DESCRIPTION
sort include directives in opposite order
fix clang-tidy warnings

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>