### PR TITLE
ENH: update filters to use eigen for matrix math

### DIFF
--- a/Source/Plugins/OrientationAnalysis/CMakeLists.txt
+++ b/Source/Plugins/OrientationAnalysis/CMakeLists.txt
@@ -180,6 +180,10 @@ target_sources(${plug_target_name}
   # -- Add in the plugin interface definition source files
   ${${PLUGIN_NAME}_SOURCE_DIR}/${PLUGIN_NAME}Plugin.cpp
   ${${PLUGIN_NAME}_SOURCE_DIR}/${PLUGIN_NAME}Plugin.h
+  
+  # -- Add in the plugin utilities source files
+  ${${PLUGIN_NAME}_SOURCE_DIR}/${PLUGIN_NAME}Utilities.cpp
+  ${${PLUGIN_NAME}_SOURCE_DIR}/${PLUGIN_NAME}Utilities.h
 
   # -- Add in our generated Version source files
   ${${PLUGIN_NAME}_BINARY_DIR}/${VERSION_HEADER_FILE_NAME}

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
@@ -56,54 +56,13 @@
 #include "EbsdLib/Core/Quaternion.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
+#include "OrientationAnalysis/OrientationAnalysisUtilities.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
 #include "EbsdLib/Core/EbsdLibConstants.h"
 
 using QuatF = Quaternion<float>;
-using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
-
-namespace
-{
-//------------------------------------------------------------------------------
-Matrix3fR OrientationMatrixToGMatrix(const Orientation<float>& oMatrix)
-{
-  if(oMatrix.size() != 9)
-  {
-    throw std::out_of_range("Orientation matrix has invalid size.");
-  }
-  Matrix3fR g1;
-  g1(0, 0) = oMatrix[0];
-  g1(0, 1) = oMatrix[1];
-  g1(0, 2) = oMatrix[2];
-  g1(1, 0) = oMatrix[3];
-  g1(1, 1) = oMatrix[4];
-  g1(1, 2) = oMatrix[5];
-  g1(2, 0) = oMatrix[6];
-  g1(2, 1) = oMatrix[7];
-  g1(2, 2) = oMatrix[8];
-  return g1;
-}
-//------------------------------------------------------------------------------
-Matrix3fR OrientationMatrixToGMatrixTranspose(const Orientation<float>& oMatrix)
-{
-  if(oMatrix.size() != 9)
-  {
-    throw std::out_of_range("Orientation matrix has invalid size.");
-  }
-  Matrix3fR g1t;
-  g1t(0, 0) = oMatrix[0];
-  g1t(0, 1) = oMatrix[3];
-  g1t(0, 2) = oMatrix[6];
-  g1t(1, 0) = oMatrix[1];
-  g1t(1, 1) = oMatrix[4];
-  g1t(1, 2) = oMatrix[7];
-  g1t(2, 0) = oMatrix[2];
-  g1t(2, 1) = oMatrix[5];
-  g1t(2, 2) = oMatrix[8];
-  return g1t;
-}
-} // namespace
+using namespace OrientationUtilities;
 
 /* Create Enumerations to allow the created Attribute Arrays to take part in renaming */
 enum createdPathID : RenameDataPath::DataID_t

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureNeighborCAxisMisalignments.cpp
@@ -37,6 +37,8 @@
 
 #include <QtCore/QTextStream>
 
+#include <Eigen/Dense>
+
 #include "SIMPLib/Common/Constants.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 #include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
@@ -59,6 +61,49 @@
 #include "EbsdLib/Core/EbsdLibConstants.h"
 
 using QuatF = Quaternion<float>;
+using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
+
+namespace
+{
+//------------------------------------------------------------------------------
+Matrix3fR OrientationMatrixToGMatrix(const Orientation<float>& oMatrix)
+{
+  if(oMatrix.size() != 9)
+  {
+    throw std::out_of_range("Orientation matrix has invalid size.");
+  }
+  Matrix3fR g1;
+  g1(0, 0) = oMatrix[0];
+  g1(0, 1) = oMatrix[1];
+  g1(0, 2) = oMatrix[2];
+  g1(1, 0) = oMatrix[3];
+  g1(1, 1) = oMatrix[4];
+  g1(1, 2) = oMatrix[5];
+  g1(2, 0) = oMatrix[6];
+  g1(2, 1) = oMatrix[7];
+  g1(2, 2) = oMatrix[8];
+  return g1;
+}
+//------------------------------------------------------------------------------
+Matrix3fR OrientationMatrixToGMatrixTranspose(const Orientation<float>& oMatrix)
+{
+  if(oMatrix.size() != 9)
+  {
+    throw std::out_of_range("Orientation matrix has invalid size.");
+  }
+  Matrix3fR g1t;
+  g1t(0, 0) = oMatrix[0];
+  g1t(0, 1) = oMatrix[3];
+  g1t(0, 2) = oMatrix[6];
+  g1t(1, 0) = oMatrix[1];
+  g1t(1, 1) = oMatrix[4];
+  g1t(1, 2) = oMatrix[7];
+  g1t(2, 0) = oMatrix[2];
+  g1t(2, 1) = oMatrix[5];
+  g1t(2, 2) = oMatrix[8];
+  return g1t;
+}
+} // namespace
 
 /* Create Enumerations to allow the created Attribute Arrays to take part in renaming */
 enum createdPathID : RenameDataPath::DataID_t
@@ -231,13 +276,13 @@ void FindFeatureNeighborCAxisMisalignments::execute()
   std::vector<std::vector<float>> misalignmentlists;
 
   float w = 0.0f;
-  float g1[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-  float g2[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-  float g1t[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-  float g2t[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
-  float c1[3] = {0.0f, 0.0f, 0.0f};
-  float c2[3] = {0.0f, 0.0f, 0.0f};
-  float caxis[3] = {0.0f, 0.0f, 1.0f};
+  Matrix3fR g1T;
+  g1T.fill(0.0f);
+  Matrix3fR g2T;
+  g2T.fill(0.0f);
+  Eigen::Vector3f c1{0.0f, 0.0f, 0.0f};
+  Eigen::Vector3f c2{0.0f, 0.0f, 0.0f};
+  const Eigen::Vector3f cAxis{0.0f, 0.0f, 1.0f};
   size_t hexneighborlistsize = 0;
   //  QuatF q1 = QuaternionMathF::New();
   //  QuatF q2 = QuaternionMathF::New();
@@ -252,15 +297,15 @@ void FindFeatureNeighborCAxisMisalignments::execute()
   {
     phase1 = m_CrystalStructures[m_FeaturePhases[i]];
     currentAvgQuatPtr = avgQuatsPtr->getTuplePointer(i);
-    OrientationTransformation::qu2om<QuatF, OrientF>({currentAvgQuatPtr[0], currentAvgQuatPtr[1], currentAvgQuatPtr[2], currentAvgQuatPtr[3]}).toGMatrix(g1);
+    OrientationF oMatrix1 = OrientationTransformation::qu2om<QuatF, OrientF>({currentAvgQuatPtr[0], currentAvgQuatPtr[1], currentAvgQuatPtr[2], currentAvgQuatPtr[3]});
 
     // transpose the g matrix so when caxis is multiplied by it
     // it will give the sample direction that the caxis is along
-    MatrixMath::Transpose3x3(g1, g1t);
-    MatrixMath::Multiply3x3with3x1(g1t, caxis, c1);
+    g1T = OrientationMatrixToGMatrixTranspose(oMatrix1);
+    c1 = g1T * cAxis;
     // normalize so that the dot product can be taken below without
     // dividing by the magnitudes (they would be 1)
-    MatrixMath::Normalize3x1(c1);
+    c1.normalize();
     misalignmentlists[i].resize(neighborlist[i].size(), -1.0f);
     for(size_t j = 0; j < neighborlist[i].size(); j++)
     {
@@ -268,28 +313,28 @@ void FindFeatureNeighborCAxisMisalignments::execute()
       nname = neighborlist[i][j];
       phase2 = m_CrystalStructures[m_FeaturePhases[nname]];
       hexneighborlistsize = neighborlist[i].size();
-      if(phase1 == phase2 && (phase1 == EbsdLib::CrystalStructure::Hexagonal_High))
+      if(phase1 == phase2 && (phase1 == EbsdLib::CrystalStructure::Hexagonal_High || phase1 == EbsdLib::CrystalStructure::Hexagonal_Low))
       {
         currentAvgQuatPtr = avgQuatsPtr->getTuplePointer(nname);
-        OrientationTransformation::qu2om<QuatF, OrientF>({currentAvgQuatPtr[0], currentAvgQuatPtr[1], currentAvgQuatPtr[2], currentAvgQuatPtr[3]}).toGMatrix(g2);
+        OrientationF oMatrix2 = OrientationTransformation::qu2om<QuatF, OrientF>({currentAvgQuatPtr[0], currentAvgQuatPtr[1], currentAvgQuatPtr[2], currentAvgQuatPtr[3]});
 
         // transpose the g matrix so when caxis is multiplied by it
         // it will give the sample direction that the caxis is along
-        MatrixMath::Transpose3x3(g2, g2t);
-        MatrixMath::Multiply3x3with3x1(g2t, caxis, c2);
+        g2T = OrientationMatrixToGMatrixTranspose(oMatrix2);
+        c2 = g2T * cAxis;
         // normalize so that the dot product can be taken below without
         // dividing by the magnitudes (they would be 1)
-        MatrixMath::Normalize3x1(c2);
+        c2.normalize();
 
         w = GeometryMath::CosThetaBetweenVectors(c1, c2);
         SIMPLibMath::bound(w, -1.0f, 1.0f);
         w = acosf(w);
-        if(w > (SIMPLib::Constants::k_PiD / 2))
+        if(w > (SIMPLib::Constants::k_PiF / 2))
         {
-          w = SIMPLib::Constants::k_PiD - w;
+          w = SIMPLib::Constants::k_PiF - w;
         }
 
-        misalignmentlists[i][j] = w * SIMPLib::Constants::k_180OverPiD;
+        misalignmentlists[i][j] = w * SIMPLib::Constants::k_180OverPiF;
         if(m_FindAvgMisals)
         {
           m_AvgCAxisMisalignments[i] += misalignmentlists[i][j];

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindFeatureReferenceCAxisMisorientations.cpp
@@ -57,52 +57,11 @@
 #include "EbsdLib/Core/Quaternion.hpp"
 
 #include "OrientationAnalysis/OrientationAnalysisConstants.h"
+#include "OrientationAnalysis/OrientationAnalysisUtilities.h"
 #include "OrientationAnalysis/OrientationAnalysisVersion.h"
 
 using QuatF = Quaternion<float>;
-using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
-
-namespace
-{
-//------------------------------------------------------------------------------
-Matrix3fR OrientationMatrixToGMatrix(const Orientation<float>& oMatrix)
-{
-  if(oMatrix.size() != 9)
-  {
-    throw std::out_of_range("Orientation matrix has invalid size.");
-  }
-  Matrix3fR g1;
-  g1(0, 0) = oMatrix[0];
-  g1(0, 1) = oMatrix[1];
-  g1(0, 2) = oMatrix[2];
-  g1(1, 0) = oMatrix[3];
-  g1(1, 1) = oMatrix[4];
-  g1(1, 2) = oMatrix[5];
-  g1(2, 0) = oMatrix[6];
-  g1(2, 1) = oMatrix[7];
-  g1(2, 2) = oMatrix[8];
-  return g1;
-}
-//------------------------------------------------------------------------------
-Matrix3fR OrientationMatrixToGMatrixTranspose(const Orientation<float>& oMatrix)
-{
-  if(oMatrix.size() != 9)
-  {
-    throw std::out_of_range("Orientation matrix has invalid size.");
-  }
-  Matrix3fR g1t;
-  g1t(0, 0) = oMatrix[0];
-  g1t(0, 1) = oMatrix[3];
-  g1t(0, 2) = oMatrix[6];
-  g1t(1, 0) = oMatrix[1];
-  g1t(1, 1) = oMatrix[4];
-  g1t(1, 2) = oMatrix[7];
-  g1t(2, 0) = oMatrix[2];
-  g1t(2, 1) = oMatrix[5];
-  g1t(2, 2) = oMatrix[8];
-  return g1t;
-}
-} // namespace
+using namespace OrientationUtilities;
 
 // -----------------------------------------------------------------------------
 //

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindGBCDMetricBased.cpp
@@ -329,11 +329,11 @@ public:
  */
 class ProbeDistrib
 {
-  QVector<double>* distribValues = nullptr;
-  QVector<double>* errorValues = nullptr;
-  QVector<float> samplPtsX;
-  QVector<float> samplPtsY;
-  QVector<float> samplPtsZ;
+  std::vector<double>* distribValues = nullptr;
+  std::vector<double>* errorValues = nullptr;
+  std::vector<float> samplPtsX;
+  std::vector<float> samplPtsY;
+  std::vector<float> samplPtsZ;
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
   tbb::concurrent_vector<TriAreaAndNormals> selectedTris;
 #else
@@ -346,7 +346,7 @@ class ProbeDistrib
   const Matrix3fR& gFixedT;
 
 public:
-  ProbeDistrib(QVector<double>* __distribValues, QVector<double>* __errorValues, QVector<float> __samplPtsX, QVector<float> __samplPtsY, QVector<float> __samplPtsZ,
+  ProbeDistrib(std::vector<double>* __distribValues, std::vector<double>* __errorValues, std::vector<float> __samplPtsX, std::vector<float> __samplPtsY, std::vector<float> __samplPtsZ,
 #ifdef SIMPL_USE_PARALLEL_ALGORITHMS
                tbb::concurrent_vector<TriAreaAndNormals> __selectedTris,
 #else
@@ -401,8 +401,8 @@ public:
           }
         }
       }
-      (*errorValues)[ptIdx] = sqrt((*distribValues)[ptIdx] / totalFaceArea / double(numDistinctGBs)) / ballVolume;
 
+      (*errorValues)[ptIdx] = sqrt((*distribValues)[ptIdx] / totalFaceArea / double(numDistinctGBs)) / ballVolume;
       (*distribValues)[ptIdx] /= totalFaceArea;
       (*distribValues)[ptIdx] /= ballVolume;
     }
@@ -814,9 +814,9 @@ void FindGBCDMetricBased::execute()
 
   // generate "Golden Section Spiral", see http://www.softimageblog.com/archives/115
   int numSamplPts_WholeSph = 2 * m_NumSamplPts; // here we generate points on the whole sphere
-  QVector<float> samplPtsX(0);
-  QVector<float> samplPtsY(0);
-  QVector<float> samplPtsZ(0);
+  std::vector<float> samplPtsX(0);
+  std::vector<float> samplPtsY(0);
+  std::vector<float> samplPtsZ(0);
 
   float _inc = 2.3999632f; // = pi * (3 - sqrt(5))
   float _off = 2.0f / float(numSamplPts_WholeSph);
@@ -941,8 +941,8 @@ void FindGBCDMetricBased::execute()
     totalFaceArea += m_FaceAreas[triIdx] * double(triIncluded.at(triIdx));
   }
 
-  QVector<double> distribValues(samplPtsX.size(), 0.0);
-  QVector<double> errorValues(samplPtsX.size(), 0.0);
+  std::vector<double> distribValues(samplPtsX.size(), 0.0);
+  std::vector<double> errorValues(samplPtsX.size(), 0.0);
 
   int32_t pointsChunkSize = 100;
   if(samplPtsX.size() < pointsChunkSize)
@@ -979,8 +979,8 @@ void FindGBCDMetricBased::execute()
   }
 
   // ------------------------------------------- writing the output --------------------------------
-  fprintf(fDist, "%.1f %.1f %.1f %.1f\n", m_MisorientationRotation.h, m_MisorientationRotation.k, m_MisorientationRotation.l, m_MisorientationRotation.angle);
-  fprintf(fErr, "%.1f %.1f %.1f %.1f\n", m_MisorientationRotation.h, m_MisorientationRotation.k, m_MisorientationRotation.l, m_MisorientationRotation.angle);
+  fprintf(fDist, "%.8E %.8E %.8E %.8E\n", m_MisorientationRotation.h, m_MisorientationRotation.k, m_MisorientationRotation.l, m_MisorientationRotation.angle);
+  fprintf(fErr, "%.8E %.8E %.8E %.8E\n", m_MisorientationRotation.h, m_MisorientationRotation.k, m_MisorientationRotation.l, m_MisorientationRotation.angle);
 
   for(int ptIdx = 0; ptIdx < samplPtsX.size(); ptIdx++)
   {
@@ -991,11 +991,11 @@ void FindGBCDMetricBased::execute()
     float zenithDeg = static_cast<float>(SIMPLib::Constants::k_180OverPiD * zenith);
     float azimuthDeg = static_cast<float>(SIMPLib::Constants::k_180OverPiD * azimuth);
 
-    fprintf(fDist, "%.2f %.2f %.4f\n", azimuthDeg, 90.0f - zenithDeg, distribValues[ptIdx]);
+    fprintf(fDist, "%.8E %.8E %.8E\n", azimuthDeg, 90.0f - zenithDeg, distribValues[ptIdx]);
 
     if(!m_SaveRelativeErr)
     {
-      fprintf(fErr, "%.2f %.2f %.4f\n", azimuthDeg, 90.0f - zenithDeg, errorValues[ptIdx]);
+      fprintf(fErr, "%.8E %.28f %.8E\n", azimuthDeg, 90.0f - zenithDeg, errorValues[ptIdx]);
     }
     else
     {
@@ -1004,7 +1004,7 @@ void FindGBCDMetricBased::execute()
       {
         saneErr = fmin(100.0, 100.0 * errorValues[ptIdx] / distribValues[ptIdx]);
       }
-      fprintf(fErr, "%.2f %.2f %.2f\n", azimuthDeg, 90.0f - zenithDeg, saneErr);
+      fprintf(fErr, "%.8E %.8E %.2E\n", azimuthDeg, 90.0f - zenithDeg, saneErr);
     }
   }
   fclose(fDist);

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisUtilities.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisUtilities.cpp
@@ -1,0 +1,69 @@
+#include "OrientationAnalysisUtilities.h"
+
+#include "EbsdLib/LaueOps/LaueOps.h"
+
+namespace OrientationUtilities
+{
+Matrix3fR OrientationMatrixToGMatrix(const Orientation<float>& oMatrix)
+{
+  if(oMatrix.size() != 9)
+  {
+    throw std::out_of_range("Orientation matrix has invalid size.");
+  }
+  Matrix3fR g1;
+  g1(0, 0) = oMatrix[0];
+  g1(0, 1) = oMatrix[1];
+  g1(0, 2) = oMatrix[2];
+  g1(1, 0) = oMatrix[3];
+  g1(1, 1) = oMatrix[4];
+  g1(1, 2) = oMatrix[5];
+  g1(2, 0) = oMatrix[6];
+  g1(2, 1) = oMatrix[7];
+  g1(2, 2) = oMatrix[8];
+  return g1;
+}
+
+Matrix3fR OrientationMatrixToGMatrixTranspose(const Orientation<float>& oMatrix)
+{
+  if(oMatrix.size() != 9)
+  {
+    throw std::out_of_range("Orientation matrix has invalid size.");
+  }
+  Matrix3fR g1t;
+  g1t(0, 0) = oMatrix[0];
+  g1t(0, 1) = oMatrix[3];
+  g1t(0, 2) = oMatrix[6];
+  g1t(1, 0) = oMatrix[1];
+  g1t(1, 1) = oMatrix[4];
+  g1t(1, 2) = oMatrix[7];
+  g1t(2, 0) = oMatrix[2];
+  g1t(2, 1) = oMatrix[5];
+  g1t(2, 2) = oMatrix[8];
+  return g1t;
+}
+
+std::string CrystalStructureEnumToString(uint32_t crystalStructureType)
+{
+  if(crystalStructureType < 0 || crystalStructureType > 10)
+  {
+    return "UnknownCrystalStructure";
+  }
+  const std::vector<std::string> allLaueNames = LaueOps::GetLaueNames();
+  return allLaueNames[crystalStructureType];
+}
+
+Matrix3fR EbsdLibMatrixToEigenMatrix(const EbsdLib::Matrix3X3F& ebsdMatrix)
+{
+  Matrix3fR eigenMatrix;
+  eigenMatrix(0, 0) = ebsdMatrix[0];
+  eigenMatrix(0, 1) = ebsdMatrix[1];
+  eigenMatrix(0, 2) = ebsdMatrix[2];
+  eigenMatrix(1, 0) = ebsdMatrix[3];
+  eigenMatrix(1, 1) = ebsdMatrix[4];
+  eigenMatrix(1, 2) = ebsdMatrix[5];
+  eigenMatrix(2, 0) = ebsdMatrix[6];
+  eigenMatrix(2, 1) = ebsdMatrix[7];
+  eigenMatrix(2, 2) = ebsdMatrix[8];
+  return eigenMatrix;
+}
+} // namespace OrientationUtilities

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisUtilities.h
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisUtilities.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "EbsdLib/Core/EbsdLibConstants.h"
+#include "EbsdLib/Core/Orientation.hpp"
+
+#include <Eigen/Dense>
+
+namespace OrientationUtilities
+{
+using Matrix3fR = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
+
+Matrix3fR OrientationMatrixToGMatrix(const Orientation<float>& oMatrix);
+
+Matrix3fR OrientationMatrixToGMatrixTranspose(const Orientation<float>& oMatrix);
+
+std::string CrystalStructureEnumToString(uint32_t crystalStructureType);
+
+Matrix3fR EbsdLibMatrixToEigenMatrix(const EbsdLib::Matrix3X3F& ebsdMatrix);
+} // namespace OrientationUtilities


### PR DESCRIPTION
- Update FindFeatureNeighborCAxisMisalognment, FindGBCDMetricBased & FindGBPDMetricBased to use Eigen for matrix math
- Update FindFeatureNeighborCAxisMisalognment to allow Hexagonal Low phase types