### PR TITLE
BUG: Update Complex Filter Generator

### DIFF
--- a/Tools/ComplexFilterGenerator.cpp
+++ b/Tools/ComplexFilterGenerator.cpp
@@ -672,7 +672,7 @@ void InitParameterTypeMapping()
 
 void InitDefaultParameterConstructor()
 {
-  s_DefaultConstructorMapping["BooleanFilterParameter"] = "false";
+  s_DefaultConstructorMapping["BooleanFilterParameter"] = "false #error Check default values";
   s_DefaultConstructorMapping["DataArrayCreationFilterParameter"] = "DataPath{}";
   s_DefaultConstructorMapping["DataArraySelectionFilterParameter"] = "DataPath{}, complex::GetAllDataTypes() /* This will allow ANY data type. Adjust as necessary for your filter*/";
   s_DefaultConstructorMapping["ChoiceFilterParameter"] = "0, ChoicesParameter::Choices{\"Option 1\", \"Option 2\", \"Option 3\"}/* Change this to the proper choices */";
@@ -685,22 +685,22 @@ void InitDefaultParameterConstructor()
   s_DefaultConstructorMapping["OutputFileFilterParameter"] = "fs::path(\"<default file to read goes here>\"), FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputFile";
   s_DefaultConstructorMapping["OutputPathFilterParameter"] = "fs::path(\"<default file to read goes here>\"), FileSystemPathParameter::ExtensionsType{}, FileSystemPathParameter::PathType::OutputDir";
   s_DefaultConstructorMapping["FileListInfoFilterParameter"] = "GeneratedFileListParameter::ValueType{}";
-  s_DefaultConstructorMapping["FloatFilterParameter"] = "1.23345f";
-  s_DefaultConstructorMapping["IntFilterParameter"] = "1234356";
-  s_DefaultConstructorMapping["DoubleFilterParameter"] = "2.3456789";
-  s_DefaultConstructorMapping["UInt64FilterParameter"] = "13412341234212";
-  s_DefaultConstructorMapping["AxisAngleFilterParameter"] = "std::vector<float32>(4), std::vector<std::string>(4)";
-  s_DefaultConstructorMapping["IntVec2FilterParameter"] = "std::vector<int32>(2), std::vector<std::string>(2)";
-  s_DefaultConstructorMapping["IntVec3FilterParameter"] = "std::vector<int32>(3), std::vector<std::string>(3)";
-  s_DefaultConstructorMapping["FloatVec2FilterParameter"] = "std::vector<float32>(2), std::vector<std::string>(2)";
-  s_DefaultConstructorMapping["FloatVec3FilterParameter"] = "std::vector<float32>(3), std::vector<std::string>(3)";
+  s_DefaultConstructorMapping["FloatFilterParameter"] = "0.0f #error Check default values";
+  s_DefaultConstructorMapping["IntFilterParameter"] = "0 #error Check default values";
+  s_DefaultConstructorMapping["DoubleFilterParameter"] = "0.0 #error Check default values";
+  s_DefaultConstructorMapping["UInt64FilterParameter"] = "0ULL #error Check default values";
+  s_DefaultConstructorMapping["AxisAngleFilterParameter"] = "std::vector<float32>{0.0F,0.0F,1.0F,0.0F}, std::vector<std::string>{\"x\",\"y\",\"z\",\"w\"} #error Check default values";
+  s_DefaultConstructorMapping["IntVec2FilterParameter"] = "std::vector<int32>{0,0}, std::vector<std::string>{\"label1\",\"label2\"} #error Check default values";
+  s_DefaultConstructorMapping["IntVec3FilterParameter"] = "std::vector<int32>{0,0,0}, std::vector<std::string>{\"label1\",\"label2\",\"label3\"} #error Check default values";
+  s_DefaultConstructorMapping["FloatVec2FilterParameter"] = "std::vector<float32>{0.0F,0.0F}, std::vector<std::string>{\"label1\",\"label2\"} #error Check default values";
+  s_DefaultConstructorMapping["FloatVec3FilterParameter"] = "std::vector<float32>{0.0F,0.0F,0.0F}, std::vector<std::string>{\"label1\",\"label2\",\"label3\"}  #error Check default values";
   s_DefaultConstructorMapping["NumericTypeFilterParameter"] = "NumericType::int8";
   s_DefaultConstructorMapping["StringFilterParameter"] = "\"SomeString\"";
   s_DefaultConstructorMapping["SeparatorFilterParameter"] = "\"Separator\"";
   s_DefaultConstructorMapping["LinkedDataContainerSelectionFilterParameter"] = "DataPath{}";
   s_DefaultConstructorMapping["LinkedPathCreationFilterParameter"] = "DataPath{}";
-  s_DefaultConstructorMapping["MultiDataArraySelectionFilterParameter"] = "MultiArraySelectionParameter::ValueType {DataPath(), DataPath(), DataPath()}";
-  s_DefaultConstructorMapping["LinkedBooleanFilterParameter"] = "false";
+  s_DefaultConstructorMapping["MultiDataArraySelectionFilterParameter"] = "MultiArraySelectionParameter::ValueType {}";
+  s_DefaultConstructorMapping["LinkedBooleanFilterParameter"] = "false #error Check default values";
   s_DefaultConstructorMapping["LinkedChoicesFilterParameter"] = "0, ChoicesParameter::Choices{\"Option 1\", \"Option 2\", \"Option 3\"}";
   s_DefaultConstructorMapping["PreflightUpdatedValueFilterParameter"] = "{}";
 

--- a/Tools/ComplexFilterGenerator.cpp
+++ b/Tools/ComplexFilterGenerator.cpp
@@ -2143,7 +2143,7 @@ int main(int argc, char** argv)
   QMetaObjectUtilities::RegisterMetaTypes();
 
   QFileInfo fi(outputDir);
-  QString pluginName = outputDir.split("/").last();
+  QString pluginName = outputDir.split(QDir::separator()).last();
   GenerateComplexFilter(outputDir, pluginName, inputClassName);
 
   std::cout << "You will need to update the following files:" << std::endl;

--- a/Tools/ComplexFilterGenerator.cpp
+++ b/Tools/ComplexFilterGenerator.cpp
@@ -1206,7 +1206,7 @@ void GenerateHeaderFile(AbstractFilter* filter, const QString& outputDir, const 
 {
   static QRegularExpression regExp1{"(.)([A-Z][a-z]+)"};
   static QRegularExpression regExp2{"([a-z0-9])([A-Z])"};
-  const QString k_UUIDMapFileName("src/" + pluginName + "/" + QString::fromStdString(pluginName.toStdString() + "LegacyUUIDMapping.hpp").replace("/", ""));
+  const QString k_UUIDMapFileName("src/" + pluginName + "/" + QString::fromStdString(pluginName.toStdString() + "LegacyUUIDMapping.hpp"));
   const QString k_NewIncludeToken("// @@__HEADER__TOKEN__DO__NOT__DELETE__@@");
   const QString k_SIMPLToComplexToken("// @@__MAP__UPDATE__TOKEN__DO__NOT__DELETE__@@");
 

--- a/Tools/ComplexFilterGenerator.cpp
+++ b/Tools/ComplexFilterGenerator.cpp
@@ -1395,14 +1395,14 @@ void GenerateSourceFile(AbstractFilter* filter, const QString& outputDir, const 
   QString humanName = filter->getHumanLabel();
   // QString pluginName = filter->getCompiledLibraryName();
 
-  QString defaultTags = QString("\"#%1\", \"#%2\"").arg(filter->getGroupName(), filter->getSubGroupName());
+  QString defaultTags = QString("\"%1\", \"%2\"").arg(filter->getGroupName(), filter->getSubGroupName());
   if(filter->getSubGroupName() == SIMPL::FilterSubGroups::InputFilters)
   {
-    defaultTags = defaultTags + ", \"#Read\", \"#Import\"";
+    defaultTags = defaultTags + ", \"Read\", \"Import\"";
   }
   if(filter->getSubGroupName() == SIMPL::FilterSubGroups::OutputFilters)
   {
-    defaultTags = defaultTags + ", \"#Write\", \"#Export\"";
+    defaultTags = defaultTags + ", \"Write\", \"Export\"";
   }
 
   sourceTemplate = sourceTemplate.replace(k_ALGORITHM_NAME, filterName);

--- a/Tools/unit_test_filter.cpp.in
+++ b/Tools/unit_test_filter.cpp.in
@@ -29,7 +29,7 @@
 
 using namespace complex;
 
-TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: Instantiation and Parameter Check","[@PLUGIN_NAME@][@FILTER_NAME@][.][UNIMPLEMENTED][!mayfail]")
+TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: Valid Filter Execution","[@PLUGIN_NAME@][@FILTER_NAME@][.][UNIMPLEMENTED][!mayfail]")
 {
   // Instantiate the filter, a DataStructure object and an Arguments Object
   @FILTER_NAME@ filter;
@@ -48,12 +48,7 @@ TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: Instantiation and Parameter Check","[@P
   REQUIRE(executeResult.result.valid());
 }
 
-//TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: Valid filter execution")
-//{
-//
-//}
-
-//TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: InValid filter execution")
+//TEST_CASE("@PLUGIN_NAME@::@FILTER_NAME@: InValid Filter Execution")
 //{
 //
 //}


### PR DESCRIPTION
- Repaired generation on windows by fixing filesystem delimiter
- Removed Instantiation Test
  I changed the name and removed extraneous Valid execution to preserve generation code
- Removed '#' character from tag generation